### PR TITLE
Minor update to the clang-format file for better readability

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -8,6 +8,12 @@
 # the class/struct keyword
 AccessModifierOffset: -4
 
+# Bracket Alignment Style: Always break after an open bracket, if the
+# parameters don’t fit on a single line. Closing brackets will be placed
+# on a new line.
+# Applies to round (i.e. parentheses), square, and angle brackets
+AlignAfterOpenBracket: BlockIndent
+
 # Do NOT allow short enums on a single line
 AllowShortEnumsOnASingleLine: false
 
@@ -28,8 +34,8 @@ AllowShortLoopsOnASingleLine: false
 # in this project
 BasedOnStyle: Google
 
-# Increase the column limit to 100
-ColumnLimit: 100
+# Increase the column limit to 101
+ColumnLimit: 101
 
 # Do NOT analyze the formatted file for the most common alignment of & and *.
 # Used with the "PointerAlignment" option to force pointers to the type
@@ -55,12 +61,12 @@ IncludeCategories:
     Priority: 40
 
   # This project's h files
-  - Regex:    '^"src'
-    Priority: 50
+  - Regex:    '^"(src|tests|OpenTurbine)'
+    Priority: 60
 
   # Other libraries' h files (with quotes)
   - Regex:    '^"'
-    Priority: 40
+    Priority: 50
 
 # Increase the indentation width to 4 columns
 IndentWidth: 4

--- a/src/heat/heat_solve.H
+++ b/src/heat/heat_solve.H
@@ -4,8 +4,10 @@
 
 namespace openturbine::heat_solve {
 
-double* heat_conduction_solver(int axis_size, double side_length, int n_max, double k, double ic_x0,
-                               double ic_x1, double residual_tolerance);
+double* heat_conduction_solver(
+    int axis_size, double side_length, int n_max, double k, double ic_x0, double ic_x1,
+    double residual_tolerance
+);
 
 template <typename T>
 std::vector<double> linspace(T start_in, T end_in, int num_in);

--- a/src/heat/heat_solve.cpp
+++ b/src/heat/heat_solve.cpp
@@ -8,8 +8,10 @@
 
 namespace openturbine::heat_solve {
 
-double* heat_conduction_solver(int axis_size, double side_length, int n_max, double k, double ic_x0,
-                               double ic_x1, double residual_tolerance) {
+double* heat_conduction_solver(
+    int axis_size, double side_length, int n_max, double k, double ic_x0, double ic_x1,
+    double residual_tolerance
+) {
     // Spatial step size
     double dx{side_length / axis_size};
     // Spatial grid points for the plate
@@ -23,11 +25,14 @@ double* heat_conduction_solver(int axis_size, double side_length, int n_max, dou
 
     // Initialize
     Kokkos::parallel_for(
-        "U_init", axis_size, KOKKOS_LAMBDA(int i) { U[i] = 0.0; });
+        "U_init", axis_size, KOKKOS_LAMBDA(int i) { U[i] = 0.0; }
+    );
     Kokkos::parallel_for(
-        "U_im1_init", axis_size, KOKKOS_LAMBDA(int i) { U_im1[i] = 0.0; });
+        "U_im1_init", axis_size, KOKKOS_LAMBDA(int i) { U_im1[i] = 0.0; }
+    );
     Kokkos::parallel_for(
-        "deltaU_init", axis_size, KOKKOS_LAMBDA(int i) { deltaU[i] = 0.0; });
+        "deltaU_init", axis_size, KOKKOS_LAMBDA(int i) { deltaU[i] = 0.0; }
+    );
 
     // Apply IC
     U[0] = ic_x0;
@@ -107,7 +112,8 @@ double* kokkos_laplacian(int axis_size, double* U, double dx) {
     // not operate on the boundaries.
     auto laplacian = static_cast<double*>(std::malloc(axis_size * sizeof(double)));
     Kokkos::parallel_for(
-        "laplacian", axis_size - 2, KOKKOS_LAMBDA(int i) {
+        "laplacian", axis_size - 2,
+        KOKKOS_LAMBDA(int i) {
             // std::cout << "Iteration: " << i << std::endl;
 
             i = i + 1;  // shift over 1 to enforce the BC
@@ -117,7 +123,8 @@ double* kokkos_laplacian(int axis_size, double* U, double dx) {
             // std::cout << "   " << left << " " << center << " " << right <<
             // std::endl;
             laplacian[i] = (left + right - 2 * center) / pow(dx, 2);
-        });
+        }
+    );
     return laplacian;
 }
 
@@ -126,10 +133,12 @@ double* kokkos_1d_heat_conduction(int axis_size, double* U_im1, double dt, doubl
     // NOTE: the boundaries are not computed and are left uninitialized.
     auto heat = static_cast<double*>(std::malloc(axis_size * sizeof(double)));
     Kokkos::parallel_for(
-        "1d_heat_conduction", axis_size - 2, KOKKOS_LAMBDA(int i) {
+        "1d_heat_conduction", axis_size - 2,
+        KOKKOS_LAMBDA(int i) {
             i = i + 1;  // shift over 1 to enforce the BC
             heat[i] = U_im1[i] + dt * (k * dU[i]);
-        });
+        }
+    );
     return heat;
 }
 
@@ -137,7 +146,8 @@ double kokkos_calculate_residual(int axis_size, double* U, double* U_im1) {
     double residual;
     Kokkos::parallel_reduce(
         "residual", axis_size,
-        KOKKOS_LAMBDA(const int& i, double& iresidual) { iresidual += U[i] - U_im1[i]; }, residual);
+        KOKKOS_LAMBDA(const int& i, double& iresidual) { iresidual += U[i] - U_im1[i]; }, residual
+    );
     return residual;
 }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -61,8 +61,9 @@ int main(int argc, char* argv[]) {
     auto U = static_cast<double*>(std::malloc(axis_size * sizeof(double)));
 
     Kokkos::initialize(argc, argv);
-    heat_solve::heat_conduction_solver(axis_size, side_length, n_max, k, ic_x0, ic_x1,
-                                       residual_tolerance);
+    heat_solve::heat_conduction_solver(
+        axis_size, side_length, n_max, k, ic_x0, ic_x1, residual_tolerance
+    );
     Kokkos::finalize();
 
     util::print_array(U, axis_size);

--- a/src/rigid_pendulum_poc/solver.cpp
+++ b/src/rigid_pendulum_poc/solver.cpp
@@ -6,8 +6,10 @@
 
 namespace openturbine::rigid_pendulum {
 
-void solve_linear_system(Kokkos::View<double**, Kokkos::DefaultHostExecutionSpace> system,
-                         Kokkos::View<double*, Kokkos::DefaultHostExecutionSpace> solution) {
+void solve_linear_system(
+    Kokkos::View<double**, Kokkos::DefaultHostExecutionSpace> system,
+    Kokkos::View<double*, Kokkos::DefaultHostExecutionSpace> solution
+) {
     auto rows = static_cast<int>(system.extent(0));
     auto columns = static_cast<int>(system.extent(1));
 
@@ -17,7 +19,8 @@ void solve_linear_system(Kokkos::View<double**, Kokkos::DefaultHostExecutionSpac
 
     if (rows != static_cast<int>(solution.extent(0))) {
         throw std::invalid_argument(
-            "Provided system and solution must contain the same number of rows");
+            "Provided system and solution must contain the same number of rows"
+        );
     }
 
     int right_hand_sides{1};
@@ -26,24 +29,26 @@ void solve_linear_system(Kokkos::View<double**, Kokkos::DefaultHostExecutionSpac
     int leading_dimension_solution{1};
 
     auto log = util::Log::Get();
-    log->Debug("Solving a " + std::to_string(rows) + " x " + std::to_string(rows) +
-               " system of linear equations with LAPACKE_dgesv" + "\n");
+    log->Debug(
+        "Solving a " + std::to_string(rows) + " x " + std::to_string(rows) +
+        " system of linear equations with LAPACKE_dgesv" + "\n"
+    );
 
     // Call DGESV from LAPACK to compute the solution to a real system of linear
     // equations A * x = b, returns 0 if successful
     // https://www.netlib.org/lapack/lapacke.html
-    auto info =
-        LAPACKE_dgesv(LAPACK_ROW_MAJOR,  // input: matrix_layout
-                      rows,              // input: number of linear equations
-                      right_hand_sides,  // input: number of rhs
-                      system.data(),     // input/output: Upon entry, the nxn coefficient matrix
-                                         // Upon exit, the factors L and U from the factorization
-                      leading_dimension_sytem,  // input: leading dimension of system
-                      pivots.data(),            // output: pivot indices
-                      solution.data(),  // input/output: Upon entry, the right-hand side matrix
-                                        // Upon exit, the solution matrix
-                      leading_dimension_solution  // input: leading dimension of solution
-        );
+    auto info = LAPACKE_dgesv(
+        LAPACK_ROW_MAJOR,           // input: matrix_layout
+        rows,                       // input: number of linear equations
+        right_hand_sides,           // input: number of rhs
+        system.data(),              // input/output: Upon entry, the nxn coefficient matrix
+                                    // Upon exit, the factors L and U from the factorization
+        leading_dimension_sytem,    // input: leading dimension of system
+        pivots.data(),              // output: pivot indices
+        solution.data(),            // input/output: Upon entry, the right-hand side matrix
+                                    // Upon exit, the solution matrix
+        leading_dimension_solution  // input: leading dimension of solution
+    );
 
     log->Debug("LAPACKE_dgesv returned exit code " + std::to_string(info) + "\n");
 

--- a/src/rigid_pendulum_poc/solver.h
+++ b/src/rigid_pendulum_poc/solver.h
@@ -11,7 +11,7 @@ namespace openturbine::rigid_pendulum {
 ///     (nx1) of right-hand side values. The solution is stored in the vector b.
 /// @param system A matrix of coefficients
 /// @param solution A vector of right-hand side values
-void solve_linear_system(Kokkos::View<double**, Kokkos::DefaultHostExecutionSpace>,
-                         Kokkos::View<double*, Kokkos::DefaultHostExecutionSpace>);
+void
+    solve_linear_system(Kokkos::View<double**, Kokkos::DefaultHostExecutionSpace>, Kokkos::View<double*, Kokkos::DefaultHostExecutionSpace>);
 
 }  // namespace openturbine::rigid_pendulum

--- a/src/utilities/log.h
+++ b/src/utilities/log.h
@@ -59,9 +59,10 @@ public:
      *  @param type: Output type for logging, default is Console and File
      *  @return The static instance of the ptr to Log
      */
-    static Log* Get(std::string name = "log.txt",
-                    SeverityLevel max_severity = SeverityLevel::kDebug,
-                    OutputType type = OutputType::kConsoleAndFile);
+    static Log* Get(
+        std::string name = "log.txt", SeverityLevel max_severity = SeverityLevel::kDebug,
+        OutputType type = OutputType::kConsoleAndFile
+    );
 
     std::string GetOutputFileName() const { return file_name_; }
     SeverityLevel GetMaxSeverityLevel() const { return max_severity_level_; }

--- a/tests/unit_tests/rigid_pendulum_poc/test_linear_systems_solver.cpp
+++ b/tests/unit_tests/rigid_pendulum_poc/test_linear_systems_solver.cpp
@@ -8,11 +8,12 @@
 namespace openturbine::rigid_pendulum::tests {
 
 Kokkos::View<double**, Kokkos::DefaultHostExecutionSpace> create_diagonal_matrix(
-    const std::vector<double>& values) {
-    auto matrix = Kokkos::View<double**, Kokkos::DefaultHostExecutionSpace>("matrix", values.size(),
-                                                                            values.size());
-    auto diagonal_entries =
-        Kokkos::RangePolicy<Kokkos::DefaultHostExecutionSpace>(0, values.size());
+    const std::vector<double>& values
+) {
+    auto matrix = Kokkos::View<double**, Kokkos::DefaultHostExecutionSpace>(
+        "matrix", values.size(), values.size()
+    );
+    auto diagonal_entries = Kokkos::RangePolicy<Kokkos::DefaultHostExecutionSpace>(0, values.size());
     auto fill_diagonal = [matrix, values](int index) {
         matrix(index, index) = values[index];
     };
@@ -24,7 +25,8 @@ Kokkos::View<double**, Kokkos::DefaultHostExecutionSpace> create_diagonal_matrix
 }
 
 Kokkos::View<double*, Kokkos::DefaultHostExecutionSpace> create_vector(
-    const std::vector<double>& values) {
+    const std::vector<double>& values
+) {
     auto vector = Kokkos::View<double*, Kokkos::DefaultHostExecutionSpace>("vector", values.size());
     auto entries = Kokkos::RangePolicy<Kokkos::DefaultHostExecutionSpace>(0, values.size());
     auto fill_vector = [vector, values](int index) {
@@ -37,11 +39,14 @@ Kokkos::View<double*, Kokkos::DefaultHostExecutionSpace> create_vector(
 }
 
 Kokkos::View<double**, Kokkos::DefaultHostExecutionSpace> create_matrix(
-    const std::vector<std::vector<double>>& values) {
-    auto matrix = Kokkos::View<double**, Kokkos::DefaultHostExecutionSpace>("matrix", values.size(),
-                                                                            values.front().size());
+    const std::vector<std::vector<double>>& values
+) {
+    auto matrix = Kokkos::View<double**, Kokkos::DefaultHostExecutionSpace>(
+        "matrix", values.size(), values.front().size()
+    );
     auto entries = Kokkos::MDRangePolicy<Kokkos::DefaultHostExecutionSpace, Kokkos::Rank<2>>(
-        {0, 0}, {values.size(), values.front().size()});
+        {0, 0}, {values.size(), values.front().size()}
+    );
     auto fill_matrix = [matrix, values](int row, int column) {
         matrix(row, column) = values[row][column];
     };
@@ -124,8 +129,10 @@ TEST(LinearSolverTest, Check2x3MatrixShape) {
     auto matrix_2x3 = create_matrix({{1., 2., 3.}, {4., 5., 6.}});
     auto solution_2x1 = create_vector({1., 1.});
 
-    EXPECT_THROW(openturbine::rigid_pendulum::solve_linear_system(matrix_2x3, solution_2x1),
-                 std::invalid_argument);
+    EXPECT_THROW(
+        openturbine::rigid_pendulum::solve_linear_system(matrix_2x3, solution_2x1),
+        std::invalid_argument
+    );
 }
 
 TEST(LinearSolverTest, Check5x3MatrixShape) {
@@ -138,24 +145,30 @@ TEST(LinearSolverTest, Check5x3MatrixShape) {
     });
     auto solution_5x1 = create_vector({1., 1., 1., 1., 1.});
 
-    EXPECT_THROW(openturbine::rigid_pendulum::solve_linear_system(matrix_5x3, solution_5x1),
-                 std::invalid_argument);
+    EXPECT_THROW(
+        openturbine::rigid_pendulum::solve_linear_system(matrix_5x3, solution_5x1),
+        std::invalid_argument
+    );
 }
 
 TEST(LinearSolverTest, Check1x1Matrix2x1VectorCompatibility) {
     auto system_1x1 = create_diagonal_matrix({1.});
     auto solution_2x1 = create_vector({1., 2.});
 
-    EXPECT_THROW(openturbine::rigid_pendulum::solve_linear_system(system_1x1, solution_2x1),
-                 std::invalid_argument);
+    EXPECT_THROW(
+        openturbine::rigid_pendulum::solve_linear_system(system_1x1, solution_2x1),
+        std::invalid_argument
+    );
 }
 
 TEST(LinearSolverTest, Check3x3Matrix2x1VectorCompatibility) {
     auto system_3x3 = create_diagonal_matrix({1., 1., 1.});
     auto solution_2x1 = create_vector({1., 2.});
 
-    EXPECT_THROW(openturbine::rigid_pendulum::solve_linear_system(system_3x3, solution_2x1),
-                 std::invalid_argument);
+    EXPECT_THROW(
+        openturbine::rigid_pendulum::solve_linear_system(system_3x3, solution_2x1),
+        std::invalid_argument
+    );
 }
 
 }  // namespace openturbine::rigid_pendulum::tests

--- a/tests/unit_tests/test_heat_solve.cpp
+++ b/tests/unit_tests/test_heat_solve.cpp
@@ -64,12 +64,13 @@ TEST(HeatSolve, FullSolve) {
     // For all points at 0.0, the domain should be all 0.0 after a few
     // iterations. This tests for any numerical noise.
     auto U = static_cast<double*>(std::malloc(axis_size * sizeof(double)));
-    U = openturbine::heat_solve::heat_conduction_solver(axis_size, side_length,
-                                                        5,  // number of iterations
-                                                        k,
-                                                        0.0,  // x=0 IC
-                                                        0.0,  // x=end IC
-                                                        1e-5  // tolerance
+    U = openturbine::heat_solve::heat_conduction_solver(
+        axis_size, side_length,
+        5,  // number of iterations
+        k,
+        0.0,  // x=0 IC
+        0.0,  // x=end IC
+        1e-5  // tolerance
     );
     ASSERT_EQ(std::accumulate(U, U + axis_size, 0.0), 0.0);
     std::free(U);
@@ -80,12 +81,13 @@ TEST(HeatSolve, FullSolve) {
     // a small amount of difference.
     double test_temp = 10.0;
     U = static_cast<double*>(std::malloc(axis_size * sizeof(double)));
-    U = openturbine::heat_solve::heat_conduction_solver(axis_size, side_length,
-                                                        500,  // number of iterations
-                                                        k,
-                                                        test_temp,  // x=0 IC
-                                                        test_temp,  // x=end IC
-                                                        1e-8        // tolerance
+    U = openturbine::heat_solve::heat_conduction_solver(
+        axis_size, side_length,
+        500,  // number of iterations
+        k,
+        test_temp,  // x=0 IC
+        test_temp,  // x=end IC
+        1e-8        // tolerance
     );
     ASSERT_NEAR(std::accumulate(U, U + axis_size, 0.0), test_temp * axis_size / side_length, 1e-6);
 
@@ -94,12 +96,13 @@ TEST(HeatSolve, FullSolve) {
     // of the end points.
     test_temp = 10.0;
     U = static_cast<double*>(std::malloc(axis_size * sizeof(double)));
-    U = openturbine::heat_solve::heat_conduction_solver(axis_size, side_length,
-                                                        500,  // number of iterations
-                                                        k,
-                                                        0.0,        // x=0 IC
-                                                        test_temp,  // x=end IC
-                                                        1e-8        // tolerance
+    U = openturbine::heat_solve::heat_conduction_solver(
+        axis_size, side_length,
+        500,  // number of iterations
+        k,
+        0.0,        // x=0 IC
+        test_temp,  // x=end IC
+        1e-8        // tolerance
     );
     ASSERT_NEAR(U[5], test_temp / 2.0, 1e-6);
 }

--- a/tests/unit_tests/utest_main.cpp
+++ b/tests/unit_tests/utest_main.cpp
@@ -2,9 +2,11 @@
  *  Entry point for unit tests
  */
 
-#include "OpenTurbineTestEnv.H"
-#include "gtest/gtest.h"
 #include <Kokkos_Core.hpp>
+
+#include "gtest/gtest.h"
+
+#include "OpenTurbineTestEnv.H"
 
 //! Global instance of the environment (for access in tests)
 openturbine_tests::OTurbTestEnv* utest_env{nullptr};


### PR DESCRIPTION
Modified .clang-format and applied it to `src/` and `tests/ `directory files. Highlights are as follows
- Added block indent for alignment after open bracket
- Increased the column limit to 101
- Fixed the include categories to improve grouping