### PR TITLE
Include version info in CMake output

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,8 +59,11 @@ endif()
 
 ############################# OpenTurbine ##############################
 
+generate_version_info()
+
 # General information about machine, compiler, and build type
 message(STATUS "OpenTurbine Information:")
+message(STATUS "VERSION = ${OTURB_VERSION_TAG}-${OTURB_REPO_DIRTY}")
 message(STATUS "CMAKE_SYSTEM_NAME = ${CMAKE_SYSTEM_NAME}")
 message(STATUS "CMAKE_CXX_COMPILER_ID = ${CMAKE_CXX_COMPILER_ID}")
 message(STATUS "CMAKE_CXX_COMPILER_VERSION = ${CMAKE_CXX_COMPILER_VERSION}")
@@ -90,7 +93,6 @@ endif()
 include(set_compile_flags)
 
 # Build OpenTurbine
-generate_version_info()
 add_subdirectory(src)
 
 if(OTURB_ENABLE_CUDA)


### PR DESCRIPTION
This pull request adds the OpenTurbine version info to a message section in the CMake configuration output. See below for an example. The infrastructure for this was added initially in #6, and a subsequent discussion in https://github.com/Exawind/openturbine/pull/9 and https://github.com/Exawind/openturbine/discussions/10 suggested this change.

```
$ cmake ..
-- OpenTurbine Information:
-- VERSION = v0.0.0-37-g824e4ae-DIRTY
-- CMAKE_SYSTEM_NAME = Darwin
-- CMAKE_CXX_COMPILER_ID = AppleClang
-- CMAKE_CXX_COMPILER_VERSION = 14.0.0.14000029
-- CMAKE_BUILD_TYPE = 
-- Enabled Kokkos devices: SERIAL
-- Enabled Kokkos devices: SERIAL
-- Configuring done
-- Generating done
-- Build files have been written to: <removed path>
```