### PR TITLE
Create a Model class to perform the beam FE model creation

### DIFF
--- a/src/gebt_poc/CMakeLists.txt
+++ b/src/gebt_poc/CMakeLists.txt
@@ -1,4 +1,5 @@
 target_sources(${oturb_lib_name}
     PRIVATE
+    model.cpp
     section.cpp
 )

--- a/src/gebt_poc/model.cpp
+++ b/src/gebt_poc/model.cpp
@@ -2,24 +2,11 @@
 
 namespace openturbine::gebt_poc {
 
-Kokkos::View<Section*> CreateSections(std::vector<Section> sections) {
-    auto sections_view = Kokkos::View<Section*>("sections", sections.size());
-    auto sections_host = Kokkos::create_mirror(sections_view);
-
-    for (std::size_t index = 0; index < sections.size(); ++index) {
-        sections_host(index) = sections[index];
-    }
-
-    // *** Question for David: How to implement a deep_copy() for a Kokkos::View<Section*>?
-    Kokkos::parallel_for(
-        sections.size(),
-        KOKKOS_LAMBDA(std::size_t index) { sections_view(index) = sections_host(index); }
-    );
-
-    return sections_view;
+Model::Model(std::string name) : name_(name) {
 }
 
-Model::Model(std::string name, Kokkos::View<Section*> sections) : name_(name), sections_(sections) {
+Model::Model(std::string name, std::vector<Section> sections)
+    : name_(name), sections_(std::move(sections)) {
 }
 
 }  // namespace openturbine::gebt_poc

--- a/src/gebt_poc/model.cpp
+++ b/src/gebt_poc/model.cpp
@@ -2,9 +2,24 @@
 
 namespace openturbine::gebt_poc {
 
-Model::Model(std::string name, Kokkos::View<Section*> sections)
-    : name_(name), sections_("sections", sections.extent(0)) {
-    Kokkos::deep_copy(sections_, sections);
+Kokkos::View<Section*> CreateSections(std::vector<Section> sections) {
+    auto sections_view = Kokkos::View<Section*>("sections", sections.size());
+    auto sections_host = Kokkos::create_mirror(sections_view);
+
+    for (std::size_t index = 0; index < sections.size(); ++index) {
+        sections_host(index) = sections[index];
+    }
+
+    // *** Question for David: How to implement a deep_copy() for a Kokkos::View<Section*>?
+    Kokkos::parallel_for(
+        sections.size(),
+        KOKKOS_LAMBDA(std::size_t index) { sections_view(index) = sections_host(index); }
+    );
+
+    return sections_view;
+}
+
+Model::Model(std::string name, Kokkos::View<Section*> sections) : name_(name), sections_(sections) {
 }
 
 }  // namespace openturbine::gebt_poc

--- a/src/gebt_poc/model.cpp
+++ b/src/gebt_poc/model.cpp
@@ -1,0 +1,10 @@
+#include "src/gebt_poc/model.h"
+
+namespace openturbine::gebt_poc {
+
+Model::Model(std::string name, Kokkos::View<Section*> sections)
+    : name_(name), sections_("sections", sections.extent(0)) {
+    Kokkos::deep_copy(sections_, sections);
+}
+
+}  // namespace openturbine::gebt_poc

--- a/src/gebt_poc/model.h
+++ b/src/gebt_poc/model.h
@@ -4,23 +4,24 @@
 
 namespace openturbine::gebt_poc {
 
-/// Creates a Kokkos view of sections from a provided std::vector of sections
-Kokkos::View<Section*> CreateSections(std::vector<Section>);
-
 /// Class to manage different aspects of the beam finite element model creation
 class Model {
 public:
-    Model(std::string name, Kokkos::View<Section*>);
+    Model(std::string name);
+    Model(std::string name, std::vector<Section>);
 
     /// Returns the name of the model
     inline std::string GetName() const { return name_; }
 
-    /// Returns the sections of the model
-    inline Kokkos::View<Section*> GetSections() const { return sections_; }
+    /// Adds a section to the model
+    void AddSection(Section section) { sections_.emplace_back(section); }
+
+    /// Returns the sections of the model as a read-only vector
+    inline const std::vector<Section>& GetSections() const { return sections_; }
 
 private:
-    std::string name_;                 //< Name of the model
-    Kokkos::View<Section*> sections_;  //< Sections of the beam
+    std::string name_;               //< Name of the model
+    std::vector<Section> sections_;  //< Sections of the beam
 };
 
 }  // namespace openturbine::gebt_poc

--- a/src/gebt_poc/model.h
+++ b/src/gebt_poc/model.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include "src/gebt_poc/section.h"
+
+namespace openturbine::gebt_poc {
+
+/// Class to manages different aspects of the beam finite element model
+class Model {
+public:
+    Model(std::string name) : name_(name) {}
+
+    /// Returns the name of the model
+    inline std::string GetName() const { return name_; }
+
+    /// Adds a section to the model
+    void AddSection(Section section) { sections_.emplace_back(section); }
+
+    /// Returns the sections of the model
+    inline const std::vector<Section>& GetSections() const { return sections_; }
+
+private:
+    std::string name_;               //< Name of the model
+    std::vector<Section> sections_;  //< Sections of the beam
+};
+
+}  // namespace openturbine::gebt_poc

--- a/src/gebt_poc/model.h
+++ b/src/gebt_poc/model.h
@@ -7,20 +7,17 @@ namespace openturbine::gebt_poc {
 /// Class to manages different aspects of the beam finite element model
 class Model {
 public:
-    Model(std::string name) : name_(name) {}
+    Model(std::string name, Kokkos::View<Section*> sections);
 
     /// Returns the name of the model
     inline std::string GetName() const { return name_; }
 
-    /// Adds a section to the model
-    void AddSection(Section section) { sections_.emplace_back(section); }
-
     /// Returns the sections of the model
-    inline const std::vector<Section>& GetSections() const { return sections_; }
+    inline Kokkos::View<Section*> GetSections() const { return sections_; }
 
 private:
-    std::string name_;               //< Name of the model
-    std::vector<Section> sections_;  //< Sections of the beam
+    std::string name_;                 //< Name of the model
+    Kokkos::View<Section*> sections_;  //< Sections of the beam
 };
 
 }  // namespace openturbine::gebt_poc

--- a/src/gebt_poc/model.h
+++ b/src/gebt_poc/model.h
@@ -4,10 +4,13 @@
 
 namespace openturbine::gebt_poc {
 
-/// Class to manages different aspects of the beam finite element model
+/// Creates a Kokkos view of sections from a provided std::vector of sections
+Kokkos::View<Section*> CreateSections(std::vector<Section>);
+
+/// Class to manage different aspects of the beam finite element model creation
 class Model {
 public:
-    Model(std::string name, Kokkos::View<Section*> sections);
+    Model(std::string name, Kokkos::View<Section*>);
 
     /// Returns the name of the model
     inline std::string GetName() const { return name_; }

--- a/src/gebt_poc/section.cpp
+++ b/src/gebt_poc/section.cpp
@@ -2,8 +2,7 @@
 
 namespace openturbine::gebt_poc {
 
-StiffnessMatrix::StiffnessMatrix()
-    : stiffness_matrix_("stiffness_matrix", 6, 6) {
+StiffnessMatrix::StiffnessMatrix() : stiffness_matrix_("stiffness_matrix", 6, 6) {
     stiffness_matrix_ = gen_alpha_solver::create_identity_matrix(6);
 }
 

--- a/src/gebt_poc/section.cpp
+++ b/src/gebt_poc/section.cpp
@@ -2,6 +2,11 @@
 
 namespace openturbine::gebt_poc {
 
+StiffnessMatrix::StiffnessMatrix()
+    : stiffness_matrix_("stiffness_matrix", 6, 6) {
+    stiffness_matrix_ = gen_alpha_solver::create_identity_matrix(6);
+}
+
 StiffnessMatrix::StiffnessMatrix(const Kokkos::View<double**> stiffness)
     : stiffness_matrix_("stiffness_matrix", stiffness.extent(0), stiffness.extent(1)) {
     if (stiffness_matrix_.extent(0) != 6 || stiffness_matrix_.extent(1) != 6) {

--- a/src/gebt_poc/section.cpp
+++ b/src/gebt_poc/section.cpp
@@ -12,9 +12,13 @@ StiffnessMatrix::StiffnessMatrix(const Kokkos::View<double**> stiffness)
 }
 
 Section::Section(
-    double location, gen_alpha_solver::MassMatrix mass_matrix, StiffnessMatrix stiffness_matrix
+    double location, gen_alpha_solver::MassMatrix mass_matrix, StiffnessMatrix stiffness_matrix,
+    std::string name
 )
-    : location_(location), mass_matrix_(mass_matrix), stiffness_matrix_(stiffness_matrix) {
+    : location_(location),
+      mass_matrix_(mass_matrix),
+      stiffness_matrix_(stiffness_matrix),
+      name_(name) {
     if (location_ < 0. || location_ > 1.) {
         throw std::invalid_argument("Section location must be between 0 and 1");
     }

--- a/src/gebt_poc/section.cpp
+++ b/src/gebt_poc/section.cpp
@@ -16,13 +16,13 @@ StiffnessMatrix::StiffnessMatrix(const Kokkos::View<double**> stiffness)
 }
 
 Section::Section(
-    double location, gen_alpha_solver::MassMatrix mass_matrix, StiffnessMatrix stiffness_matrix,
-    std::string name
+    std::string name, double location, gen_alpha_solver::MassMatrix mass_matrix,
+    StiffnessMatrix stiffness_matrix
 )
-    : location_(location),
+    : name_(name),
+      location_(location),
       mass_matrix_(mass_matrix),
-      stiffness_matrix_(stiffness_matrix),
-      name_(name) {
+      stiffness_matrix_(stiffness_matrix) {
     if (location_ < 0. || location_ > 1.) {
         throw std::invalid_argument("Section location must be between 0 and 1");
     }

--- a/src/gebt_poc/section.h
+++ b/src/gebt_poc/section.h
@@ -21,7 +21,7 @@ private:
 class Section {
 public:
     /// Constructor that initializes section with given location, mass, and stiffness
-    Section(double location, gen_alpha_solver::MassMatrix, StiffnessMatrix);
+    Section(double location, gen_alpha_solver::MassMatrix, StiffnessMatrix, std::string name = "");
 
     /// Returns the normalized location of the section
     inline double GetNormalizedLocation() const { return location_; }
@@ -36,6 +36,7 @@ private:
     double location_;                           //< Normalized location of the section (0 <= l <= 1)
     gen_alpha_solver::MassMatrix mass_matrix_;  //< Mass matrix of the section
     StiffnessMatrix stiffness_matrix_;          //< Stiffness matrix of the section
+    std::string name_;                          //< Name of the section
 };
 
 }  // namespace openturbine::gebt_poc

--- a/src/gebt_poc/section.h
+++ b/src/gebt_poc/section.h
@@ -7,6 +7,8 @@ namespace openturbine::gebt_poc {
 /// Class to create and store a 6 x 6 stiffness matrix for a section
 class StiffnessMatrix {
 public:
+    StiffnessMatrix();
+
     /// Constructor that initializes the stiffness matrix to the given matrix
     StiffnessMatrix(const Kokkos::View<double**>);
 
@@ -20,6 +22,8 @@ private:
 /// Class to manage normalized location, mass matrix, and stiffness matrix of a beam section
 class Section {
 public:
+    Section() : location_(0.), mass_matrix_(), stiffness_matrix_(), name_("") {}
+
     /// Constructor that initializes section with given location, mass, and stiffness
     Section(double location, gen_alpha_solver::MassMatrix, StiffnessMatrix, std::string name = "");
 
@@ -31,6 +35,9 @@ public:
 
     /// Returns the stiffness matrix of the section
     inline const StiffnessMatrix& GetStiffnessMatrix() const { return stiffness_matrix_; }
+
+    /// Returns the name of the section
+    inline std::string GetName() const { return name_; }
 
 private:
     double location_;                           //< Normalized location of the section (0 <= l <= 1)

--- a/src/gebt_poc/section.h
+++ b/src/gebt_poc/section.h
@@ -7,6 +7,7 @@ namespace openturbine::gebt_poc {
 /// Class to create and store a 6 x 6 stiffness matrix for a section
 class StiffnessMatrix {
 public:
+    /// Default constructor that initializes the stiffness matrix to the identity matrix
     StiffnessMatrix();
 
     /// Constructor that initializes the stiffness matrix to the given matrix
@@ -22,28 +23,27 @@ private:
 /// Class to manage normalized location, mass matrix, and stiffness matrix of a beam section
 class Section {
 public:
-    Section() : location_(0.), mass_matrix_(), stiffness_matrix_(), name_("") {}
+    Section() : name_(""), location_(0.), mass_matrix_(), stiffness_matrix_() {}
 
-    /// Constructor that initializes section with given location, mass, and stiffness
-    Section(double location, gen_alpha_solver::MassMatrix, StiffnessMatrix, std::string name = "");
+    Section(std::string name, double location, gen_alpha_solver::MassMatrix, StiffnessMatrix);
+
+    /// Returns the name of the section
+    inline std::string GetName() const { return name_; }
 
     /// Returns the normalized location of the section
     inline double GetNormalizedLocation() const { return location_; }
 
     /// Returns the mass matrix of the section
-    inline const gen_alpha_solver::MassMatrix& GetMass() const { return mass_matrix_; }
+    inline const gen_alpha_solver::MassMatrix& GetMassMatrix() const { return mass_matrix_; }
 
     /// Returns the stiffness matrix of the section
     inline const StiffnessMatrix& GetStiffnessMatrix() const { return stiffness_matrix_; }
 
-    /// Returns the name of the section
-    inline std::string GetName() const { return name_; }
-
 private:
+    std::string name_;                          //< Name of the section
     double location_;                           //< Normalized location of the section (0 <= l <= 1)
     gen_alpha_solver::MassMatrix mass_matrix_;  //< Mass matrix of the section
     StiffnessMatrix stiffness_matrix_;          //< Stiffness matrix of the section
-    std::string name_;                          //< Name of the section
 };
 
 }  // namespace openturbine::gebt_poc

--- a/tests/unit_tests/gebt_poc/CMakeLists.txt
+++ b/tests/unit_tests/gebt_poc/CMakeLists.txt
@@ -2,6 +2,7 @@
 target_sources(
     ${oturb_unit_test_exe_name}
     PRIVATE
+    test_model.cpp
     test_point.cpp
     test_section.cpp
 )

--- a/tests/unit_tests/gebt_poc/test_model.cpp
+++ b/tests/unit_tests/gebt_poc/test_model.cpp
@@ -5,23 +5,18 @@
 
 namespace openturbine::gebt_poc::tests {
 
-TEST(ModelTest, ConstructModelWithNoSections) {
-    Model model("model", Kokkos::View<Section*>("sections", 0));
+TEST(ModelTest, ConstructModelWithZeroSections) {
+    Model model("model", CreateSections({}));
 
     EXPECT_EQ(model.GetName(), "model");
     EXPECT_EQ(model.GetSections().extent(0), 0);
 }
 
 TEST(ModelTest, ConstructModelWithOneSection) {
-    auto section = Section(0.5, gen_alpha_solver::MassMatrix(), StiffnessMatrix(), "section_1");
-    Kokkos::View<Section*> sections("sections", 1);
-    Kokkos::deep_copy(sections, section);
-
-    Model model("model", sections);
+    Model model("model", CreateSections({Section()}));
 
     EXPECT_EQ(model.GetName(), "model");
     EXPECT_EQ(model.GetSections().extent(0), 1);
-    EXPECT_EQ(model.GetSections()(0).GetName(), "section_1");
 }
 
 }  // namespace openturbine::gebt_poc::tests

--- a/tests/unit_tests/gebt_poc/test_model.cpp
+++ b/tests/unit_tests/gebt_poc/test_model.cpp
@@ -5,22 +5,23 @@
 
 namespace openturbine::gebt_poc::tests {
 
-TEST(ModelTest, ConstructDefaultModel) {
-    Model model("model");
+TEST(ModelTest, ConstructModelWithNoSections) {
+    Model model("model", Kokkos::View<Section*>("sections", 0));
 
     EXPECT_EQ(model.GetName(), "model");
-    EXPECT_EQ(model.GetSections().size(), 0);
+    EXPECT_EQ(model.GetSections().extent(0), 0);
 }
 
-TEST(ModelTest, AddASectionToModel) {
-    Model model("model");
-    auto section = Section(
-        0., gen_alpha_solver::MassMatrix(1., 1.), gen_alpha_solver::create_identity_matrix(6)
-    );
+TEST(ModelTest, ConstructModelWithOneSection) {
+    auto section = Section(0.5, gen_alpha_solver::MassMatrix(), StiffnessMatrix(), "section_1");
+    Kokkos::View<Section*> sections("sections", 1);
+    Kokkos::deep_copy(sections, section);
 
-    model.AddSection(section);
+    Model model("model", sections);
 
-    EXPECT_EQ(model.GetSections().size(), 1);
+    EXPECT_EQ(model.GetName(), "model");
+    EXPECT_EQ(model.GetSections().extent(0), 1);
+    EXPECT_EQ(model.GetSections()(0).GetName(), "section_1");
 }
 
 }  // namespace openturbine::gebt_poc::tests

--- a/tests/unit_tests/gebt_poc/test_model.cpp
+++ b/tests/unit_tests/gebt_poc/test_model.cpp
@@ -1,0 +1,26 @@
+#include <gtest/gtest.h>
+
+#include "src/gebt_poc/model.h"
+#include "tests/unit_tests/gen_alpha_poc/test_utilities.h"
+
+namespace openturbine::gebt_poc::tests {
+
+TEST(ModelTest, ConstructDefaultModel) {
+    Model model("model");
+
+    EXPECT_EQ(model.GetName(), "model");
+    EXPECT_EQ(model.GetSections().size(), 0);
+}
+
+TEST(ModelTest, AddASectionToModel) {
+    Model model("model");
+    auto section = Section(
+        0., gen_alpha_solver::MassMatrix(1., 1.), gen_alpha_solver::create_identity_matrix(6)
+    );
+
+    model.AddSection(section);
+
+    EXPECT_EQ(model.GetSections().size(), 1);
+}
+
+}  // namespace openturbine::gebt_poc::tests

--- a/tests/unit_tests/gebt_poc/test_model.cpp
+++ b/tests/unit_tests/gebt_poc/test_model.cpp
@@ -5,18 +5,32 @@
 
 namespace openturbine::gebt_poc::tests {
 
-TEST(ModelTest, ConstructModelWithZeroSections) {
-    Model model("model", CreateSections({}));
+TEST(ModelTest, ConstructDefaultModel) {
+    Model model("model");
 
     EXPECT_EQ(model.GetName(), "model");
-    EXPECT_EQ(model.GetSections().extent(0), 0);
+    EXPECT_EQ(model.GetSections().size(), 0);
 }
 
-TEST(ModelTest, ConstructModelWithOneSection) {
-    Model model("model", CreateSections({Section()}));
+TEST(ModelTest, ConstructModelWithSections) {
+    auto section_1 = Section();
+    auto section_2 = Section();
+
+    Model model("model", {section_1, section_2});
 
     EXPECT_EQ(model.GetName(), "model");
-    EXPECT_EQ(model.GetSections().extent(0), 1);
+    EXPECT_EQ(model.GetSections().size(), 2);
+}
+
+TEST(ModelTest, AddASectionToModel) {
+    Model model("model");
+    auto section = Section(
+        "s_1", 0., gen_alpha_solver::MassMatrix(1., 1.), gen_alpha_solver::create_identity_matrix(6)
+    );
+
+    model.AddSection(section);
+
+    EXPECT_EQ(model.GetSections().size(), 1);
 }
 
 }  // namespace openturbine::gebt_poc::tests

--- a/tests/unit_tests/gebt_poc/test_section.cpp
+++ b/tests/unit_tests/gebt_poc/test_section.cpp
@@ -68,9 +68,10 @@ TEST(StiffnessMatrixTest, ConstructorWithProvidedRandomMatrix) {
 TEST(SectionTest, DefaultConstructor) {
     Section section;
 
+    EXPECT_EQ(section.GetName(), "");
     EXPECT_EQ(section.GetNormalizedLocation(), 0.);
     openturbine::gen_alpha_solver::tests::expect_kokkos_view_2D_equal(
-        section.GetMass().GetMassMatrix(),
+        section.GetMassMatrix().GetMassMatrix(),
         {
             {1., 0., 0., 0., 0., 0.},  // row 1
             {0., 1., 0., 0., 0., 0.},  // row 2
@@ -91,7 +92,6 @@ TEST(SectionTest, DefaultConstructor) {
             {0., 0., 0., 0., 0., 1.}   // row 6
         }
     );
-    EXPECT_EQ(section.GetName(), "");
 }
 
 TEST(SectionTest, ConstructUnitSection) {
@@ -99,11 +99,11 @@ TEST(SectionTest, ConstructUnitSection) {
     auto stiffness_matrix = gen_alpha_solver::create_identity_matrix(6);
     auto location = 0.;
 
-    auto section = Section(location, mass_matrix, stiffness_matrix, "section_1");
+    auto section = Section("section_1", location, mass_matrix, stiffness_matrix);
 
     EXPECT_EQ(section.GetNormalizedLocation(), location);
     openturbine::gen_alpha_solver::tests::expect_kokkos_view_2D_equal(
-        section.GetMass().GetMassMatrix(),
+        section.GetMassMatrix().GetMassMatrix(),
         {
             {1., 0., 0., 0., 0., 0.},  // row 1
             {0., 1., 0., 0., 0., 0.},  // row 2
@@ -128,16 +128,18 @@ TEST(SectionTest, ConstructUnitSection) {
 }
 
 TEST(SectionTest, ExpectThrowIfLocationIsOutOfBounds) {
+    auto name = "section_1";
     auto mass_matrix = gen_alpha_solver::MassMatrix(1., 1.);
     auto stiffness_matrix = gen_alpha_solver::create_identity_matrix(6);
     auto location_less_than_zero = -0.1;
     auto location_greater_than_one = 1.1;
 
     EXPECT_THROW(
-        Section(location_less_than_zero, mass_matrix, stiffness_matrix), std::invalid_argument
+        Section(name, location_less_than_zero, mass_matrix, stiffness_matrix), std::invalid_argument
     );
     EXPECT_THROW(
-        Section(location_greater_than_one, mass_matrix, stiffness_matrix), std::invalid_argument
+        Section(name, location_greater_than_one, mass_matrix, stiffness_matrix),
+        std::invalid_argument
     );
 }
 

--- a/tests/unit_tests/gebt_poc/test_section.cpp
+++ b/tests/unit_tests/gebt_poc/test_section.cpp
@@ -57,14 +57,7 @@ TEST(StiffnessMatrixTest, ConstructorWithProvidedRandomMatrix) {
 
 TEST(SectionTest, ConstructUnitSection) {
     auto mass_matrix = gen_alpha_solver::MassMatrix(1., 1.);
-    auto stiffness_matrix = StiffnessMatrix(gen_alpha_solver::create_matrix({
-        {1., 0., 0., 0., 0., 0.},  // row 1
-        {0., 1., 0., 0., 0., 0.},  // row 2
-        {0., 0., 1., 0., 0., 0.},  // row 3
-        {0., 0., 0., 1., 0., 0.},  // row 4
-        {0., 0., 0., 0., 1., 0.},  // row 5
-        {0., 0., 0., 0., 0., 1.}   // row 6
-    }));
+    auto stiffness_matrix = gen_alpha_solver::create_identity_matrix(6);
     auto location = 0.;
 
     auto section = Section(location, mass_matrix, stiffness_matrix);
@@ -96,14 +89,7 @@ TEST(SectionTest, ConstructUnitSection) {
 
 TEST(SectionTest, ExpectThrowIfLocationIsOutOfBounds) {
     auto mass_matrix = gen_alpha_solver::MassMatrix(1., 1.);
-    auto stiffness_matrix = StiffnessMatrix(gen_alpha_solver::create_matrix({
-        {1., 0., 0., 0., 0., 0.},  // row 1
-        {0., 1., 0., 0., 0., 0.},  // row 2
-        {0., 0., 1., 0., 0., 0.},  // row 3
-        {0., 0., 0., 1., 0., 0.},  // row 4
-        {0., 0., 0., 0., 1., 0.},  // row 5
-        {0., 0., 0., 0., 0., 1.}   // row 6
-    }));
+    auto stiffness_matrix = gen_alpha_solver::create_identity_matrix(6);
     auto location_less_than_zero = -0.1;
     auto location_greater_than_one = 1.1;
 

--- a/tests/unit_tests/gebt_poc/test_section.cpp
+++ b/tests/unit_tests/gebt_poc/test_section.cpp
@@ -5,14 +5,27 @@
 
 namespace openturbine::gebt_poc::tests {
 
+TEST(StiffnessMatrixTest, DefaultConstructor) {
+    StiffnessMatrix stiffness;
+
+    openturbine::gen_alpha_solver::tests::expect_kokkos_view_2D_equal(
+        stiffness.GetStiffnessMatrix(),
+        {
+            {1., 0., 0., 0., 0., 0.},  // row 1
+            {0., 1., 0., 0., 0., 0.},  // row 2
+            {0., 0., 1., 0., 0., 0.},  // row 3
+            {0., 0., 0., 1., 0., 0.},  // row 4
+            {0., 0., 0., 0., 1., 0.},  // row 5
+            {0., 0., 0., 0., 0., 1.}   // row 6
+        }
+    );
+}
+
 TEST(StiffnessMatrixTest, ConstructorWithProvidedZerosMatrix) {
     Kokkos::View<double**> matrix("stiffness_matrix", 6, 6);
     Kokkos::deep_copy(matrix, 0.);
 
     StiffnessMatrix stiffness(matrix);
-
-    EXPECT_EQ(stiffness.GetStiffnessMatrix().extent(0), 6);
-    EXPECT_EQ(stiffness.GetStiffnessMatrix().extent(1), 6);
 
     openturbine::gen_alpha_solver::tests::expect_kokkos_view_2D_equal(
         stiffness.GetStiffnessMatrix(),
@@ -39,9 +52,6 @@ TEST(StiffnessMatrixTest, ConstructorWithProvidedRandomMatrix) {
 
     StiffnessMatrix stiffness(stiffness_matrix);
 
-    EXPECT_EQ(stiffness.GetStiffnessMatrix().extent(0), 6);
-    EXPECT_EQ(stiffness.GetStiffnessMatrix().extent(1), 6);
-
     openturbine::gen_alpha_solver::tests::expect_kokkos_view_2D_equal(
         stiffness.GetStiffnessMatrix(),
         {
@@ -55,12 +65,41 @@ TEST(StiffnessMatrixTest, ConstructorWithProvidedRandomMatrix) {
     );
 }
 
+TEST(SectionTest, DefaultConstructor) {
+    Section section;
+
+    EXPECT_EQ(section.GetNormalizedLocation(), 0.);
+    openturbine::gen_alpha_solver::tests::expect_kokkos_view_2D_equal(
+        section.GetMass().GetMassMatrix(),
+        {
+            {1., 0., 0., 0., 0., 0.},  // row 1
+            {0., 1., 0., 0., 0., 0.},  // row 2
+            {0., 0., 1., 0., 0., 0.},  // row 3
+            {0., 0., 0., 1., 0., 0.},  // row 4
+            {0., 0., 0., 0., 1., 0.},  // row 5
+            {0., 0., 0., 0., 0., 1.}   // row 6
+        }
+    );
+    openturbine::gen_alpha_solver::tests::expect_kokkos_view_2D_equal(
+        section.GetStiffnessMatrix().GetStiffnessMatrix(),
+        {
+            {1., 0., 0., 0., 0., 0.},  // row 1
+            {0., 1., 0., 0., 0., 0.},  // row 2
+            {0., 0., 1., 0., 0., 0.},  // row 3
+            {0., 0., 0., 1., 0., 0.},  // row 4
+            {0., 0., 0., 0., 1., 0.},  // row 5
+            {0., 0., 0., 0., 0., 1.}   // row 6
+        }
+    );
+    EXPECT_EQ(section.GetName(), "");
+}
+
 TEST(SectionTest, ConstructUnitSection) {
     auto mass_matrix = gen_alpha_solver::MassMatrix(1., 1.);
     auto stiffness_matrix = gen_alpha_solver::create_identity_matrix(6);
     auto location = 0.;
 
-    auto section = Section(location, mass_matrix, stiffness_matrix);
+    auto section = Section(location, mass_matrix, stiffness_matrix, "section_1");
 
     EXPECT_EQ(section.GetNormalizedLocation(), location);
     openturbine::gen_alpha_solver::tests::expect_kokkos_view_2D_equal(
@@ -85,6 +124,7 @@ TEST(SectionTest, ConstructUnitSection) {
             {0., 0., 0., 0., 0., 1.}   // row 6
         }
     );
+    EXPECT_EQ(section.GetName(), "section_1");
 }
 
 TEST(SectionTest, ExpectThrowIfLocationIsOutOfBounds) {


### PR DESCRIPTION
A `Model` class was introduced in this PR with the responsibility of creating the components of a beam finite element model based on the input provided by the user. As a first step, the following attribute mentioned in #57 was added.

> A `std::vector<Section>` provides the complete list of sectional mass and stiffness matrices, to be used as material properties for the finite element code