### PR TITLE
Expand CI pipeline to check build on macOS

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,56 +9,80 @@ jobs:
     - name: Clone
       uses: actions/checkout@v3
     - name: Check formatting
-      uses: DoozyX/clang-format-lint-action@v0.15
+      uses: DoozyX/clang-format-lint-action@v0.16.2
       with:
         source: './src ./tests/unit_tests'
         exclude: '.'
         extensions: 'H,h,cpp'
-        clangFormatVersion: 14
+        clangFormatVersion: 16
   CPU:
     needs: Formatting
-    runs-on: ubuntu-latest
+    runs-on: ${{matrix.os}}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+        include:
+          - os: ubuntu-latest
+            install_deps: sudo apt-get install liblapack-dev liblapacke-dev libgtest-dev
+          - os: macos-latest
+            install_deps: brew install gfortran lapack googletest
     steps:
-    - name: Install LAPACK
+    - name: Install dependencies
       run: |
-        sudo apt-get install liblapack-dev
-        sudo apt-get install liblapacke-dev
+        ${{matrix.install_deps}}
+    - name: Cache install Kokkos
+      id: cache-kokkos
+      uses: actions/cache@v3
+      with:
+        path: ~/dependencies/kokkos
+        key: ${{runner.os}}-kokkos
     - name: Install Kokkos
+      if: steps.cache-kokkos.outputs.cache-hit != 'true'
       run: |
+        sudo mkdir -p ~/dependencies/kokkos
         git clone https://github.com/kokkos/kokkos
         cd kokkos
         mkdir build
         cd build
-        cmake ../
+        cmake .. -D CMAKE_INSTALL_PREFIX:PATH=~/dependencies/kokkos
         make
         sudo make install
+    - name: Cache install Kokkos-Kernels
+      id: cache-kokkos-kernels
+      uses: actions/cache@v3
+      with:
+        path: ~/dependencies/kokkos_kernels
+        key: ${{runner.os}}-kokkos-kernels
     - name: Install Kokkos-Kernels
+      if: steps.cache-kokkos-kernels.outputs.cache-hit != 'true'
       run: |
-        git clone https://github.com/kokkos/kokkos-kernels
+        sudo mkdir -p ~/dependencies/kokkos_kernels
+        export Kokkos_DIR=~/dependencies/kokkos
+        if [ ${{matrix.os}} = 'ubuntu-latest' ]; then
+          git clone https://github.com/kokkos/kokkos-kernels
+        fi
+        if [ ${{matrix.os}} = 'macos-latest' ]; then
+          export FC=$(brew --prefix gcc)/bin/gfortran
+          git clone -b 3.7.00 https://github.com/kokkos/kokkos-kernels
+        fi
         cd kokkos-kernels
         mkdir build
         cd build
-        cmake ../ -D KokkosKernels_ENABLE_TPL_BLAS="ON"
+        cmake .. \
+          -D CMAKE_INSTALL_PREFIX:PATH=~/dependencies/kokkos_kernels \
+          -D KokkosKernels_ENABLE_TPL_BLAS=ON
         make
         sudo make install
-    - name: Install GoogleTest
-      run: |
-        sudo apt-get install libgtest-dev
-        cd /usr/src/gtest
-        sudo cmake CMakeLists.txt
-        sudo make
-        sudo cp lib/*.a /usr/lib
-        sudo ln -s /usr/lib/libgtest.a /usr/local/lib/libgtest.a
-        sudo ln -s /usr/lib/libgtest_main.a /usr/local/lib/libgtest_main.a
     - name: Clone
       uses: actions/checkout@v3
       with:
         submodules: true
     - name: Test
       run: |
+        export KokkosKernels_DIR=~/dependencies/kokkos_kernels
         mkdir build
         cd build
-        cmake .. -DOTURB_ENABLE_TESTS:BOOL=ON -DKokkosKernels_DIR=$kokkos_kernels_dir
+        cmake .. -DOTURB_ENABLE_TESTS:BOOL=ON
         make
         ./openturbine -h
         ./openturbine_unit_tests


### PR DESCRIPTION
Fixes the issue described in #28.

This work was critical to make sure we are able to get a successful build on macOS. With the CI system building only on linux, we were slipping on the ability to build OpenTurbine on macOS - e.g., currently the `main` branch would not compile on macOS.

In short, the following features were added to the CI pipeline:

- [`matrix.os` strategy](https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs) was implemented to define CPU jobs for `ubuntu-latest` and `macos-latest` operating systems
- Caching of kokkos and kokkos-kernels packages were reinstated, saving a significant amount of time in workflow run