### PR TITLE
Set Kokkos_DIR environment variable based on installation location from Spack

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,10 +1,10 @@
 name: OpenTurbine CI
 
-on:
-  push:
-    branches: [main develop]
-  pull_request:
-    branches: [main develop]
+on: push
+  # push:
+  #   branches: [main, develop]
+  # pull_request:
+  #   branches: [main, develop]
 
 jobs:
   Formatting:
@@ -53,6 +53,7 @@ jobs:
       run: |
         . ~/.spack/Spack/share/spack/setup-env.sh
         export Kokkos_DIR=$(spack find -p kokkos | grep -m1 kokkos | awk '{print $2}')
+        # echo $Kokkos_DIR
         # ls $Kokkos_DIR
         mkdir build
         cd build

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,4 +1,4 @@
-name: OpenTurbine CI
+name: OpenTurbine-CI
 
 on: push
   # push:
@@ -8,7 +8,7 @@ on: push
 
 jobs:
   Formatting:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
     - name: Clone
       uses: actions/checkout@v3
@@ -21,7 +21,7 @@ jobs:
         clangFormatVersion: 14
   CPU:
     needs: Formatting
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
     - name: Cache install Spack packages
       id: cache-install
@@ -52,7 +52,8 @@ jobs:
     - name: Test
       run: |
         . ~/.spack/Spack/share/spack/setup-env.sh
-        export Kokkos_DIR=$(spack find -p kokkos | grep -m1 kokkos | awk '{print $2}')
+        # Find the Kokkos installation directory via spack & extract the path via grep & awk
+        export Kokkos_DIR=$(spack find -p kokkos | grep -m 1 kokkos | awk '{print $2}')
         # echo $Kokkos_DIR
         # ls $Kokkos_DIR
         mkdir build

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,13 +1,12 @@
 name: OpenTurbine CI
 
-on: push
-  # push:
-  #   branches: [main]
-  # pull_request:
-  #   branches: [main]
+on:
+  push:
+    branches: [main develop]
+  pull_request:
+    branches: [main develop]
 
 jobs:
-
   Formatting:
     runs-on: ubuntu-22.04
     steps:
@@ -20,12 +19,10 @@ jobs:
         exclude: '.'
         extensions: 'H,h,cpp'
         clangFormatVersion: 14
-
   CPU:
     needs: Formatting
     runs-on: ubuntu-22.04
     steps:
-
     - name: Cache install Spack packages
       id: cache-install
       uses: actions/cache@v3
@@ -39,7 +36,6 @@ jobs:
         git clone https://github.com/spack/spack ~/.spack/Spack
         . ~/.spack/Spack/share/spack/setup-env.sh
         spack install kokkos
-
     - name: Install GoogleTest
       run: |
         sudo apt-get install libgtest-dev
@@ -49,16 +45,14 @@ jobs:
         sudo cp lib/*.a /usr/lib
         sudo ln -s /usr/lib/libgtest.a /usr/local/lib/libgtest.a
         sudo ln -s /usr/lib/libgtest_main.a /usr/local/lib/libgtest_main.a
-
     - name: Clone
       uses: actions/checkout@v3
-      with: 
+      with:
         submodules: true
     - name: Test
       run: |
         . ~/.spack/Spack/share/spack/setup-env.sh
-        export Kokkos_DIR=/home/runner/.spack/Spack/opt/spack/linux-ubuntu22.04-x86_64_v4/gcc-12.1.0/kokkos-3.7.01-zhffzchmugzhigeekgnatfeikkrjwmfw
-        # echo $Kokkos_DIR
+        export Kokkos_DIR=$(spack find -p kokkos | grep -m1 kokkos | awk '{print $2}')
         # ls $Kokkos_DIR
         mkdir build
         cd build
@@ -66,7 +60,6 @@ jobs:
         make
         ./openturbine -h
         ./openturbine_unit_tests
-
     # - name: Dependencies
     #   run: ${{matrix.install_deps}}
     # - name: Setup
@@ -88,5 +81,3 @@ jobs:
     #   working-directory: ${{runner.workspace}}/build-ci-${{matrix.build_type}}
     #   run: |
     #     ctest ${{matrix.ctest_args}} --output-on-failure
-
-


### PR DESCRIPTION
Fixes #12. 

Previously, the Kokkos directory path (`Kokkos_DIR`) was hardcoded into the Github Actions configuration file, which caused `CMake` configuration error when there was a mismatch. Here, the path is set dynamically from `Spack` to fix the issue.

Specifically: 
- the Kokkos installation directory is searched via the command `spack find -p kokkos`
- the installation path is subsequently extracted by piping commands via `grep -m 1 kokkos` (to filter the output to show only the lines containing the installation path of the Kokkos package)
- `awk '{print $2}'` (to extract the second column of the filtered output, which contains the installation path)

The Github Actions result shows the [CI workflow was successful](https://github.com/faisal-bhuiyan/openturbine/actions/runs/4368158392) with the above changes included into it.