### PR TITLE
Implement linear solver using Kokkos data structures and LAPACK

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,15 +1,18 @@
 
 set(Kokkos_DIR "$ENV{Kokkos_ROOT}" CACHE STRING "Kokkos root directory")
 find_package(Kokkos REQUIRED)
+find_package(LAPACK REQUIRED)
 
 target_sources(${oturb_exe_name} PRIVATE main.cpp)
 target_link_libraries(${oturb_exe_name} PRIVATE
     Kokkos::kokkos
+    LAPACK::LAPACK
 )
 
 target_sources(${oturb_lib_name} PRIVATE heat/heat_solve.cpp)
 target_link_libraries(${oturb_lib_name} PRIVATE
     Kokkos::kokkos
+    LAPACK::LAPACK
 )
 
 target_include_directories(${oturb_exe_name} PRIVATE ${PROJECT_BINARY_DIR})

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -2,19 +2,14 @@
 set(Kokkos_DIR "$ENV{Kokkos_ROOT}" CACHE STRING "Kokkos root directory")
 find_package(Kokkos REQUIRED)
 
-set(KokkosKernels_DIR "$ENV{KokkosKernels_ROOT}" CACHE STRING "KokkosKernels root directory")
-find_package(KokkosKernels REQUIRED)
-
 target_sources(${oturb_exe_name} PRIVATE main.cpp)
 target_link_libraries(${oturb_exe_name} PRIVATE
     Kokkos::kokkos
-    Kokkos::kokkoskernels
 )
 
 target_sources(${oturb_lib_name} PRIVATE heat/heat_solve.cpp)
 target_link_libraries(${oturb_lib_name} PRIVATE
     Kokkos::kokkos
-    Kokkos::kokkoskernels
 )
 
 target_include_directories(${oturb_exe_name} PRIVATE ${PROJECT_BINARY_DIR})

--- a/src/rigid_pendulum_poc/solver.cpp
+++ b/src/rigid_pendulum_poc/solver.cpp
@@ -5,7 +5,10 @@ namespace openturbine::rigid_pendulum {
 
 void solve_linear_system([[maybe_unused]] Kokkos::View<double**> system, [[maybe_unused]] Kokkos::View<double*> solution)
 {
-
+  for(unsigned index = 0; index < solution.extent(0); ++index)
+  {
+    solution(index) /= system(index, index);
+  }
 }
 
 }  // namespace openturbine::rigid_pendulum

--- a/src/rigid_pendulum_poc/solver.cpp
+++ b/src/rigid_pendulum_poc/solver.cpp
@@ -1,22 +1,11 @@
 #include "src/rigid_pendulum_poc/solver.h"
 
-#include <Kokkos_Core.hpp>
-#include <KokkosBlas1_abs.hpp> // For absolute value operations
-#include <KokkosBlas1_axpby.hpp> // For linear combination operations
-#include <KokkosBlas1_dot.hpp> // For dot product operations
-#include <KokkosBlas1_nrm2.hpp> // For norm operations
-
-#include "src/utilities/log.h"
 
 namespace openturbine::rigid_pendulum {
 
-LinearSolver::LinearSolver(SolverType solver_type)
-    : solver_type_(solver_type) {
-}
+void solve_linear_system([[maybe_unused]] Kokkos::View<double**> system, [[maybe_unused]] Kokkos::View<double*> solution)
+{
 
-Kokkos::View<double*> LinearSolver::Solve(const Kokkos::View<double*>& stiffness_matrix,
-    const Kokkos::View<double*>& load_vector) const {
-    return load_vector;
 }
 
 }  // namespace openturbine::rigid_pendulum

--- a/src/rigid_pendulum_poc/solver.cpp
+++ b/src/rigid_pendulum_poc/solver.cpp
@@ -1,14 +1,19 @@
+#include <lapacke.h>
+
 #include "src/rigid_pendulum_poc/solver.h"
 
 
 namespace openturbine::rigid_pendulum {
 
-void solve_linear_system([[maybe_unused]] Kokkos::View<double**> system, [[maybe_unused]] Kokkos::View<double*> solution)
+int solve_linear_system(Kokkos::View<double**> system, Kokkos::View<double*> solution)
 {
-  for(unsigned index = 0; index < solution.extent(0); ++index)
-  {
-    solution(index) /= system(index, index);
-  }
+  int rows = system.extent(0);
+  int rightHandSides = 1;
+  int leadingDimension = rows;
+
+  auto pivots = Kokkos::View<int*, Kokkos::DefaultHostExecutionSpace>("pivots", solution.size());
+
+  return LAPACKE_dgesv(LAPACK_ROW_MAJOR, rows, rightHandSides, system.data(), leadingDimension, pivots.data(), solution.data(), 1);
 }
 
 }  // namespace openturbine::rigid_pendulum

--- a/src/rigid_pendulum_poc/solver.h
+++ b/src/rigid_pendulum_poc/solver.h
@@ -1,33 +1,10 @@
 #pragma once
 
-#include <iostream>
-#include <vector>
-
-#include <Kokkos_Core.hpp>
+#include<Kokkos_Core.hpp>
 
 namespace openturbine::rigid_pendulum {
 
-/// @brief Enumerate different types of solvers
-enum class SolverType {
-    kNone = 0,
-    kDirectLinearSolver = 1,
-    kIterativeLinearSolver = 2,
-    kIterativeNonlinearSolver = 3
-};
-
-/// @brief A class for solving linear systems
-class LinearSolver {
-public:
-    LinearSolver(SolverType=SolverType::kNone);
-
-    SolverType GetSolverType() const { return solver_type_; }
-
-    Kokkos::View<double*> Solve(const Kokkos::View<double*>&, const Kokkos::View<double*>&) const;
-
-private:
-    SolverType solver_type_;
-};
-
+void solve_linear_system(Kokkos::View<double**> system, Kokkos::View<double*> solution);
 
 }  // namespace openturbine::rigid_pendulum
 

--- a/src/rigid_pendulum_poc/solver.h
+++ b/src/rigid_pendulum_poc/solver.h
@@ -4,7 +4,7 @@
 
 namespace openturbine::rigid_pendulum {
 
-void solve_linear_system(Kokkos::View<double**> system, Kokkos::View<double*> solution);
+[[nodiscard]] int solve_linear_system(Kokkos::View<double**> system, Kokkos::View<double*> solution);
 
 }  // namespace openturbine::rigid_pendulum
 

--- a/tests/unit_tests/test_solver.cpp
+++ b/tests/unit_tests/test_solver.cpp
@@ -10,7 +10,7 @@ namespace openturbine::rigid_pendulum::tests {
 Kokkos::View<double**, Kokkos::DefaultHostExecutionSpace> 
 create_diagonal_matrix(std::vector<double> diagonal)
 {
-  auto matrix = Kokkos::View<double**, Kokkos::DefaultHostExecutionSpace>("identity", diagonal.size(), diagonal.size());
+  auto matrix = Kokkos::View<double**, Kokkos::DefaultHostExecutionSpace>("matrix", diagonal.size(), diagonal.size());
   auto diagonal_entries = Kokkos::RangePolicy<Kokkos::DefaultHostExecutionSpace>(0, diagonal.size());
   auto fill_diagonal = [matrix, diagonal](int index) { matrix(index, index) = diagonal[index]; };
 
@@ -20,15 +20,23 @@ create_diagonal_matrix(std::vector<double> diagonal)
   return matrix;
 }
 
+Kokkos::View<double*, Kokkos::DefaultHostExecutionSpace>
+create_vector(std::vector<double> values)
+{
+  auto vector = Kokkos::View<double*, Kokkos::DefaultHostExecutionSpace>("vector", values.size());
+  auto entries = Kokkos::RangePolicy<Kokkos::DefaultHostExecutionSpace>(0, values.size());
+  auto fill_vector = [vector, values](int index) { vector(index) = values[index]; };
+
+  Kokkos::parallel_for(entries, fill_vector);
+
+  return vector;
+}
+
 TEST(LinearSolverTest, solve_1x1_identity)
 {
   auto identity = create_diagonal_matrix({1});
-  auto solution = Kokkos::View<double*>("solution", 1);
-  auto exactSolution = Kokkos::View<double*>("exact solution", 1);
-
-  solution(0) = 1.;
-  
-  Kokkos::deep_copy(exactSolution, solution);
+  auto solution = create_vector({1});
+  auto exactSolution = create_vector({1});
 
   openturbine::rigid_pendulum::solve_linear_system(identity, solution);
 
@@ -38,12 +46,8 @@ TEST(LinearSolverTest, solve_1x1_identity)
 TEST(LinearSolverTest, solve_3x3_identity)
 {
   auto identity = create_diagonal_matrix({1., 1., 1.});
-  auto solution = Kokkos::View<double*>("solution", 3);
-  auto exactSolution = Kokkos::View<double*>("exact solution", 3);
-
-  solution(0) = 1.;
-  solution(1) = 2.;
-  solution(2) = 3.;
+  auto solution = create_vector({1., 2., 3.});
+  auto exactSolution = create_vector({1., 2., 3.});
   
   Kokkos::deep_copy(exactSolution, solution);
 
@@ -57,12 +61,8 @@ TEST(LinearSolverTest, solve_3x3_identity)
 TEST(LinearSolverTest, solve_1x1_diagonal)
 {
   auto identity = create_diagonal_matrix({2.});
-  auto solution = Kokkos::View<double*>("solution", 3);
-  auto exactSolution = Kokkos::View<double*>("exact solution", 3);
-
-  solution(0) = 1.;
-  
-  exactSolution(0) = .5;
+  auto solution = create_vector({1.});
+  auto exactSolution = create_vector({.5});
 
   openturbine::rigid_pendulum::solve_linear_system(identity, solution);
 
@@ -72,16 +72,8 @@ TEST(LinearSolverTest, solve_1x1_diagonal)
 TEST(LinearSolverTest, solve_3x3_diagonal)
 {
   auto identity = create_diagonal_matrix({2., 8., 32.});
-  auto solution = Kokkos::View<double*>("solution", 3);
-  auto exactSolution = Kokkos::View<double*>("exact solution", 3);
-
-  solution(0) = 1.;
-  solution(1) = 2.;
-  solution(2) = 4.;
-  
-  exactSolution(0) = .5;
-  exactSolution(1) = .25;
-  exactSolution(2) = .125;
+  auto solution = create_vector({1., 2., 4.});
+  auto exactSolution = create_vector({.5, .25, .125});
 
   openturbine::rigid_pendulum::solve_linear_system(identity, solution);
 

--- a/tests/unit_tests/test_solver.cpp
+++ b/tests/unit_tests/test_solver.cpp
@@ -1,5 +1,6 @@
-#include "gtest/gtest.h"
+#include <limits>
 
+#include <gtest/gtest.h>
 #include <Kokkos_Core.hpp>
 
 #include "src/rigid_pendulum_poc/solver.h"
@@ -10,13 +11,11 @@ Kokkos::View<double**, Kokkos::DefaultHostExecutionSpace>
 create_diagonal_matrix(std::vector<double> diagonal)
 {
   auto matrix = Kokkos::View<double**, Kokkos::DefaultHostExecutionSpace>("identity", diagonal.size(), diagonal.size());
-  Kokkos::deep_copy(matrix, 0);
+  auto diagonal_entries = Kokkos::RangePolicy<Kokkos::DefaultHostExecutionSpace>(0, diagonal.size());
+  auto fill_diagonal = [matrix, diagonal](int index) { matrix(index, index) = diagonal[index]; };
 
-  for(auto& entry : diagonal)
-  {
-    auto index = &entry - &diagonal[0];
-    matrix(index, index) = entry;
-  }
+  Kokkos::deep_copy(matrix, 0);
+  Kokkos::parallel_for(diagonal_entries, fill_diagonal);
 
   return matrix;
 }
@@ -53,6 +52,42 @@ TEST(LinearSolverTest, solve_3x3_identity)
   EXPECT_EQ(solution(0), exactSolution(0));
   EXPECT_EQ(solution(1), exactSolution(1));
   EXPECT_EQ(solution(2), exactSolution(2));
+}
+
+TEST(LinearSolverTest, solve_1x1_diagonal)
+{
+  auto identity = create_diagonal_matrix({2.});
+  auto solution = Kokkos::View<double*>("solution", 3);
+  auto exactSolution = Kokkos::View<double*>("exact solution", 3);
+
+  solution(0) = 1.;
+  
+  exactSolution(0) = .5;
+
+  openturbine::rigid_pendulum::solve_linear_system(identity, solution);
+
+  EXPECT_NEAR(solution(0), exactSolution(0), std::numeric_limits<double>::epsilon());
+}
+
+TEST(LinearSolverTest, solve_3x3_diagonal)
+{
+  auto identity = create_diagonal_matrix({2., 8., 32.});
+  auto solution = Kokkos::View<double*>("solution", 3);
+  auto exactSolution = Kokkos::View<double*>("exact solution", 3);
+
+  solution(0) = 1.;
+  solution(1) = 2.;
+  solution(2) = 4.;
+  
+  exactSolution(0) = .5;
+  exactSolution(1) = .25;
+  exactSolution(2) = .125;
+
+  openturbine::rigid_pendulum::solve_linear_system(identity, solution);
+
+  EXPECT_NEAR(solution(0), exactSolution(0), std::numeric_limits<double>::epsilon());
+  EXPECT_NEAR(solution(1), exactSolution(1), std::numeric_limits<double>::epsilon());
+  EXPECT_NEAR(solution(2), exactSolution(2), std::numeric_limits<double>::epsilon());
 }
 
 }  // namespace oturb_tests

--- a/tests/unit_tests/test_solver.cpp
+++ b/tests/unit_tests/test_solver.cpp
@@ -4,55 +4,22 @@
 
 #include "src/rigid_pendulum_poc/solver.h"
 
-namespace oturb_tests {
+namespace openturbine::rigid_pendulum::tests {
 
-using namespace openturbine::rigid_pendulum;
+TEST(LinearSolverTest, solve_1x1_identity)
+{
+  auto identity = Kokkos::View<double**>("identity", 1, 1);
+  auto solution = Kokkos::View<double*>("solution", 1);
+  auto exactSolution = Kokkos::View<double*>("exact solution", 1);
 
-TEST(SolverType, DefaultValue) {
-    // Test that the default value of a SolverType object is kNone
-    SolverType type {};
-    EXPECT_EQ(type, SolverType::kNone);
-}
+  identity(0, 0) = 1.;
+  solution(0) = 1.;
+  
+  Kokkos::deep_copy(exactSolution, solution);
 
-TEST(SolverType, Comparison) {
-    // Test that different solver types can be compared
-    EXPECT_LT(SolverType::kNone, SolverType::kDirectLinearSolver);
-    EXPECT_EQ(SolverType::kDirectLinearSolver, SolverType::kDirectLinearSolver);
-    EXPECT_NE(SolverType::kDirectLinearSolver, SolverType::kNone);
-    EXPECT_LT(SolverType::kNone, SolverType::kIterativeLinearSolver);
-    EXPECT_EQ(SolverType::kIterativeLinearSolver, SolverType::kIterativeLinearSolver);
-    EXPECT_NE(SolverType::kIterativeLinearSolver, SolverType::kDirectLinearSolver);
-    EXPECT_NE(SolverType::kIterativeLinearSolver, SolverType::kNone);
-    EXPECT_LT(SolverType::kNone, SolverType::kIterativeNonlinearSolver);
-    EXPECT_EQ(SolverType::kIterativeNonlinearSolver, SolverType::kIterativeNonlinearSolver);
-    EXPECT_NE(SolverType::kIterativeNonlinearSolver, SolverType::kIterativeLinearSolver);
-    EXPECT_NE(SolverType::kIterativeNonlinearSolver, SolverType::kDirectLinearSolver);
-    EXPECT_NE(SolverType::kIterativeNonlinearSolver, SolverType::kNone);
-}
+  openturbine::rigid_pendulum::solve_linear_system(identity, solution);
 
-class LinearSolverTest : public ::testing::Test {
-protected:
-    virtual void SetUp() {
-        Kokkos::initialize();
-    }
-
-    virtual void TearDown() {
-        Kokkos::finalize();
-    }
-};
-
-TEST_F(LinearSolverTest, Test1) {
-    LinearSolver solver {};
-    EXPECT_EQ(solver.GetSolverType(), SolverType::kNone);
-
-    Kokkos::View<double*> x("x", 1);
-    x[0] = 1.0;
-    Kokkos::View<double*> A("A", 1);
-    A[0] = 1.0;
-    Kokkos::View<double*> b("b", 1);
-    Kokkos::deep_copy(b, solver.Solve(A, x));
-
-    ASSERT_EQ(b(0), 1.);
+  EXPECT_EQ(solution(0), exactSolution(0));
 }
 
 }  // namespace oturb_tests

--- a/tests/unit_tests/test_solver.cpp
+++ b/tests/unit_tests/test_solver.cpp
@@ -6,13 +6,27 @@
 
 namespace openturbine::rigid_pendulum::tests {
 
+Kokkos::View<double**, Kokkos::DefaultHostExecutionSpace> 
+create_diagonal_matrix(std::vector<double> diagonal)
+{
+  auto matrix = Kokkos::View<double**, Kokkos::DefaultHostExecutionSpace>("identity", diagonal.size(), diagonal.size());
+  Kokkos::deep_copy(matrix, 0);
+
+  for(auto& entry : diagonal)
+  {
+    auto index = &entry - &diagonal[0];
+    matrix(index, index) = entry;
+  }
+
+  return matrix;
+}
+
 TEST(LinearSolverTest, solve_1x1_identity)
 {
-  auto identity = Kokkos::View<double**>("identity", 1, 1);
+  auto identity = create_diagonal_matrix({1});
   auto solution = Kokkos::View<double*>("solution", 1);
   auto exactSolution = Kokkos::View<double*>("exact solution", 1);
 
-  identity(0, 0) = 1.;
   solution(0) = 1.;
   
   Kokkos::deep_copy(exactSolution, solution);
@@ -24,14 +38,9 @@ TEST(LinearSolverTest, solve_1x1_identity)
 
 TEST(LinearSolverTest, solve_3x3_identity)
 {
-  auto identity = Kokkos::View<double**>("identity", 3, 3);
+  auto identity = create_diagonal_matrix({1., 1., 1.});
   auto solution = Kokkos::View<double*>("solution", 3);
   auto exactSolution = Kokkos::View<double*>("exact solution", 3);
-
-  Kokkos::deep_copy(identity, 0);
-  identity(0, 0) = 1.;
-  identity(1, 1) = 1.;
-  identity(2, 2) = 1.;
 
   solution(0) = 1.;
   solution(1) = 2.;

--- a/tests/unit_tests/test_solver.cpp
+++ b/tests/unit_tests/test_solver.cpp
@@ -22,5 +22,29 @@ TEST(LinearSolverTest, solve_1x1_identity)
   EXPECT_EQ(solution(0), exactSolution(0));
 }
 
+TEST(LinearSolverTest, solve_3x3_identity)
+{
+  auto identity = Kokkos::View<double**>("identity", 3, 3);
+  auto solution = Kokkos::View<double*>("solution", 3);
+  auto exactSolution = Kokkos::View<double*>("exact solution", 3);
+
+  Kokkos::deep_copy(identity, 0);
+  identity(0, 0) = 1.;
+  identity(1, 1) = 1.;
+  identity(2, 2) = 1.;
+
+  solution(0) = 1.;
+  solution(1) = 2.;
+  solution(2) = 3.;
+  
+  Kokkos::deep_copy(exactSolution, solution);
+
+  openturbine::rigid_pendulum::solve_linear_system(identity, solution);
+
+  EXPECT_EQ(solution(0), exactSolution(0));
+  EXPECT_EQ(solution(1), exactSolution(1));
+  EXPECT_EQ(solution(2), exactSolution(2));
+}
+
 }  // namespace oturb_tests
 


### PR DESCRIPTION
This set of commits provides a wrapper for LAPACK's general solver using `Kokkos::View`s.  
This would usually be just one commit, but many intermediate commits have be provided to demonstrate the TDD process used to arrive at this solution.
This code is not production ready.  It lacks guard rails to prevent using device memory or non-row-major matrices.  It also lacks size checking and error handling for in input system.  These should be added before merging into master to prevent segfault risk.  
