### PR TITLE
Introduce a data structure to handle beam sections

### DIFF
--- a/src/gebt_poc/section.cpp
+++ b/src/gebt_poc/section.cpp
@@ -11,4 +11,13 @@ StiffnessMatrix::StiffnessMatrix(const Kokkos::View<double**> stiffness)
     Kokkos::deep_copy(stiffness_matrix_, stiffness);
 }
 
+Section::Section(
+    double location, gen_alpha_solver::MassMatrix mass_matrix, StiffnessMatrix stiffness_matrix
+)
+    : location_(location), mass_matrix_(mass_matrix), stiffness_matrix_(stiffness_matrix) {
+    if (location_ < 0. || location_ > 1.) {
+        throw std::invalid_argument("Section location must be between 0 and 1");
+    }
+}
+
 }  // namespace openturbine::gebt_poc

--- a/src/gebt_poc/section.h
+++ b/src/gebt_poc/section.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "src/gen_alpha_poc/vector.h"
+#include "src/gen_alpha_poc/state.h"
 
 namespace openturbine::gebt_poc {
 
@@ -14,7 +14,28 @@ public:
     inline Kokkos::View<const double**> GetStiffnessMatrix() const { return stiffness_matrix_; }
 
 private:
-    Kokkos::View<double**> stiffness_matrix_;  //< Stiffness matrix
+    Kokkos::View<double**> stiffness_matrix_;  //< Stiffness matrix (6 x 6)
+};
+
+/// Class to manage normalized location, mass matrix, and stiffness matrix of a beam section
+class Section {
+public:
+    /// Constructor that initializes section with given location, mass, and stiffness
+    Section(double location, gen_alpha_solver::MassMatrix, StiffnessMatrix);
+
+    /// Returns the normalized location of the section
+    inline double GetNormalizedLocation() const { return location_; }
+
+    /// Returns the mass matrix of the section
+    inline const gen_alpha_solver::MassMatrix& GetMass() const { return mass_matrix_; }
+
+    /// Returns the stiffness matrix of the section
+    inline const StiffnessMatrix& GetStiffnessMatrix() const { return stiffness_matrix_; }
+
+private:
+    double location_;                           //< Normalized location of the section (0 <= l <= 1)
+    gen_alpha_solver::MassMatrix mass_matrix_;  //< Mass matrix of the section
+    StiffnessMatrix stiffness_matrix_;          //< Stiffness matrix of the section
 };
 
 }  // namespace openturbine::gebt_poc

--- a/tests/unit_tests/gebt_poc/test_section.cpp
+++ b/tests/unit_tests/gebt_poc/test_section.cpp
@@ -55,4 +55,64 @@ TEST(StiffnessMatrixTest, ConstructorWithProvidedRandomMatrix) {
     );
 }
 
+TEST(SectionTest, ConstructUnitSection) {
+    auto mass_matrix = gen_alpha_solver::MassMatrix(1., 1.);
+    auto stiffness_matrix = StiffnessMatrix(gen_alpha_solver::create_matrix({
+        {1., 0., 0., 0., 0., 0.},  // row 1
+        {0., 1., 0., 0., 0., 0.},  // row 2
+        {0., 0., 1., 0., 0., 0.},  // row 3
+        {0., 0., 0., 1., 0., 0.},  // row 4
+        {0., 0., 0., 0., 1., 0.},  // row 5
+        {0., 0., 0., 0., 0., 1.}   // row 6
+    }));
+    auto location = 0.;
+
+    auto section = Section(location, mass_matrix, stiffness_matrix);
+
+    EXPECT_EQ(section.GetNormalizedLocation(), location);
+    openturbine::gen_alpha_solver::tests::expect_kokkos_view_2D_equal(
+        section.GetMass().GetMassMatrix(),
+        {
+            {1., 0., 0., 0., 0., 0.},  // row 1
+            {0., 1., 0., 0., 0., 0.},  // row 2
+            {0., 0., 1., 0., 0., 0.},  // row 3
+            {0., 0., 0., 1., 0., 0.},  // row 4
+            {0., 0., 0., 0., 1., 0.},  // row 5
+            {0., 0., 0., 0., 0., 1.}   // row 6
+        }
+    );
+    openturbine::gen_alpha_solver::tests::expect_kokkos_view_2D_equal(
+        section.GetStiffnessMatrix().GetStiffnessMatrix(),
+        {
+            {1., 0., 0., 0., 0., 0.},  // row 1
+            {0., 1., 0., 0., 0., 0.},  // row 2
+            {0., 0., 1., 0., 0., 0.},  // row 3
+            {0., 0., 0., 1., 0., 0.},  // row 4
+            {0., 0., 0., 0., 1., 0.},  // row 5
+            {0., 0., 0., 0., 0., 1.}   // row 6
+        }
+    );
+}
+
+TEST(SectionTest, ExpectThrowIfLocationIsOutOfBounds) {
+    auto mass_matrix = gen_alpha_solver::MassMatrix(1., 1.);
+    auto stiffness_matrix = StiffnessMatrix(gen_alpha_solver::create_matrix({
+        {1., 0., 0., 0., 0., 0.},  // row 1
+        {0., 1., 0., 0., 0., 0.},  // row 2
+        {0., 0., 1., 0., 0., 0.},  // row 3
+        {0., 0., 0., 1., 0., 0.},  // row 4
+        {0., 0., 0., 0., 1., 0.},  // row 5
+        {0., 0., 0., 0., 0., 1.}   // row 6
+    }));
+    auto location_less_than_zero = -0.1;
+    auto location_greater_than_one = 1.1;
+
+    EXPECT_THROW(
+        Section(location_less_than_zero, mass_matrix, stiffness_matrix), std::invalid_argument
+    );
+    EXPECT_THROW(
+        Section(location_greater_than_one, mass_matrix, stiffness_matrix), std::invalid_argument
+    );
+}
+
 }  // namespace openturbine::gebt_poc::tests


### PR DESCRIPTION
Takes care of the second item outlined in the tasks listed in #57.

> Create a Section class that consists of the mass matrix, stiffness matrix, and a normalized location along the length of the beam