### PR TITLE
Implement rotation of 3-D vectors using quaternions

### DIFF
--- a/src/rigid_pendulum_poc/CMakeLists.txt
+++ b/src/rigid_pendulum_poc/CMakeLists.txt
@@ -9,5 +9,6 @@ target_sources(${oturb_lib_name}
     state.cpp
     time_integrator.cpp
     time_stepper.cpp
+    utilities.cpp
     # IOManager.cpp
 )

--- a/src/rigid_pendulum_poc/quaternion.cpp
+++ b/src/rigid_pendulum_poc/quaternion.cpp
@@ -17,6 +17,27 @@ bool close_to(double a, double b, double epsilon) {
     return (delta / a) < epsilon ? true : false;
 }
 
+double wrap_angle_to_pi(double angle) {
+    double wrapped_angle = std::fmod(angle, 2. * kPI);
+
+    // Check if the angle is close to PI or -PI to avoid numerical issues
+    if (close_to(wrapped_angle, kPI)) {
+        return kPI;
+    }
+    if (close_to(wrapped_angle, -kPI)) {
+        return -kPI;
+    }
+
+    if (wrapped_angle > kPI) {
+        wrapped_angle -= 2. * kPI;
+    }
+    if (wrapped_angle < -kPI) {
+        wrapped_angle += 2. * kPI;
+    }
+
+    return wrapped_angle;
+}
+
 Quaternion::Quaternion(double q0, double q1, double q2, double q3)
     : q0_(q0), q1_(q1), q2_(q2), q3_(q3) {
 }

--- a/src/rigid_pendulum_poc/quaternion.cpp
+++ b/src/rigid_pendulum_poc/quaternion.cpp
@@ -88,4 +88,34 @@ Vector rotation_vector_from_quaternion(const Quaternion& quaternion) {
     return {q1 * k, q2 * k, q3 * k};
 }
 
+Quaternion quaternion_from_axis_angle(double angle, const Vector& axis) {
+    auto [v0, v1, v2] = axis;
+    double sin_angle = std::sin(angle / 2.0);
+    double cos_angle = std::cos(angle / 2.0);
+
+    return Quaternion(cos_angle, v0 * sin_angle, v1 * sin_angle, v2 * sin_angle);
+}
+
+std::tuple<double, Vector> axis_angle_from_quaternion(const Quaternion& quaternion) {
+    auto [q0, q1, q2, q3] = quaternion.GetComponents();
+    double angle = 2. * std::atan2(std::sqrt(q1 * q1 + q2 * q2 + q3 * q3), q0);
+
+    // If angle is null, return the angle 0 and axis {1, 0, 0}
+    if (close_to(angle, 0.)) {
+        return {0., {1., 0., 0.}};
+    }
+
+    angle = wrap_angle_to_pi(angle);
+    double k = 1. / std::sqrt(q1 * q1 + q2 * q2 + q3 * q3);
+
+    // normalize the axis
+    // TODO: Take care of the tech debt (Vector class) and use its normalize method
+    auto axis = Vector{q1 * k, q2 * k, q3 * k};
+    auto [v0, v1, v2] = axis;
+    auto length = std::sqrt(v0 * v0 + v1 * v1 + v2 * v2);
+    auto normalized_axis = Vector{v0 / length, v1 / length, v2 / length};
+
+    return {angle, normalized_axis};
+}
+
 }  // namespace openturbine::rigid_pendulum

--- a/src/rigid_pendulum_poc/quaternion.cpp
+++ b/src/rigid_pendulum_poc/quaternion.cpp
@@ -118,4 +118,18 @@ std::tuple<double, Vector> axis_angle_from_quaternion(const Quaternion& quaterni
     return {angle, normalized_axis};
 }
 
+Vector rotate_vector(const Quaternion& quaternion, const Vector& vector) {
+    auto [v0, v1, v2] = vector;
+    auto [q0, q1, q2, q3] = quaternion.GetComponents();
+
+    return Vector(
+        (q0 * q0 + q1 * q1 - q2 * q2 - q3 * q3) * v0 + 2. * (q1 * q2 - q0 * q3) * v1 +
+            2. * (q1 * q3 + q0 * q2) * v2,
+        2. * (q1 * q2 + q0 * q3) * v0 + (q0 * q0 - q1 * q1 + q2 * q2 - q3 * q3) * v1 +
+            2. * (q2 * q3 - q0 * q1) * v2,
+        2. * (q1 * q3 - q0 * q2) * v0 + 2. * (q2 * q3 + q0 * q1) * v1 +
+            (q0 * q0 - q1 * q1 - q2 * q2 + q3 * q3) * v2
+    );
+}
+
 }  // namespace openturbine::rigid_pendulum

--- a/src/rigid_pendulum_poc/quaternion.cpp
+++ b/src/rigid_pendulum_poc/quaternion.cpp
@@ -2,42 +2,6 @@
 
 namespace openturbine::rigid_pendulum {
 
-bool close_to(double a, double b, double epsilon) {
-    auto delta = std::abs(a - b);
-    a = std::abs(a);
-    b = std::abs(b);
-
-    if (a < epsilon) {
-        if (b < epsilon) {
-            return true;
-        }
-        return false;
-    }
-
-    return (delta / a) < epsilon ? true : false;
-}
-
-double wrap_angle_to_pi(double angle) {
-    double wrapped_angle = std::fmod(angle, 2. * kPI);
-
-    // Check if the angle is close to PI or -PI to avoid numerical issues
-    if (close_to(wrapped_angle, kPI)) {
-        return kPI;
-    }
-    if (close_to(wrapped_angle, -kPI)) {
-        return -kPI;
-    }
-
-    if (wrapped_angle > kPI) {
-        wrapped_angle -= 2. * kPI;
-    }
-    if (wrapped_angle < -kPI) {
-        wrapped_angle += 2. * kPI;
-    }
-
-    return wrapped_angle;
-}
-
 Quaternion::Quaternion(double q0, double q1, double q2, double q3)
     : q0_(q0), q1_(q1), q2_(q2), q3_(q3) {
 }
@@ -88,7 +52,7 @@ Vector rotation_vector_from_quaternion(const Quaternion& quaternion) {
     return {q1 * k, q2 * k, q3 * k};
 }
 
-Quaternion quaternion_from_axis_angle(double angle, const Vector& axis) {
+Quaternion quaternion_from_angle_axis(double angle, const Vector& axis) {
     auto [v0, v1, v2] = axis;
     double sin_angle = std::sin(angle / 2.0);
     double cos_angle = std::cos(angle / 2.0);
@@ -96,7 +60,7 @@ Quaternion quaternion_from_axis_angle(double angle, const Vector& axis) {
     return Quaternion(cos_angle, v0 * sin_angle, v1 * sin_angle, v2 * sin_angle);
 }
 
-std::tuple<double, Vector> axis_angle_from_quaternion(const Quaternion& quaternion) {
+std::tuple<double, Vector> angle_axis_from_quaternion(const Quaternion& quaternion) {
     auto [q0, q1, q2, q3] = quaternion.GetComponents();
     double angle = 2. * std::atan2(std::sqrt(q1 * q1 + q2 * q2 + q3 * q3), q0);
 

--- a/src/rigid_pendulum_poc/quaternion.cpp
+++ b/src/rigid_pendulum_poc/quaternion.cpp
@@ -2,19 +2,19 @@
 
 namespace openturbine::rigid_pendulum {
 
-bool close_to(double a, double b) {
+bool close_to(double a, double b, double epsilon) {
     auto delta = std::abs(a - b);
     a = std::abs(a);
     b = std::abs(b);
 
-    if (a < 1e-6) {
-        if (b < 1e-6) {
+    if (a < epsilon) {
+        if (b < epsilon) {
             return true;
         }
         return false;
     }
 
-    return (delta / a) < kTOLERANCE ? true : false;
+    return (delta / a) < epsilon ? true : false;
 }
 
 Quaternion::Quaternion(double q0, double q1, double q2, double q3)
@@ -36,11 +36,8 @@ Quaternion Quaternion::GetUnitQuaternion() const {
     return *this / length;
 }
 
-Quaternion quaternion_from_rotation_vector(const std::tuple<double, double, double>& vector) {
-    auto v0 = std::get<0>(vector);
-    auto v1 = std::get<1>(vector);
-    auto v2 = std::get<2>(vector);
-
+Quaternion quaternion_from_rotation_vector(const Vector& vector) {
+    auto [v0, v1, v2] = vector;
     double angle = std::sqrt(v0 * v0 + v1 * v1 + v2 * v2);
 
     // Return the quaternion {1, 0, 0, 0} if provided rotation vector is null
@@ -55,7 +52,7 @@ Quaternion quaternion_from_rotation_vector(const std::tuple<double, double, doub
     return Quaternion(cos_angle, v0 * factor, v1 * factor, v2 * factor);
 }
 
-std::tuple<double, double, double> rotation_vector_from_quaternion(const Quaternion& quaternion) {
+Vector rotation_vector_from_quaternion(const Quaternion& quaternion) {
     auto [q0, q1, q2, q3] = quaternion.GetComponents();
     auto sin_angle_squared = q1 * q1 + q2 * q2 + q3 * q3;
 

--- a/src/rigid_pendulum_poc/quaternion.h
+++ b/src/rigid_pendulum_poc/quaternion.h
@@ -5,10 +5,19 @@
 
 namespace openturbine::rigid_pendulum {
 
+using Vector = std::tuple<double, double, double>;
+
+// TODO: Move the following definitions to a constants.h file in a common math directory
 static constexpr double kTOLERANCE = 1e-6;
 
-/// Returns a boolean indicating if two provided doubles are close to each other
-bool close_to(double a, double b);
+// TODO: Move the following math related functions to a common math directory
+/*!
+ * @brief  Returns a boolean indicating if two provided doubles are close to each other
+ * @param  a: First double
+ * @param  b: Second double
+ * @param  epsilon: Tolerance for closeness
+ */
+bool close_to(double a, double b, double epsilon = kTOLERANCE);
 
 /// @brief Class to represent a quaternion
 class Quaternion {
@@ -106,9 +115,9 @@ private:
 };
 
 /// Returns a 4-D quaternion from provided 3-D rotation vector, i.e. exponential map
-Quaternion quaternion_from_rotation_vector(const std::tuple<double, double, double>&);
+Quaternion quaternion_from_rotation_vector(const Vector&);
 
 /// Returns a 3-D rotation vector from provided 4-D quaternion, i.e. logarithmic map
-std::tuple<double, double, double> rotation_vector_from_quaternion(const Quaternion&);
+Vector rotation_vector_from_quaternion(const Quaternion&);
 
 }  // namespace openturbine::rigid_pendulum

--- a/src/rigid_pendulum_poc/quaternion.h
+++ b/src/rigid_pendulum_poc/quaternion.h
@@ -115,7 +115,7 @@ Vector rotation_vector_from_quaternion(const Quaternion&);
  * @brief Returns a quaternion from provided Euler parameters/angle-axis representation of rotation
  * @param angle Angle of rotation in radians, in radians
  * @param axis Axis of rotation, a unit vector
- * @return Quaternion representing the rotation
+ * @return Unit quaternion representing the rotation
  */
 Quaternion quaternion_from_angle_axis(double angle, const Vector&);
 
@@ -126,7 +126,7 @@ Quaternion quaternion_from_angle_axis(double angle, const Vector&);
  */
 std::tuple<double, Vector> angle_axis_from_quaternion(const Quaternion&);
 
-/// Rotates provided vector by provided quaternion and returns the result
+/// Rotates provided vector by provided *unit* quaternion and returns the result
 Vector rotate_vector(const Quaternion&, const Vector&);
 
 }  // namespace openturbine::rigid_pendulum

--- a/src/rigid_pendulum_poc/quaternion.h
+++ b/src/rigid_pendulum_poc/quaternion.h
@@ -9,6 +9,7 @@ using Vector = std::tuple<double, double, double>;
 
 // TODO: Move the following definitions to a constants.h file in a common math directory
 static constexpr double kTOLERANCE = 1e-6;
+static constexpr double kPI = 3.14159265358979323846;
 
 // TODO: Move the following math related functions to a common math directory
 /*!
@@ -18,6 +19,12 @@ static constexpr double kTOLERANCE = 1e-6;
  * @param  epsilon: Tolerance for closeness
  */
 bool close_to(double a, double b, double epsilon = kTOLERANCE);
+
+/*!
+ * @brief  Takes an angle and returns the equivalent angle in the range [-pi, pi]
+ * @param  angle: Angle to be wrapped, in radians
+ */
+double wrap_angle_to_pi(double angle);
 
 /// @brief Class to represent a quaternion
 class Quaternion {

--- a/src/rigid_pendulum_poc/quaternion.h
+++ b/src/rigid_pendulum_poc/quaternion.h
@@ -143,4 +143,7 @@ Quaternion quaternion_from_axis_angle(double angle, const Vector&);
  */
 std::tuple<double, Vector> axis_angle_from_quaternion(const Quaternion&);
 
+/// Rotates provided vector by provided quaternion and returns the result
+Vector rotate_vector(const Quaternion&, const Vector&);
+
 }  // namespace openturbine::rigid_pendulum

--- a/src/rigid_pendulum_poc/quaternion.h
+++ b/src/rigid_pendulum_poc/quaternion.h
@@ -3,29 +3,12 @@
 #include <cmath>
 #include <tuple>
 
+#include "src/rigid_pendulum_poc/utilities.h"
+
 namespace openturbine::rigid_pendulum {
 
 // TECH DEBT: We need to introduce a Vector class to represent 3D vectors
 using Vector = std::tuple<double, double, double>;
-
-// TODO: Move the following definitions to a constants.h file in a common math directory
-static constexpr double kTOLERANCE = 1e-6;
-static constexpr double kPI = 3.14159265358979323846;
-
-// TODO: Move the following math related functions to a common math directory
-/*!
- * @brief  Returns a boolean indicating if two provided doubles are close to each other
- * @param  a: First double
- * @param  b: Second double
- * @param  epsilon: Tolerance for closeness
- */
-bool close_to(double a, double b, double epsilon = kTOLERANCE);
-
-/*!
- * @brief  Takes an angle and returns the equivalent angle in the range [-pi, pi]
- * @param  angle: Angle to be wrapped, in radians
- */
-double wrap_angle_to_pi(double angle);
 
 /// @brief Class to represent a quaternion
 class Quaternion {
@@ -129,19 +112,19 @@ Quaternion quaternion_from_rotation_vector(const Vector&);
 Vector rotation_vector_from_quaternion(const Quaternion&);
 
 /*!
- * @brief Returns a quaternion from provided Euler parameters/axis-angle representation of rotation
+ * @brief Returns a quaternion from provided Euler parameters/angle-axis representation of rotation
  * @param angle Angle of rotation in radians, in radians
  * @param axis Axis of rotation, a unit vector
  * @return Quaternion representing the rotation
  */
-Quaternion quaternion_from_axis_angle(double angle, const Vector&);
+Quaternion quaternion_from_angle_axis(double angle, const Vector&);
 
 /*!
- * @brief Returns Euler parameters/axis-angle representation of rotation from provided quaternion
+ * @brief Returns Euler parameters/angle-axis representation of rotation from provided quaternion
  * @param quaternion Quaternion to be converted
  * @return Tuple of angle of rotation in radians and axis of rotation as a unit vector
  */
-std::tuple<double, Vector> axis_angle_from_quaternion(const Quaternion&);
+std::tuple<double, Vector> angle_axis_from_quaternion(const Quaternion&);
 
 /// Rotates provided vector by provided quaternion and returns the result
 Vector rotate_vector(const Quaternion&, const Vector&);

--- a/src/rigid_pendulum_poc/quaternion.h
+++ b/src/rigid_pendulum_poc/quaternion.h
@@ -5,6 +5,7 @@
 
 namespace openturbine::rigid_pendulum {
 
+// TECH DEBT: We need to introduce a Vector class to represent 3D vectors
 using Vector = std::tuple<double, double, double>;
 
 // TODO: Move the following definitions to a constants.h file in a common math directory
@@ -126,5 +127,20 @@ Quaternion quaternion_from_rotation_vector(const Vector&);
 
 /// Returns a 3-D rotation vector from provided 4-D quaternion, i.e. logarithmic map
 Vector rotation_vector_from_quaternion(const Quaternion&);
+
+/*!
+ * @brief Returns a quaternion from provided Euler parameters/axis-angle representation of rotation
+ * @param angle Angle of rotation in radians, in radians
+ * @param axis Axis of rotation, a unit vector
+ * @return Quaternion representing the rotation
+ */
+Quaternion quaternion_from_axis_angle(double angle, const Vector&);
+
+/*!
+ * @brief Returns Euler parameters/axis-angle representation of rotation from provided quaternion
+ * @param quaternion Quaternion to be converted
+ * @return Tuple of angle of rotation in radians and axis of rotation as a unit vector
+ */
+std::tuple<double, Vector> axis_angle_from_quaternion(const Quaternion&);
 
 }  // namespace openturbine::rigid_pendulum

--- a/src/rigid_pendulum_poc/utilities.cpp
+++ b/src/rigid_pendulum_poc/utilities.cpp
@@ -1,0 +1,43 @@
+#include "src/rigid_pendulum_poc/utilities.h"
+
+#include <cmath>
+
+namespace openturbine::rigid_pendulum {
+
+bool close_to(double a, double b, double epsilon) {
+    auto delta = std::abs(a - b);
+    a = std::abs(a);
+    b = std::abs(b);
+
+    if (a < epsilon) {
+        if (b < epsilon) {
+            return true;
+        }
+        return false;
+    }
+
+    return (delta / a) < epsilon ? true : false;
+}
+
+double wrap_angle_to_pi(double angle) {
+    double wrapped_angle = std::fmod(angle, 2. * kPI);
+
+    // Check if the angle is close to PI or -PI to avoid numerical issues
+    if (close_to(wrapped_angle, kPI)) {
+        return kPI;
+    }
+    if (close_to(wrapped_angle, -kPI)) {
+        return -kPI;
+    }
+
+    if (wrapped_angle > kPI) {
+        wrapped_angle -= 2. * kPI;
+    }
+    if (wrapped_angle < -kPI) {
+        wrapped_angle += 2. * kPI;
+    }
+
+    return wrapped_angle;
+}
+
+}  // namespace openturbine::rigid_pendulum

--- a/src/rigid_pendulum_poc/utilities.h
+++ b/src/rigid_pendulum_poc/utilities.h
@@ -1,0 +1,24 @@
+#pragma once
+
+namespace openturbine::rigid_pendulum {
+
+// TODO: Move the following definitions to a constants.h file in a common math directory
+static constexpr double kTOLERANCE = 1e-6;
+static constexpr double kPI = 3.14159265358979323846;
+
+// TODO: Move the following math related functions to a common math directory
+/*!
+ * @brief  Returns a boolean indicating if two provided doubles are close to each other
+ * @param  a: First double
+ * @param  b: Second double
+ * @param  epsilon: Tolerance for closeness
+ */
+bool close_to(double a, double b, double epsilon = kTOLERANCE);
+
+/*!
+ * @brief  Takes an angle and returns the equivalent angle in the range [-pi, pi]
+ * @param  angle: Angle to be wrapped, in radians
+ */
+double wrap_angle_to_pi(double angle);
+
+}  // namespace openturbine::rigid_pendulum

--- a/tests/unit_tests/rigid_pendulum_poc/CMakeLists.txt
+++ b/tests/unit_tests/rigid_pendulum_poc/CMakeLists.txt
@@ -4,6 +4,7 @@ target_sources(
     PRIVATE
     test_generalized_alpha_solver.cpp
     test_linear_systems_solver.cpp
+    test_math_utilities.cpp
     test_quaternions.cpp
     test_time_stepper.cpp
     test_utilities.cpp

--- a/tests/unit_tests/rigid_pendulum_poc/test_math_utilities.cpp
+++ b/tests/unit_tests/rigid_pendulum_poc/test_math_utilities.cpp
@@ -4,76 +4,260 @@
 
 namespace openturbine::rigid_pendulum::tests {
 
-TEST(MathUtilitiesTest, CloseTo) {
+TEST(MathUtilitiesTest, CloseTo_Set1) {
     ASSERT_TRUE(close_to(1., 1.));
+}
+
+TEST(MathUtilitiesTest, CloseTo_Set2) {
     ASSERT_TRUE(close_to(1., 1. + 1e-7));
+}
+
+TEST(MathUtilitiesTest, CloseTo_Set3) {
     ASSERT_TRUE(close_to(1., 1. - 1e-7));
+}
+
+TEST(MathUtilitiesTest, CloseTo_Set4) {
     ASSERT_FALSE(close_to(1., 1. + 1e-5));
+}
+
+TEST(MathUtilitiesTest, CloseTo_Set5) {
     ASSERT_FALSE(close_to(1., 1. - 1e-5));
+}
+
+TEST(MathUtilitiesTest, CloseTo_Set6) {
     ASSERT_TRUE(close_to(1e-7, 1e-7));
+}
 
+TEST(MathUtilitiesTest, CloseTo_Set7) {
     ASSERT_TRUE(close_to(-1., -1.));
-    ASSERT_TRUE(close_to(-1., -1. + 1e-7));
-    ASSERT_TRUE(close_to(-1., -1. - 1e-7));
-    ASSERT_FALSE(close_to(-1., -1. + 1e-5));
-    ASSERT_FALSE(close_to(-1., -1. - 1e-5));
-    ASSERT_TRUE(close_to(-1e-7, -1e-7));
+}
 
+TEST(MathUtilitiesTest, CloseTo_Set8) {
+    ASSERT_TRUE(close_to(-1., -1. + 1e-7));
+}
+
+TEST(MathUtilitiesTest, CloseTo_Set9) {
+    ASSERT_TRUE(close_to(-1., -1. - 1e-7));
+}
+
+TEST(MathUtilitiesTest, CloseTo_Set10) {
+    ASSERT_FALSE(close_to(-1., -1. + 1e-5));
+}
+
+TEST(MathUtilitiesTest, CloseTo_Set11) {
+    ASSERT_FALSE(close_to(-1., -1. - 1e-5));
+}
+
+TEST(MathUtilitiesTest, CloseTo_Set12) {
+    ASSERT_TRUE(close_to(-1e-7, -1e-7));
+}
+
+TEST(MathUtilitiesTest, CloseTo_Set13) {
     ASSERT_FALSE(close_to(1., -1.));
+}
+
+TEST(MathUtilitiesTest, CloseTo_Set14) {
     ASSERT_FALSE(close_to(-1., 1.));
+}
+
+TEST(MathUtilitiesTest, CloseTo_Set15) {
     ASSERT_FALSE(close_to(1., -1. + 1e-7));
+}
+
+TEST(MathUtilitiesTest, CloseTo_Set16) {
     ASSERT_FALSE(close_to(-1., 1. + 1e-7));
+}
+
+TEST(MathUtilitiesTest, CloseTo_Set17) {
     ASSERT_FALSE(close_to(1., -1. - 1e-7));
+}
+
+TEST(MathUtilitiesTest, CloseTo_Set18) {
     ASSERT_FALSE(close_to(-1., 1. - 1e-7));
+}
+
+TEST(MathUtilitiesTest, CloseTo_Set19) {
     ASSERT_FALSE(close_to(1., -1. + 1e-5));
+}
+
+TEST(MathUtilitiesTest, CloseTo_Set20) {
     ASSERT_FALSE(close_to(-1., 1. + 1e-5));
+}
+
+TEST(MathUtilitiesTest, CloseTo_Set21) {
     ASSERT_FALSE(close_to(1., -1. - 1e-5));
+}
+
+TEST(MathUtilitiesTest, CloseTo_Set22) {
     ASSERT_FALSE(close_to(-1., 1. - 1e-5));
 }
 
-TEST(MathUtilitiesTest, WrapAngleToPi) {
-    // 0 degrees
-    ASSERT_NEAR(wrap_angle_to_pi(0), 0., 1e-6);
+TEST(MathUtilitiesTest, WrapAngleToPi_ZeroDegree) {
+    // 0 degree
+    auto angle = 0.;
+    auto expected = 0.;
+
+    ASSERT_NEAR(wrap_angle_to_pi(angle), expected, 1e-6);
+}
+
+TEST(MathUtilitiesTest, WrapAngleToPi_FortyFiveDegrees) {
     // 45 degrees
-    ASSERT_NEAR(wrap_angle_to_pi(kPI / 4.), kPI / 4., 1e-6);
+    auto angle = kPI / 4.;
+    auto expected = kPI / 4.;
+
+    ASSERT_NEAR(wrap_angle_to_pi(angle), expected, 1e-6);
+}
+
+TEST(MathUtilitiesTest, WrapAngleToPi_NegativeFortyFiveDegrees) {
     // -45 degrees
-    ASSERT_NEAR(wrap_angle_to_pi(-kPI / 4.), -kPI / 4., 1e-6);
+    auto angle = -kPI / 4.;
+    auto expected = -kPI / 4.;
+
+    ASSERT_NEAR(wrap_angle_to_pi(angle), expected, 1e-6);
+}
+
+TEST(MathUtilitiesTest, WrapAngleToPi_NinetyDegrees) {
     // 90 degrees
-    ASSERT_NEAR(wrap_angle_to_pi(0.5 * kPI), 0.5 * kPI, 1e-6);
+    auto angle = kPI / 2.;
+    auto expected = kPI / 2.;
+
+    ASSERT_NEAR(wrap_angle_to_pi(angle), expected, 1e-6);
+}
+
+TEST(MathUtilitiesTest, WrapAngleToPi_NegativeNinetyDegrees) {
     // -90 degrees
-    ASSERT_NEAR(wrap_angle_to_pi(-0.5 * kPI), -0.5 * kPI, 1e-6);
+    auto angle = -kPI / 2.;
+    auto expected = -kPI / 2.;
+
+    ASSERT_NEAR(wrap_angle_to_pi(angle), expected, 1e-6);
+}
+
+TEST(MathUtilitiesTest, WrapAngleToPi_OneHundredThirtyFiveDegrees) {
     // 135 degrees
-    ASSERT_NEAR(wrap_angle_to_pi(kPI / 2. + kPI / 4.), 0.75 * kPI, 1e-6);
+    auto angle = kPI / 2. + kPI / 4.;
+    auto expected = 0.75 * kPI;
+
+    ASSERT_NEAR(wrap_angle_to_pi(angle), expected, 1e-6);
+}
+
+TEST(MathUtilitiesTest, WrapAngleToPi_NegativeOneHundredThirtyFiveDegrees) {
     // -135 degrees
-    ASSERT_NEAR(wrap_angle_to_pi(-kPI / 2. - kPI / 4.), -0.75 * kPI, 1e-6);
+    auto angle = -kPI / 2. - kPI / 4.;
+    auto expected = -0.75 * kPI;
+
+    ASSERT_NEAR(wrap_angle_to_pi(angle), expected, 1e-6);
+}
+
+TEST(MathUtilitiesTest, WrapAngleToPi_OneHundredEightyDegrees) {
     // 180 degrees
-    ASSERT_NEAR(wrap_angle_to_pi(kPI), kPI, 1e-6);
+    auto angle = kPI;
+    auto expected = kPI;
+
+    ASSERT_NEAR(wrap_angle_to_pi(angle), expected, 1e-6);
+}
+
+TEST(MathUtilitiesTest, WrapAngleToPi_NegativeOneHundredEightyDegrees) {
     // -180 degrees
-    ASSERT_NEAR(wrap_angle_to_pi(-kPI), -kPI, 1e-6);
+    auto angle = -kPI;
+    auto expected = -kPI;
+
+    ASSERT_NEAR(wrap_angle_to_pi(angle), expected, 1e-6);
+}
+
+TEST(MathUtilitiesTest, WrapAngleToPi_TwoHundredTwentyFiveDegrees) {
     // 225 degrees
-    ASSERT_NEAR(wrap_angle_to_pi(kPI + kPI / 4.), -0.75 * kPI, 1e-6);
+    auto angle = kPI + kPI / 4.;
+    auto expected = -0.75 * kPI;
+
+    ASSERT_NEAR(wrap_angle_to_pi(angle), expected, 1e-6);
+}
+
+TEST(MathUtilitiesTest, WrapAngleToPi_NegativeTwoHundredTwentyFiveDegrees) {
     // -225 degrees
-    ASSERT_NEAR(wrap_angle_to_pi(-kPI - kPI / 4.), 0.75 * kPI, 1e-6);
+    auto angle = -kPI - kPI / 4.;
+    auto expected = 0.75 * kPI;
+
+    ASSERT_NEAR(wrap_angle_to_pi(angle), expected, 1e-6);
+}
+
+TEST(MathUtilitiesTest, WrapAngleToPi_TwoHundredSeventyDegrees) {
     // 270 degrees
-    ASSERT_NEAR(wrap_angle_to_pi(3. * kPI / 2.), -0.5 * kPI, 1e-6);
+    auto angle = 3. * kPI / 2.;
+    auto expected = -0.5 * kPI;
+
+    ASSERT_NEAR(wrap_angle_to_pi(angle), expected, 1e-6);
+}
+
+TEST(MathUtilitiesTest, WrapAngleToPi_NegativeTwoHundredSeventyDegrees) {
     // -270 degrees
-    ASSERT_NEAR(wrap_angle_to_pi(-3. * kPI / 2.), 0.5 * kPI, 1e-6);
+    auto angle = -3. * kPI / 2.;
+    auto expected = 0.5 * kPI;
+
+    ASSERT_NEAR(wrap_angle_to_pi(angle), expected, 1e-6);
+}
+
+TEST(MathUtilitiesTest, WrapAngleToPi_ThreeHundredSixtyDegrees) {
     // 360 degrees
-    ASSERT_NEAR(wrap_angle_to_pi(2. * kPI), 0., 1e-6);
+    auto angle = 2. * kPI;
+    auto expected = 0.;
+
+    ASSERT_NEAR(wrap_angle_to_pi(angle), expected, 1e-6);
+}
+
+TEST(MathUtilitiesTest, WrapAngleToPi_NegativeThreeHundredSixtyDegrees) {
     // -360 degrees
-    ASSERT_NEAR(wrap_angle_to_pi(-2. * kPI), 0., 1e-6);
+    auto angle = -2. * kPI;
+    auto expected = 0.;
+
+    ASSERT_NEAR(wrap_angle_to_pi(angle), expected, 1e-6);
+}
+
+TEST(MathUtilitiesTest, WrapAngleToPi_FourHundredFiveDegrees) {
     // 405 degrees = 360 + 45
-    ASSERT_NEAR(wrap_angle_to_pi(2. * kPI + kPI / 4.), kPI / 4., 1e-6);
+    auto angle = 2. * kPI + kPI / 4.;
+    auto expected = kPI / 4.;
+
+    ASSERT_NEAR(wrap_angle_to_pi(angle), expected, 1e-6);
+}
+
+TEST(MathUtilitiesTest, WrapAngleToPi_NegativeFourHundredFiveDegrees) {
     // -405 degrees = -360 - 45
-    ASSERT_NEAR(wrap_angle_to_pi(-2. * kPI - kPI / 4.), -kPI / 4., 1e-6);
+    auto angle = -2. * kPI - kPI / 4.;
+    auto expected = -kPI / 4.;
+
+    ASSERT_NEAR(wrap_angle_to_pi(angle), expected, 1e-6);
+}
+
+TEST(MathUtilitiesTest, WrapAngleToPi_FiveThousandsTwoHundredTwentyDegrees) {
     // 14 * 2 * pi + pi
-    ASSERT_NEAR(wrap_angle_to_pi(29. * kPI), kPI, 1e-6);
+    auto angle = 29. * kPI;
+    auto expected = kPI;
+
+    ASSERT_NEAR(wrap_angle_to_pi(angle), expected, 1e-6);
+}
+
+TEST(MathUtilitiesTest, WrapAngleToPi_NegativeFiveThousandsTwoHundredTwentyDegrees) {
     // -14 * 2 * pi - pi
-    ASSERT_NEAR(wrap_angle_to_pi(-29. * kPI), -kPI, 1e-6);
+    auto angle = -29. * kPI;
+    auto expected = -kPI;
+
+    ASSERT_NEAR(wrap_angle_to_pi(angle), expected, 1e-6);
+}
+
+TEST(MathUtilitiesTest, WrapAngleToPi_ThirtySixThousandThirtyDegrees) {
     // 200. * pi + (pi / 6.)
-    ASSERT_NEAR(wrap_angle_to_pi(200. * kPI + kPI / 6.), kPI / 6., 1e-6);
+    auto angle = 200. * kPI + kPI / 6.;
+    auto expected = kPI / 6.;
+
+    ASSERT_NEAR(wrap_angle_to_pi(angle), expected, 1e-6);
+}
+
+TEST(MathUtilitiesTest, WrapAngleToPi_NegativeThirtySixThousandThirtyDegrees) {
     // -200. * pi - (pi / 6.)
-    ASSERT_NEAR(wrap_angle_to_pi(-200. * kPI - kPI / 6.), -kPI / 6., 1e-6);
+    auto angle = -200. * kPI - kPI / 6.;
+    auto expected = -kPI / 6.;
+
+    ASSERT_NEAR(wrap_angle_to_pi(angle), expected, 1e-6);
 }
 
 }  // namespace openturbine::rigid_pendulum::tests

--- a/tests/unit_tests/rigid_pendulum_poc/test_math_utilities.cpp
+++ b/tests/unit_tests/rigid_pendulum_poc/test_math_utilities.cpp
@@ -9,23 +9,23 @@ TEST(MathUtilitiesTest, CloseTo_Set1) {
 }
 
 TEST(MathUtilitiesTest, CloseTo_Set2) {
-    ASSERT_TRUE(close_to(1., 1. + 1e-7));
+    ASSERT_TRUE(close_to(1., 1. + kTOLERANCE / 10.));
 }
 
 TEST(MathUtilitiesTest, CloseTo_Set3) {
-    ASSERT_TRUE(close_to(1., 1. - 1e-7));
+    ASSERT_TRUE(close_to(1., 1. - kTOLERANCE / 10.));
 }
 
 TEST(MathUtilitiesTest, CloseTo_Set4) {
-    ASSERT_FALSE(close_to(1., 1. + 1e-5));
+    ASSERT_FALSE(close_to(1., 1. + kTOLERANCE * 10.));
 }
 
 TEST(MathUtilitiesTest, CloseTo_Set5) {
-    ASSERT_FALSE(close_to(1., 1. - 1e-5));
+    ASSERT_FALSE(close_to(1., 1. - kTOLERANCE * 10.));
 }
 
 TEST(MathUtilitiesTest, CloseTo_Set6) {
-    ASSERT_TRUE(close_to(1e-7, 1e-7));
+    ASSERT_TRUE(close_to(kTOLERANCE / 10., kTOLERANCE / 10.));
 }
 
 TEST(MathUtilitiesTest, CloseTo_Set7) {
@@ -33,23 +33,23 @@ TEST(MathUtilitiesTest, CloseTo_Set7) {
 }
 
 TEST(MathUtilitiesTest, CloseTo_Set8) {
-    ASSERT_TRUE(close_to(-1., -1. + 1e-7));
+    ASSERT_TRUE(close_to(-1., -1. + kTOLERANCE / 10.));
 }
 
 TEST(MathUtilitiesTest, CloseTo_Set9) {
-    ASSERT_TRUE(close_to(-1., -1. - 1e-7));
+    ASSERT_TRUE(close_to(-1., -1. - kTOLERANCE / 10.));
 }
 
 TEST(MathUtilitiesTest, CloseTo_Set10) {
-    ASSERT_FALSE(close_to(-1., -1. + 1e-5));
+    ASSERT_FALSE(close_to(-1., -1. + kTOLERANCE * 10.));
 }
 
 TEST(MathUtilitiesTest, CloseTo_Set11) {
-    ASSERT_FALSE(close_to(-1., -1. - 1e-5));
+    ASSERT_FALSE(close_to(-1., -1. - kTOLERANCE * 10.));
 }
 
 TEST(MathUtilitiesTest, CloseTo_Set12) {
-    ASSERT_TRUE(close_to(-1e-7, -1e-7));
+    ASSERT_TRUE(close_to(-1e-7, -kTOLERANCE / 10.));
 }
 
 TEST(MathUtilitiesTest, CloseTo_Set13) {
@@ -61,35 +61,35 @@ TEST(MathUtilitiesTest, CloseTo_Set14) {
 }
 
 TEST(MathUtilitiesTest, CloseTo_Set15) {
-    ASSERT_FALSE(close_to(1., -1. + 1e-7));
+    ASSERT_FALSE(close_to(1., -1. + kTOLERANCE / 10.));
 }
 
 TEST(MathUtilitiesTest, CloseTo_Set16) {
-    ASSERT_FALSE(close_to(-1., 1. + 1e-7));
+    ASSERT_FALSE(close_to(-1., 1. + kTOLERANCE / 10.));
 }
 
 TEST(MathUtilitiesTest, CloseTo_Set17) {
-    ASSERT_FALSE(close_to(1., -1. - 1e-7));
+    ASSERT_FALSE(close_to(1., -1. - kTOLERANCE / 10.));
 }
 
 TEST(MathUtilitiesTest, CloseTo_Set18) {
-    ASSERT_FALSE(close_to(-1., 1. - 1e-7));
+    ASSERT_FALSE(close_to(-1., 1. - kTOLERANCE / 10.));
 }
 
 TEST(MathUtilitiesTest, CloseTo_Set19) {
-    ASSERT_FALSE(close_to(1., -1. + 1e-5));
+    ASSERT_FALSE(close_to(1., -1. + kTOLERANCE * 10.));
 }
 
 TEST(MathUtilitiesTest, CloseTo_Set20) {
-    ASSERT_FALSE(close_to(-1., 1. + 1e-5));
+    ASSERT_FALSE(close_to(-1., 1. + kTOLERANCE * 10.));
 }
 
 TEST(MathUtilitiesTest, CloseTo_Set21) {
-    ASSERT_FALSE(close_to(1., -1. - 1e-5));
+    ASSERT_FALSE(close_to(1., -1. - kTOLERANCE * 10.));
 }
 
 TEST(MathUtilitiesTest, CloseTo_Set22) {
-    ASSERT_FALSE(close_to(-1., 1. - 1e-5));
+    ASSERT_FALSE(close_to(-1., 1. - kTOLERANCE * 10.));
 }
 
 TEST(MathUtilitiesTest, WrapAngleToPi_ZeroDegree) {

--- a/tests/unit_tests/rigid_pendulum_poc/test_math_utilities.cpp
+++ b/tests/unit_tests/rigid_pendulum_poc/test_math_utilities.cpp
@@ -1,0 +1,79 @@
+#include <gtest/gtest.h>
+
+#include "src/rigid_pendulum_poc/utilities.h"
+
+namespace openturbine::rigid_pendulum::tests {
+
+TEST(MathUtilitiesTest, CloseTo) {
+    ASSERT_TRUE(close_to(1., 1.));
+    ASSERT_TRUE(close_to(1., 1. + 1e-7));
+    ASSERT_TRUE(close_to(1., 1. - 1e-7));
+    ASSERT_FALSE(close_to(1., 1. + 1e-5));
+    ASSERT_FALSE(close_to(1., 1. - 1e-5));
+    ASSERT_TRUE(close_to(1e-7, 1e-7));
+
+    ASSERT_TRUE(close_to(-1., -1.));
+    ASSERT_TRUE(close_to(-1., -1. + 1e-7));
+    ASSERT_TRUE(close_to(-1., -1. - 1e-7));
+    ASSERT_FALSE(close_to(-1., -1. + 1e-5));
+    ASSERT_FALSE(close_to(-1., -1. - 1e-5));
+    ASSERT_TRUE(close_to(-1e-7, -1e-7));
+
+    ASSERT_FALSE(close_to(1., -1.));
+    ASSERT_FALSE(close_to(-1., 1.));
+    ASSERT_FALSE(close_to(1., -1. + 1e-7));
+    ASSERT_FALSE(close_to(-1., 1. + 1e-7));
+    ASSERT_FALSE(close_to(1., -1. - 1e-7));
+    ASSERT_FALSE(close_to(-1., 1. - 1e-7));
+    ASSERT_FALSE(close_to(1., -1. + 1e-5));
+    ASSERT_FALSE(close_to(-1., 1. + 1e-5));
+    ASSERT_FALSE(close_to(1., -1. - 1e-5));
+    ASSERT_FALSE(close_to(-1., 1. - 1e-5));
+}
+
+TEST(MathUtilitiesTest, WrapAngleToPi) {
+    // 0 degrees
+    ASSERT_NEAR(wrap_angle_to_pi(0), 0., 1e-6);
+    // 45 degrees
+    ASSERT_NEAR(wrap_angle_to_pi(kPI / 4.), kPI / 4., 1e-6);
+    // -45 degrees
+    ASSERT_NEAR(wrap_angle_to_pi(-kPI / 4.), -kPI / 4., 1e-6);
+    // 90 degrees
+    ASSERT_NEAR(wrap_angle_to_pi(0.5 * kPI), 0.5 * kPI, 1e-6);
+    // -90 degrees
+    ASSERT_NEAR(wrap_angle_to_pi(-0.5 * kPI), -0.5 * kPI, 1e-6);
+    // 135 degrees
+    ASSERT_NEAR(wrap_angle_to_pi(kPI / 2. + kPI / 4.), 0.75 * kPI, 1e-6);
+    // -135 degrees
+    ASSERT_NEAR(wrap_angle_to_pi(-kPI / 2. - kPI / 4.), -0.75 * kPI, 1e-6);
+    // 180 degrees
+    ASSERT_NEAR(wrap_angle_to_pi(kPI), kPI, 1e-6);
+    // -180 degrees
+    ASSERT_NEAR(wrap_angle_to_pi(-kPI), -kPI, 1e-6);
+    // 225 degrees
+    ASSERT_NEAR(wrap_angle_to_pi(kPI + kPI / 4.), -0.75 * kPI, 1e-6);
+    // -225 degrees
+    ASSERT_NEAR(wrap_angle_to_pi(-kPI - kPI / 4.), 0.75 * kPI, 1e-6);
+    // 270 degrees
+    ASSERT_NEAR(wrap_angle_to_pi(3. * kPI / 2.), -0.5 * kPI, 1e-6);
+    // -270 degrees
+    ASSERT_NEAR(wrap_angle_to_pi(-3. * kPI / 2.), 0.5 * kPI, 1e-6);
+    // 360 degrees
+    ASSERT_NEAR(wrap_angle_to_pi(2. * kPI), 0., 1e-6);
+    // -360 degrees
+    ASSERT_NEAR(wrap_angle_to_pi(-2. * kPI), 0., 1e-6);
+    // 405 degrees = 360 + 45
+    ASSERT_NEAR(wrap_angle_to_pi(2. * kPI + kPI / 4.), kPI / 4., 1e-6);
+    // -405 degrees = -360 - 45
+    ASSERT_NEAR(wrap_angle_to_pi(-2. * kPI - kPI / 4.), -kPI / 4., 1e-6);
+    // 14 * 2 * pi + pi
+    ASSERT_NEAR(wrap_angle_to_pi(29. * kPI), kPI, 1e-6);
+    // -14 * 2 * pi - pi
+    ASSERT_NEAR(wrap_angle_to_pi(-29. * kPI), -kPI, 1e-6);
+    // 200. * pi + (pi / 6.)
+    ASSERT_NEAR(wrap_angle_to_pi(200. * kPI + kPI / 6.), kPI / 6., 1e-6);
+    // -200. * pi - (pi / 6.)
+    ASSERT_NEAR(wrap_angle_to_pi(-200. * kPI - kPI / 6.), -kPI / 6., 1e-6);
+}
+
+}  // namespace openturbine::rigid_pendulum::tests

--- a/tests/unit_tests/rigid_pendulum_poc/test_quaternions.cpp
+++ b/tests/unit_tests/rigid_pendulum_poc/test_quaternions.cpp
@@ -1,6 +1,7 @@
 #include <gtest/gtest.h>
 
 #include "src/rigid_pendulum_poc/quaternion.h"
+#include "src/rigid_pendulum_poc/utilities.h"
 
 namespace openturbine::rigid_pendulum::tests {
 
@@ -31,33 +32,6 @@ TEST(QuaternionTest, Length) {
     Quaternion q(1., 2., 3., 4.);
 
     ASSERT_EQ(q.Length(), std::sqrt(30.));
-}
-
-TEST(QuaternionTest, CloseTo) {
-    ASSERT_TRUE(close_to(1., 1.));
-    ASSERT_TRUE(close_to(1., 1. + 1e-7));
-    ASSERT_TRUE(close_to(1., 1. - 1e-7));
-    ASSERT_FALSE(close_to(1., 1. + 1e-5));
-    ASSERT_FALSE(close_to(1., 1. - 1e-5));
-    ASSERT_TRUE(close_to(1e-7, 1e-7));
-
-    ASSERT_TRUE(close_to(-1., -1.));
-    ASSERT_TRUE(close_to(-1., -1. + 1e-7));
-    ASSERT_TRUE(close_to(-1., -1. - 1e-7));
-    ASSERT_FALSE(close_to(-1., -1. + 1e-5));
-    ASSERT_FALSE(close_to(-1., -1. - 1e-5));
-    ASSERT_TRUE(close_to(-1e-7, -1e-7));
-
-    ASSERT_FALSE(close_to(1., -1.));
-    ASSERT_FALSE(close_to(-1., 1.));
-    ASSERT_FALSE(close_to(1., -1. + 1e-7));
-    ASSERT_FALSE(close_to(-1., 1. + 1e-7));
-    ASSERT_FALSE(close_to(1., -1. - 1e-7));
-    ASSERT_FALSE(close_to(-1., 1. - 1e-7));
-    ASSERT_FALSE(close_to(1., -1. + 1e-5));
-    ASSERT_FALSE(close_to(-1., 1. + 1e-5));
-    ASSERT_FALSE(close_to(1., -1. - 1e-5));
-    ASSERT_FALSE(close_to(-1., 1. - 1e-5));
 }
 
 TEST(QuaternionTest, AdditionOfTwoQuaternions) {
@@ -236,80 +210,10 @@ TEST(QuaternionTest, GetRotationVectorFromNullQuaternion) {
     ASSERT_NEAR(std::get<2>(v), std::get<2>(expected), 1e-6);
 }
 
-TEST(QuaternionTest, WrapAngleToPi) {
-    auto angle = 0.;  // 0 degrees
-    auto wrapped_angle = wrap_angle_to_pi(angle);
-    ASSERT_NEAR(wrapped_angle, 0., 1e-6);
-
-    angle = kPI / 2.;  // 90 degrees
-    wrapped_angle = wrap_angle_to_pi(angle);
-    ASSERT_NEAR(wrapped_angle, 0.5 * kPI, 1e-6);
-
-    angle = -kPI / 2.;  // -90 degrees
-    wrapped_angle = wrap_angle_to_pi(angle);
-    ASSERT_NEAR(wrapped_angle, -0.5 * kPI, 1e-6);
-
-    angle = kPI / 2. + kPI / 4.;  // 135 degrees
-    wrapped_angle = wrap_angle_to_pi(angle);
-    ASSERT_NEAR(wrapped_angle, 0.75 * kPI, 1e-6);
-
-    angle = -kPI / 2. - kPI / 4.;  // -135 degrees
-    wrapped_angle = wrap_angle_to_pi(angle);
-    ASSERT_NEAR(wrapped_angle, -0.75 * kPI, 1e-6);
-
-    angle = kPI;  // 180 degrees
-    wrapped_angle = wrap_angle_to_pi(angle);
-    ASSERT_NEAR(wrapped_angle, kPI, 1e-6);
-
-    angle = -kPI;
-    wrapped_angle = wrap_angle_to_pi(angle);  // -180 degrees
-    ASSERT_NEAR(wrapped_angle, -kPI, 1e-6);
-
-    angle = 3. * kPI / 2.;  // 270 degrees
-    wrapped_angle = wrap_angle_to_pi(angle);
-    ASSERT_NEAR(wrapped_angle, -0.5 * kPI, 1e-6);
-
-    angle = -3. * kPI / 2.;  // -270 degrees
-    wrapped_angle = wrap_angle_to_pi(angle);
-    ASSERT_NEAR(wrapped_angle, 0.5 * kPI, 1e-6);
-
-    angle = 2. * kPI;  // 360 degrees
-    wrapped_angle = wrap_angle_to_pi(angle);
-    ASSERT_NEAR(wrapped_angle, 0., 1e-6);
-
-    angle = -2. * kPI;  // -360 degrees
-    wrapped_angle = wrap_angle_to_pi(angle);
-    ASSERT_NEAR(wrapped_angle, 0., 1e-6);
-
-    angle = 2. * kPI + kPI / 4.;  // 405 degrees = 360 + 45
-    wrapped_angle = wrap_angle_to_pi(angle);
-    ASSERT_NEAR(wrapped_angle, kPI / 4., 1e-6);
-
-    angle = -2. * kPI - kPI / 4.;  // -405 degrees = -360 - 45
-    wrapped_angle = wrap_angle_to_pi(angle);
-    ASSERT_NEAR(wrapped_angle, -kPI / 4., 1e-6);
-
-    angle = 29. * kPI;  // 14 * 2 * kPI + kPI
-    wrapped_angle = wrap_angle_to_pi(angle);
-    ASSERT_NEAR(wrapped_angle, kPI, 1e-6);
-
-    angle = -29. * kPI;  // -14 * 2 * kPI - kPI
-    wrapped_angle = wrap_angle_to_pi(angle);
-    ASSERT_NEAR(wrapped_angle, -kPI, 1e-6);
-
-    angle = 200. * kPI + kPI / 6.;
-    wrapped_angle = wrap_angle_to_pi(angle);
-    ASSERT_NEAR(wrapped_angle, kPI / 6., 1e-6);
-
-    angle = -200. * kPI - kPI / 6.;
-    wrapped_angle = wrap_angle_to_pi(angle);
-    ASSERT_NEAR(wrapped_angle, -kPI / 6., 1e-6);
-}
-
-TEST(QuaternionTest, QuaternionFromAxisAngle_ZeroAngle) {
+TEST(QuaternionTest, QuaternionFromAngleAxis_ZeroAngle) {
     double angle = 0.;
     Vector axis{1., 0., 0.};
-    Quaternion q = quaternion_from_axis_angle(angle, axis);
+    Quaternion q = quaternion_from_angle_axis(angle, axis);
 
     Quaternion expected(1., 0., 0., 0.);
 
@@ -319,9 +223,9 @@ TEST(QuaternionTest, QuaternionFromAxisAngle_ZeroAngle) {
     ASSERT_NEAR(q.GetZComponent(), expected.GetZComponent(), 1e-6);
 }
 
-TEST(QuaternionTest, AxisAngleFromQuaternion_ZeroAngle) {
+TEST(QuaternionTest, AngleAxisFromQuaternion_ZeroAngle) {
     Quaternion q(1., 0., 0., 0.);
-    auto [angle, axis] = axis_angle_from_quaternion(q);
+    auto [angle, axis] = angle_axis_from_quaternion(q);
 
     ASSERT_NEAR(angle, 0., 1e-6);
     ASSERT_NEAR(std::get<0>(axis), 1., 1e-6);
@@ -329,10 +233,10 @@ TEST(QuaternionTest, AxisAngleFromQuaternion_ZeroAngle) {
     ASSERT_NEAR(std::get<2>(axis), 0., 1e-6);
 }
 
-TEST(QuaternionTest, QuaternionFromAxisAngle_90Degrees_XAxis) {
+TEST(QuaternionTest, QuaternionFromAngleAxis_90Degrees_XAxis) {
     double angle = kPI / 2.;
     Vector axis{1., 0., 0.};
-    Quaternion q = quaternion_from_axis_angle(angle, axis);
+    Quaternion q = quaternion_from_angle_axis(angle, axis);
 
     Quaternion expected(0.707107, 0.707107, 0., 0.);
 
@@ -342,9 +246,9 @@ TEST(QuaternionTest, QuaternionFromAxisAngle_90Degrees_XAxis) {
     ASSERT_NEAR(q.GetZComponent(), expected.GetZComponent(), 1e-6);
 }
 
-TEST(QuaternionTest, AxisAngleFromQuaternion_90Degrees_XAxis) {
+TEST(QuaternionTest, AngleAxisFromQuaternion_90Degrees_XAxis) {
     Quaternion q(0.707107, 0.707107, 0., 0.);
-    auto [angle, axis] = axis_angle_from_quaternion(q);
+    auto [angle, axis] = angle_axis_from_quaternion(q);
 
     ASSERT_NEAR(angle, kPI / 2., 1e-6);
     ASSERT_NEAR(std::get<0>(axis), 1., 1e-6);
@@ -352,10 +256,10 @@ TEST(QuaternionTest, AxisAngleFromQuaternion_90Degrees_XAxis) {
     ASSERT_NEAR(std::get<2>(axis), 0., 1e-6);
 }
 
-TEST(QuaternionTest, QuaternionFromAxisAngle_45Degrees_YAxis) {
+TEST(QuaternionTest, QuaternionFromAngleAxis_45Degrees_YAxis) {
     double angle = kPI / 4.;
     Vector axis{0., 1., 0.};
-    Quaternion q = quaternion_from_axis_angle(angle, axis);
+    Quaternion q = quaternion_from_angle_axis(angle, axis);
 
     Quaternion expected(0.923879, 0., 0.382683, 0.);
 
@@ -365,9 +269,9 @@ TEST(QuaternionTest, QuaternionFromAxisAngle_45Degrees_YAxis) {
     ASSERT_NEAR(q.GetZComponent(), expected.GetZComponent(), 1e-6);
 }
 
-TEST(QuaternionTest, AxisAngleFromQuaternion_45Degrees_YAxis) {
+TEST(QuaternionTest, AngleAxisFromQuaternion_45Degrees_YAxis) {
     Quaternion q(0.923879, 0., 0.382683, 0.);
-    auto [angle, axis] = axis_angle_from_quaternion(q);
+    auto [angle, axis] = angle_axis_from_quaternion(q);
 
     ASSERT_NEAR(angle, kPI / 4., 1e-6);
     ASSERT_NEAR(std::get<0>(axis), 0., 1e-6);
@@ -375,10 +279,10 @@ TEST(QuaternionTest, AxisAngleFromQuaternion_45Degrees_YAxis) {
     ASSERT_NEAR(std::get<2>(axis), 0., 1e-6);
 }
 
-TEST(QuaternionTest, QuaternionFromAxisAngle_60Degrees_ZAxis) {
+TEST(QuaternionTest, QuaternionFromAngleAxis_60Degrees_ZAxis) {
     double angle = kPI / 3.;
     Vector axis{0., 0., 1.};
-    Quaternion q = quaternion_from_axis_angle(angle, axis);
+    Quaternion q = quaternion_from_angle_axis(angle, axis);
 
     Quaternion expected(0.866025, 0., 0., 0.5);
 
@@ -388,9 +292,9 @@ TEST(QuaternionTest, QuaternionFromAxisAngle_60Degrees_ZAxis) {
     ASSERT_NEAR(q.GetZComponent(), expected.GetZComponent(), 1e-6);
 }
 
-TEST(QuaternionTest, AxisAngleFromQuaternion_60Degrees_ZAxis) {
+TEST(QuaternionTest, AngleAxisFromQuaternion_60Degrees_ZAxis) {
     Quaternion q(0.866025, 0., 0., 0.5);
-    auto [angle, axis] = axis_angle_from_quaternion(q);
+    auto [angle, axis] = angle_axis_from_quaternion(q);
 
     ASSERT_NEAR(angle, kPI / 3., 1e-6);
     ASSERT_NEAR(std::get<0>(axis), 0., 1e-6);
@@ -401,7 +305,7 @@ TEST(QuaternionTest, AxisAngleFromQuaternion_60Degrees_ZAxis) {
 TEST(QuaternionTest, RotateXAXIS_90Degrees_AboutYAxis) {
     double angle = kPI / 2.;
     Vector axis{0., 1., 0.};
-    Quaternion q = quaternion_from_axis_angle(angle, axis);
+    Quaternion q = quaternion_from_angle_axis(angle, axis);
 
     Vector v{1., 0., 0.};
     Vector rotated = rotate_vector(q, v);
@@ -415,7 +319,7 @@ TEST(QuaternionTest, RotateXAXIS_90Degrees_AboutYAxis) {
 TEST(QuaternionTest, RotateYAXIS_90Degrees_AboutXAxis) {
     double angle = kPI / 2.;
     Vector axis{1., 0., 0.};
-    Quaternion q = quaternion_from_axis_angle(angle, axis);
+    Quaternion q = quaternion_from_angle_axis(angle, axis);
 
     Vector v{0., 1., 0.};
     Vector rotated = rotate_vector(q, v);
@@ -429,7 +333,7 @@ TEST(QuaternionTest, RotateYAXIS_90Degrees_AboutXAxis) {
 TEST(QuaternionTest, RotateZAXIS_90Degrees_AboutXAxis) {
     double angle = kPI / 2.;
     Vector axis{1., 0., 0.};
-    Quaternion q = quaternion_from_axis_angle(angle, axis);
+    Quaternion q = quaternion_from_angle_axis(angle, axis);
 
     Vector v{0., 0., 1.};
     Vector rotated = rotate_vector(q, v);
@@ -443,7 +347,7 @@ TEST(QuaternionTest, RotateZAXIS_90Degrees_AboutXAxis) {
 TEST(QuaternionTest, RotateXAXIS_45Degrees_AboutZAxis) {
     double angle = kPI / 4.;
     Vector axis{0., 0., 1.};
-    Quaternion q = quaternion_from_axis_angle(angle, axis);
+    Quaternion q = quaternion_from_angle_axis(angle, axis);
 
     Vector v{1., 0., 0.};
     Vector rotated = rotate_vector(q, v);
@@ -457,7 +361,7 @@ TEST(QuaternionTest, RotateXAXIS_45Degrees_AboutZAxis) {
 TEST(QuaternionTest, RotateXAXIS_Neg45Degrees_AboutZAxis) {
     double angle = -kPI / 4.;
     Vector axis{0., 0., 1.};
-    Quaternion q = quaternion_from_axis_angle(angle, axis);
+    Quaternion q = quaternion_from_angle_axis(angle, axis);
 
     Vector v{1., 0., 0.};
     Vector rotated = rotate_vector(q, v);

--- a/tests/unit_tests/rigid_pendulum_poc/test_quaternions.cpp
+++ b/tests/unit_tests/rigid_pendulum_poc/test_quaternions.cpp
@@ -398,4 +398,74 @@ TEST(QuaternionTest, AxisAngleFromQuaternion_60Degrees_ZAxis) {
     ASSERT_NEAR(std::get<2>(axis), 1., 1e-6);
 }
 
+TEST(QuaternionTest, RotateXAXIS_90Degrees_AboutYAxis) {
+    double angle = kPI / 2.;
+    Vector axis{0., 1., 0.};
+    Quaternion q = quaternion_from_axis_angle(angle, axis);
+
+    Vector v{1., 0., 0.};
+    Vector rotated = rotate_vector(q, v);
+    Vector expected{0., 0., -1.};
+
+    ASSERT_NEAR(std::get<0>(rotated), std::get<0>(expected), 1e-6);
+    ASSERT_NEAR(std::get<1>(rotated), std::get<1>(expected), 1e-6);
+    ASSERT_NEAR(std::get<2>(rotated), std::get<2>(expected), 1e-6);
+}
+
+TEST(QuaternionTest, RotateYAXIS_90Degrees_AboutXAxis) {
+    double angle = kPI / 2.;
+    Vector axis{1., 0., 0.};
+    Quaternion q = quaternion_from_axis_angle(angle, axis);
+
+    Vector v{0., 1., 0.};
+    Vector rotated = rotate_vector(q, v);
+    Vector expected{0., 0., 1.};
+
+    ASSERT_NEAR(std::get<0>(rotated), std::get<0>(expected), 1e-6);
+    ASSERT_NEAR(std::get<1>(rotated), std::get<1>(expected), 1e-6);
+    ASSERT_NEAR(std::get<2>(rotated), std::get<2>(expected), 1e-6);
+}
+
+TEST(QuaternionTest, RotateZAXIS_90Degrees_AboutXAxis) {
+    double angle = kPI / 2.;
+    Vector axis{1., 0., 0.};
+    Quaternion q = quaternion_from_axis_angle(angle, axis);
+
+    Vector v{0., 0., 1.};
+    Vector rotated = rotate_vector(q, v);
+    Vector expected{0., -1., 0.};
+
+    ASSERT_NEAR(std::get<0>(rotated), std::get<0>(expected), 1e-6);
+    ASSERT_NEAR(std::get<1>(rotated), std::get<1>(expected), 1e-6);
+    ASSERT_NEAR(std::get<2>(rotated), std::get<2>(expected), 1e-6);
+}
+
+TEST(QuaternionTest, RotateXAXIS_45Degrees_AboutZAxis) {
+    double angle = kPI / 4.;
+    Vector axis{0., 0., 1.};
+    Quaternion q = quaternion_from_axis_angle(angle, axis);
+
+    Vector v{1., 0., 0.};
+    Vector rotated = rotate_vector(q, v);
+    Vector expected{0.707107, 0.707107, 0.};
+
+    ASSERT_NEAR(std::get<0>(rotated), std::get<0>(expected), 1e-6);
+    ASSERT_NEAR(std::get<1>(rotated), std::get<1>(expected), 1e-6);
+    ASSERT_NEAR(std::get<2>(rotated), std::get<2>(expected), 1e-6);
+}
+
+TEST(QuaternionTest, RotateXAXIS_Neg45Degrees_AboutZAxis) {
+    double angle = -kPI / 4.;
+    Vector axis{0., 0., 1.};
+    Quaternion q = quaternion_from_axis_angle(angle, axis);
+
+    Vector v{1., 0., 0.};
+    Vector rotated = rotate_vector(q, v);
+    Vector expected{0.707107, -0.707107, 0.};
+
+    ASSERT_NEAR(std::get<0>(rotated), std::get<0>(expected), 1e-6);
+    ASSERT_NEAR(std::get<1>(rotated), std::get<1>(expected), 1e-6);
+    ASSERT_NEAR(std::get<2>(rotated), std::get<2>(expected), 1e-6);
+}
+
 }  // namespace openturbine::rigid_pendulum::tests

--- a/tests/unit_tests/rigid_pendulum_poc/test_quaternions.cpp
+++ b/tests/unit_tests/rigid_pendulum_poc/test_quaternions.cpp
@@ -236,4 +236,74 @@ TEST(QuaternionTest, GetRotationVectorFromNullQuaternion) {
     ASSERT_NEAR(std::get<2>(v), std::get<2>(expected), 1e-6);
 }
 
+TEST(QuaternionTest, WrapAngleToPi) {
+    auto angle = 0.;  // 0 degrees
+    auto wrapped_angle = wrap_angle_to_pi(angle);
+    ASSERT_NEAR(wrapped_angle, 0., 1e-6);
+
+    angle = kPI / 2.;  // 90 degrees
+    wrapped_angle = wrap_angle_to_pi(angle);
+    ASSERT_NEAR(wrapped_angle, 0.5 * kPI, 1e-6);
+
+    angle = -kPI / 2.;  // -90 degrees
+    wrapped_angle = wrap_angle_to_pi(angle);
+    ASSERT_NEAR(wrapped_angle, -0.5 * kPI, 1e-6);
+
+    angle = kPI / 2. + kPI / 4.;  // 135 degrees
+    wrapped_angle = wrap_angle_to_pi(angle);
+    ASSERT_NEAR(wrapped_angle, 0.75 * kPI, 1e-6);
+
+    angle = -kPI / 2. - kPI / 4.;  // -135 degrees
+    wrapped_angle = wrap_angle_to_pi(angle);
+    ASSERT_NEAR(wrapped_angle, -0.75 * kPI, 1e-6);
+
+    angle = kPI;  // 180 degrees
+    wrapped_angle = wrap_angle_to_pi(angle);
+    ASSERT_NEAR(wrapped_angle, kPI, 1e-6);
+
+    angle = -kPI;
+    wrapped_angle = wrap_angle_to_pi(angle);  // -180 degrees
+    ASSERT_NEAR(wrapped_angle, -kPI, 1e-6);
+
+    angle = 3. * kPI / 2.;  // 270 degrees
+    wrapped_angle = wrap_angle_to_pi(angle);
+    ASSERT_NEAR(wrapped_angle, -0.5 * kPI, 1e-6);
+
+    angle = -3. * kPI / 2.;  // -270 degrees
+    wrapped_angle = wrap_angle_to_pi(angle);
+    ASSERT_NEAR(wrapped_angle, 0.5 * kPI, 1e-6);
+
+    angle = 2. * kPI;  // 360 degrees
+    wrapped_angle = wrap_angle_to_pi(angle);
+    ASSERT_NEAR(wrapped_angle, 0., 1e-6);
+
+    angle = -2. * kPI;  // -360 degrees
+    wrapped_angle = wrap_angle_to_pi(angle);
+    ASSERT_NEAR(wrapped_angle, 0., 1e-6);
+
+    angle = 2. * kPI + kPI / 4.;  // 405 degrees = 360 + 45
+    wrapped_angle = wrap_angle_to_pi(angle);
+    ASSERT_NEAR(wrapped_angle, kPI / 4., 1e-6);
+
+    angle = -2. * kPI - kPI / 4.;  // -405 degrees = -360 - 45
+    wrapped_angle = wrap_angle_to_pi(angle);
+    ASSERT_NEAR(wrapped_angle, -kPI / 4., 1e-6);
+
+    angle = 29. * kPI;  // 14 * 2 * kPI + kPI
+    wrapped_angle = wrap_angle_to_pi(angle);
+    ASSERT_NEAR(wrapped_angle, kPI, 1e-6);
+
+    angle = -29. * kPI;  // -14 * 2 * kPI - kPI
+    wrapped_angle = wrap_angle_to_pi(angle);
+    ASSERT_NEAR(wrapped_angle, -kPI, 1e-6);
+
+    angle = 200. * kPI + kPI / 6.;
+    wrapped_angle = wrap_angle_to_pi(angle);
+    ASSERT_NEAR(wrapped_angle, kPI / 6., 1e-6);
+
+    angle = -200. * kPI - kPI / 6.;
+    wrapped_angle = wrap_angle_to_pi(angle);
+    ASSERT_NEAR(wrapped_angle, -kPI / 6., 1e-6);
+}
+
 }  // namespace openturbine::rigid_pendulum::tests

--- a/tests/unit_tests/rigid_pendulum_poc/test_quaternions.cpp
+++ b/tests/unit_tests/rigid_pendulum_poc/test_quaternions.cpp
@@ -372,4 +372,11 @@ TEST(QuaternionTest, RotateXAXIS_Neg45Degrees_AboutZAxis) {
     ASSERT_NEAR(std::get<2>(rotated), std::get<2>(expected), 1e-6);
 }
 
+TEST(QuaternionTest, ExpectErrorWhenRotatingVectorWithNonUnitQuaternion) {
+    Quaternion q(1., 1., 0., 0.);
+    Vector v{1., 0., 0.};
+
+    ASSERT_THROW(rotate_vector(q, v), std::invalid_argument);
+}
+
 }  // namespace openturbine::rigid_pendulum::tests

--- a/tests/unit_tests/rigid_pendulum_poc/test_quaternions.cpp
+++ b/tests/unit_tests/rigid_pendulum_poc/test_quaternions.cpp
@@ -306,4 +306,96 @@ TEST(QuaternionTest, WrapAngleToPi) {
     ASSERT_NEAR(wrapped_angle, -kPI / 6., 1e-6);
 }
 
+TEST(QuaternionTest, QuaternionFromAxisAngle_ZeroAngle) {
+    double angle = 0.;
+    Vector axis{1., 0., 0.};
+    Quaternion q = quaternion_from_axis_angle(angle, axis);
+
+    Quaternion expected(1., 0., 0., 0.);
+
+    ASSERT_NEAR(q.GetScalarComponent(), expected.GetScalarComponent(), 1e-6);
+    ASSERT_NEAR(q.GetXComponent(), expected.GetXComponent(), 1e-6);
+    ASSERT_NEAR(q.GetYComponent(), expected.GetYComponent(), 1e-6);
+    ASSERT_NEAR(q.GetZComponent(), expected.GetZComponent(), 1e-6);
+}
+
+TEST(QuaternionTest, AxisAngleFromQuaternion_ZeroAngle) {
+    Quaternion q(1., 0., 0., 0.);
+    auto [angle, axis] = axis_angle_from_quaternion(q);
+
+    ASSERT_NEAR(angle, 0., 1e-6);
+    ASSERT_NEAR(std::get<0>(axis), 1., 1e-6);
+    ASSERT_NEAR(std::get<1>(axis), 0., 1e-6);
+    ASSERT_NEAR(std::get<2>(axis), 0., 1e-6);
+}
+
+TEST(QuaternionTest, QuaternionFromAxisAngle_90Degrees_XAxis) {
+    double angle = kPI / 2.;
+    Vector axis{1., 0., 0.};
+    Quaternion q = quaternion_from_axis_angle(angle, axis);
+
+    Quaternion expected(0.707107, 0.707107, 0., 0.);
+
+    ASSERT_NEAR(q.GetScalarComponent(), expected.GetScalarComponent(), 1e-6);
+    ASSERT_NEAR(q.GetXComponent(), expected.GetXComponent(), 1e-6);
+    ASSERT_NEAR(q.GetYComponent(), expected.GetYComponent(), 1e-6);
+    ASSERT_NEAR(q.GetZComponent(), expected.GetZComponent(), 1e-6);
+}
+
+TEST(QuaternionTest, AxisAngleFromQuaternion_90Degrees_XAxis) {
+    Quaternion q(0.707107, 0.707107, 0., 0.);
+    auto [angle, axis] = axis_angle_from_quaternion(q);
+
+    ASSERT_NEAR(angle, kPI / 2., 1e-6);
+    ASSERT_NEAR(std::get<0>(axis), 1., 1e-6);
+    ASSERT_NEAR(std::get<1>(axis), 0., 1e-6);
+    ASSERT_NEAR(std::get<2>(axis), 0., 1e-6);
+}
+
+TEST(QuaternionTest, QuaternionFromAxisAngle_45Degrees_YAxis) {
+    double angle = kPI / 4.;
+    Vector axis{0., 1., 0.};
+    Quaternion q = quaternion_from_axis_angle(angle, axis);
+
+    Quaternion expected(0.923879, 0., 0.382683, 0.);
+
+    ASSERT_NEAR(q.GetScalarComponent(), expected.GetScalarComponent(), 1e-6);
+    ASSERT_NEAR(q.GetXComponent(), expected.GetXComponent(), 1e-6);
+    ASSERT_NEAR(q.GetYComponent(), expected.GetYComponent(), 1e-6);
+    ASSERT_NEAR(q.GetZComponent(), expected.GetZComponent(), 1e-6);
+}
+
+TEST(QuaternionTest, AxisAngleFromQuaternion_45Degrees_YAxis) {
+    Quaternion q(0.923879, 0., 0.382683, 0.);
+    auto [angle, axis] = axis_angle_from_quaternion(q);
+
+    ASSERT_NEAR(angle, kPI / 4., 1e-6);
+    ASSERT_NEAR(std::get<0>(axis), 0., 1e-6);
+    ASSERT_NEAR(std::get<1>(axis), 1., 1e-6);
+    ASSERT_NEAR(std::get<2>(axis), 0., 1e-6);
+}
+
+TEST(QuaternionTest, QuaternionFromAxisAngle_60Degrees_ZAxis) {
+    double angle = kPI / 3.;
+    Vector axis{0., 0., 1.};
+    Quaternion q = quaternion_from_axis_angle(angle, axis);
+
+    Quaternion expected(0.866025, 0., 0., 0.5);
+
+    ASSERT_NEAR(q.GetScalarComponent(), expected.GetScalarComponent(), 1e-6);
+    ASSERT_NEAR(q.GetXComponent(), expected.GetXComponent(), 1e-6);
+    ASSERT_NEAR(q.GetYComponent(), expected.GetYComponent(), 1e-6);
+    ASSERT_NEAR(q.GetZComponent(), expected.GetZComponent(), 1e-6);
+}
+
+TEST(QuaternionTest, AxisAngleFromQuaternion_60Degrees_ZAxis) {
+    Quaternion q(0.866025, 0., 0., 0.5);
+    auto [angle, axis] = axis_angle_from_quaternion(q);
+
+    ASSERT_NEAR(angle, kPI / 3., 1e-6);
+    ASSERT_NEAR(std::get<0>(axis), 0., 1e-6);
+    ASSERT_NEAR(std::get<1>(axis), 0., 1e-6);
+    ASSERT_NEAR(std::get<2>(axis), 1., 1e-6);
+}
+
 }  // namespace openturbine::rigid_pendulum::tests


### PR DESCRIPTION
This PR introduces a method for rotating physical vectors using quaternions, implementing #38. The implementation includes the following key features:

- Introduces a new method for rotating vectors using quaternions.
- Adds helper methods for converting between axis-angle representation and quaternions.
- Utilizes test-driven development to ensure comprehensive testing of the implemented features.