### PR TITLE
Resolve missing lapack/blas symbols.

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -8,6 +8,8 @@ target_link_libraries(${oturb_exe_name} PRIVATE
     Kokkos::kokkos
     LAPACK::LAPACK
     lapacke
+    lapack
+    blas
 )
 
 target_sources(${oturb_lib_name} PRIVATE heat/heat_solve.cpp)


### PR DESCRIPTION
On my linux system, I loaded a lapack module, which includes lapacke and lapack and blas.
But linking openturbine failed with unresolved lapack and blas symbols until I explicitly added lapack and blas to the CMakeLists.txt file which was already referencing lapacke.

Apparently this isn't needed on all systems, but perhaps it is good to explicitly reference the lapack and blas libraries?