### PR TITLE
Implement nearest neighbor search and interpolate two matrices linearly

### DIFF
--- a/src/gebt_poc/CMakeLists.txt
+++ b/src/gebt_poc/CMakeLists.txt
@@ -1,4 +1,5 @@
 target_sources(${oturb_lib_name}
     PRIVATE
+    interpolation.cpp
     section.cpp
 )

--- a/src/gebt_poc/interpolation.cpp
+++ b/src/gebt_poc/interpolation.cpp
@@ -1,0 +1,19 @@
+#include "src/gebt_poc/interpolation.h"
+
+namespace openturbine::gebt_poc {
+
+Point FindNearestNeighbor(const std::vector<Point>& points, const Point& pt) {
+    if (points.empty()) {
+        throw std::invalid_argument("Points list must not be empty");
+    }
+
+    // Find the nearest neighbor using std algorithm
+    auto nearest_neighbor =
+        std::min_element(points.begin(), points.end(), [&pt](const Point& lhs, const Point& rhs) {
+            return pt.DistanceTo(lhs) < pt.DistanceTo(rhs);
+        });
+
+    return *nearest_neighbor;
+}
+
+}  // namespace openturbine::gebt_poc

--- a/src/gebt_poc/interpolation.cpp
+++ b/src/gebt_poc/interpolation.cpp
@@ -39,4 +39,21 @@ std::vector<Point> FindkNearestNeighbors(
     return k_nearest_neighbors;
 }
 
+Kokkos::View<double**> LinearInterpolation(
+    const Kokkos::View<double**> m1, const Kokkos::View<double**> m2, const double alpha
+) {
+    if (m1.extent(0) != m2.extent(0) || m1.extent(1) != m2.extent(1)) {
+        throw std::invalid_argument("Matrices must have the same dimensions");
+    }
+
+    Kokkos::View<double**> interpolated_matrix("interpolated_matrix", m1.extent(0), m1.extent(1));
+    for (size_t i = 0; i < m1.extent(0); i++) {
+        for (size_t j = 0; j < m1.extent(1); j++) {
+            interpolated_matrix(i, j) = (1. - alpha) * m1(i, j) + alpha * m2(i, j);
+        }
+    }
+
+    return interpolated_matrix;
+}
+
 }  // namespace openturbine::gebt_poc

--- a/src/gebt_poc/interpolation.cpp
+++ b/src/gebt_poc/interpolation.cpp
@@ -2,27 +2,29 @@
 
 namespace openturbine::gebt_poc {
 
-Point FindNearestNeighbor(const std::vector<Point>& points, const Point& point) {
-    if (points.empty()) {
-        throw std::invalid_argument("Points list must not be empty");
+Point FindNearestNeighbor(const std::vector<Point>& points_list, const Point& point) {
+    if (points_list.empty()) {
+        throw std::invalid_argument("points_list list must not be empty");
     }
 
-    auto nearest_neighbor =
-        std::min_element(points.begin(), points.end(), [&point](const Point& lhs, const Point& rhs) {
+    auto nearest_neighbor = std::min_element(
+        points_list.begin(), points_list.end(),
+        [&point](const Point& lhs, const Point& rhs) {
             return point.DistanceTo(lhs) < point.DistanceTo(rhs);
-        });
+        }
+    );
 
     return *nearest_neighbor;
 }
 
 std::vector<Point> FindkNearestNeighbors(
-    const std::vector<Point>& points, const Point& point, const size_t n
+    const std::vector<Point>& points_list, const Point& point, const size_t k
 ) {
     std::vector<Point> remaining_pts{};
-    std::copy(points.begin(), points.end(), std::back_inserter(remaining_pts));
+    std::copy(points_list.begin(), points_list.end(), std::back_inserter(remaining_pts));
 
     std::vector<Point> k_nearest_neighbors{};
-    while (k_nearest_neighbors.size() < n && !remaining_pts.empty()) {
+    while (k_nearest_neighbors.size() < k && !remaining_pts.empty()) {
         auto nn = FindNearestNeighbor(remaining_pts, point);
         k_nearest_neighbors.emplace_back(nn);
 
@@ -39,7 +41,7 @@ std::vector<Point> FindkNearestNeighbors(
     return k_nearest_neighbors;
 }
 
-Kokkos::View<double**> LinearInterpolation(
+Kokkos::View<double**> LinearlyInterpolateMatrices(
     const Kokkos::View<double**> m1, const Kokkos::View<double**> m2, const double alpha
 ) {
     if (m1.extent(0) != m2.extent(0) || m1.extent(1) != m2.extent(1)) {
@@ -47,11 +49,13 @@ Kokkos::View<double**> LinearInterpolation(
     }
 
     Kokkos::View<double**> interpolated_matrix("interpolated_matrix", m1.extent(0), m1.extent(1));
-    for (size_t i = 0; i < m1.extent(0); i++) {
-        for (size_t j = 0; j < m1.extent(1); j++) {
-            interpolated_matrix(i, j) = (1. - alpha) * m1(i, j) + alpha * m2(i, j);
-        }
-    }
+    auto entries = Kokkos::MDRangePolicy<Kokkos::DefaultExecutionSpace, Kokkos::Rank<2>>(
+        {0, 0}, {m1.extent(0), m1.extent(1)}
+    );
+    auto interpolate_row_column = KOKKOS_LAMBDA(size_t row, size_t column) {
+        interpolated_matrix(row, column) = (1. - alpha) * m1(row, column) + alpha * m2(row, column);
+    };
+    Kokkos::parallel_for(entries, interpolate_row_column);
 
     return interpolated_matrix;
 }

--- a/src/gebt_poc/interpolation.cpp
+++ b/src/gebt_poc/interpolation.cpp
@@ -2,18 +2,41 @@
 
 namespace openturbine::gebt_poc {
 
-Point FindNearestNeighbor(const std::vector<Point>& points, const Point& pt) {
+Point FindNearestNeighbor(const std::vector<Point>& points, const Point& point) {
     if (points.empty()) {
         throw std::invalid_argument("Points list must not be empty");
     }
 
-    // Find the nearest neighbor using std algorithm
     auto nearest_neighbor =
-        std::min_element(points.begin(), points.end(), [&pt](const Point& lhs, const Point& rhs) {
-            return pt.DistanceTo(lhs) < pt.DistanceTo(rhs);
+        std::min_element(points.begin(), points.end(), [&point](const Point& lhs, const Point& rhs) {
+            return point.DistanceTo(lhs) < point.DistanceTo(rhs);
         });
 
     return *nearest_neighbor;
+}
+
+std::vector<Point> FindkNearestNeighbors(
+    const std::vector<Point>& points, const Point& point, const size_t n
+) {
+    std::vector<Point> remaining_pts{};
+    std::copy(points.begin(), points.end(), std::back_inserter(remaining_pts));
+
+    std::vector<Point> k_nearest_neighbors{};
+    while (k_nearest_neighbors.size() < n && !remaining_pts.empty()) {
+        auto nn = FindNearestNeighbor(remaining_pts, point);
+        k_nearest_neighbors.emplace_back(nn);
+
+        remaining_pts.erase(
+            std::remove_if(
+                remaining_pts.begin(), remaining_pts.end(),
+                [&nn](const Point& p) {
+                    return p == nn;
+                }
+            ),
+            remaining_pts.end()
+        );
+    }
+    return k_nearest_neighbors;
 }
 
 }  // namespace openturbine::gebt_poc

--- a/src/gebt_poc/interpolation.h
+++ b/src/gebt_poc/interpolation.h
@@ -1,0 +1,10 @@
+#pragma once
+
+#include "src/gebt_poc/point.h"
+
+namespace openturbine::gebt_poc {
+
+/// Find the nearest neighbor of a point from a list
+Point FindNearestNeighbor(const std::vector<Point>&, const Point&);
+
+}  // namespace openturbine::gebt_poc

--- a/src/gebt_poc/interpolation.h
+++ b/src/gebt_poc/interpolation.h
@@ -7,14 +7,17 @@ namespace openturbine::gebt_poc {
 /// Find the nearest neighbor of a point from a list
 Point FindNearestNeighbor(const std::vector<Point>&, const Point&);
 
-/// Find k-nearest neighbors of a point from a list
-std::vector<Point> FindkNearestNeighbors(const std::vector<Point>&, const Point&, const size_t);
+/*!
+ * @brief  Find the k nearest neighbors of a point from a list
+ * @param  k: Number of nearest neighbors to find
+ */
+std::vector<Point> FindkNearestNeighbors(const std::vector<Point>&, const Point&, const size_t k);
 
 /*!
  * @brief  Perform linear interpolation between two matrices with the same dimensions
  * @param  alpha: Normalized distance of the interpolation point from the first matrix
  */
-Kokkos::View<double**> LinearInterpolation(
+Kokkos::View<double**> LinearlyInterpolateMatrices(
     const Kokkos::View<double**>, const Kokkos::View<double**>, const double alpha
 );
 

--- a/src/gebt_poc/interpolation.h
+++ b/src/gebt_poc/interpolation.h
@@ -10,4 +10,12 @@ Point FindNearestNeighbor(const std::vector<Point>&, const Point&);
 /// Find k-nearest neighbors of a point from a list
 std::vector<Point> FindkNearestNeighbors(const std::vector<Point>&, const Point&, const size_t);
 
+/*!
+ * @brief  Perform linear interpolation between two matrices with the same dimensions
+ * @param  alpha: Normalized distance of the interpolation point from the first matrix
+ */
+Kokkos::View<double**> LinearInterpolation(
+    const Kokkos::View<double**>, const Kokkos::View<double**>, const double alpha
+);
+
 }  // namespace openturbine::gebt_poc

--- a/src/gebt_poc/interpolation.h
+++ b/src/gebt_poc/interpolation.h
@@ -7,4 +7,7 @@ namespace openturbine::gebt_poc {
 /// Find the nearest neighbor of a point from a list
 Point FindNearestNeighbor(const std::vector<Point>&, const Point&);
 
+/// Find k-nearest neighbors of a point from a list
+std::vector<Point> FindkNearestNeighbors(const std::vector<Point>&, const Point&, const size_t);
+
 }  // namespace openturbine::gebt_poc

--- a/tests/unit_tests/gebt_poc/CMakeLists.txt
+++ b/tests/unit_tests/gebt_poc/CMakeLists.txt
@@ -2,6 +2,7 @@
 target_sources(
     ${oturb_unit_test_exe_name}
     PRIVATE
+    test_interpolation.cpp
     test_model.cpp
     test_point.cpp
     test_section.cpp

--- a/tests/unit_tests/gebt_poc/test_interpolation.cpp
+++ b/tests/unit_tests/gebt_poc/test_interpolation.cpp
@@ -1,0 +1,64 @@
+#include <gtest/gtest.h>
+
+#include "src/gebt_poc/interpolation.h"
+
+namespace openturbine::gebt_poc::tests {
+
+TEST(MatrixInterpolationTest, FindNearestNeighborOnALine) {
+    // Create a list of points on a line from 0 to 10
+    std::vector<Point> points = {
+        Point(0., 0., 0.),  // point 1
+        Point(1., 0., 0.),  // point 2
+        Point(2., 0., 0.),  // point 3
+        Point(3., 0., 0.),  // point 4
+        Point(4., 0., 0.),  // point 5
+        Point(5., 0., 0.),  // point 6
+        Point(6., 0., 0.),  // point 7
+        Point(7., 0., 0.),  // point 8
+        Point(8., 0., 0.),  // point 9
+        Point(9., 0., 0.)   // point 10
+    };
+
+    Point pt_1(1.5, 0., 0.);
+    auto nearest_neighbor_1 = FindNearestNeighbor(points, pt_1);
+    EXPECT_EQ(nearest_neighbor_1, Point(1., 0., 0.));
+
+    Point pt_2(5.51, 0., 0.);
+    auto nearest_neighbor_2 = FindNearestNeighbor(points, pt_2);
+    EXPECT_EQ(nearest_neighbor_2, Point(6., 0., 0.));
+
+    Point pt_3(8.49, 0., 0.);
+    auto nearest_neighbor_3 = FindNearestNeighbor(points, pt_3);
+    EXPECT_EQ(nearest_neighbor_3, Point(8., 0., 0.));
+
+    Point pt_4(19.5, 0., 0.);
+    auto nearest_neighbor_4 = FindNearestNeighbor(points, pt_4);
+    EXPECT_EQ(nearest_neighbor_4, Point(9., 0., 0.));
+}
+
+TEST(MatrixInterpolationTest, FindNearestNeighborOnAPlane) {
+    std::vector<Point> points = {
+        Point(0., 0., 0.),  // point 1
+        Point(1., 0., 0.),  // point 2
+        Point(1., 1., 0.),  // point 3
+        Point(0., 1., 0.),  // point 4
+    };
+
+    Point pt_1(0.5, 0.5, 0.);
+    auto nearest_neighbor_1 = FindNearestNeighbor(points, pt_1);
+    EXPECT_EQ(nearest_neighbor_1, Point(0., 0., 0.));
+
+    Point pt_2(0.5, 0.51, 0.);
+    auto nearest_neighbor_2 = FindNearestNeighbor(points, pt_2);
+    EXPECT_EQ(nearest_neighbor_2, Point(1., 1., 0.));
+
+    Point pt_3(0., 0.51, 0.);
+    auto nearest_neighbor_3 = FindNearestNeighbor(points, pt_3);
+    EXPECT_EQ(nearest_neighbor_3, Point(0., 1., 0.));
+
+    Point pt_4(5., 5., 0.);
+    auto nearest_neighbor_4 = FindNearestNeighbor(points, pt_4);
+    EXPECT_EQ(nearest_neighbor_4, Point(1., 1., 0.));
+}
+
+}  // namespace openturbine::gebt_poc::tests

--- a/tests/unit_tests/gebt_poc/test_interpolation.cpp
+++ b/tests/unit_tests/gebt_poc/test_interpolation.cpp
@@ -5,7 +5,6 @@
 namespace openturbine::gebt_poc::tests {
 
 TEST(MatrixInterpolationTest, FindNearestNeighborOnALine) {
-    // Create a list of points on a line from 0 to 10
     std::vector<Point> points = {
         Point(0., 0., 0.),  // point 1
         Point(1., 0., 0.),  // point 2
@@ -59,6 +58,41 @@ TEST(MatrixInterpolationTest, FindNearestNeighborOnAPlane) {
     Point pt_4(5., 5., 0.);
     auto nearest_neighbor_4 = FindNearestNeighbor(points, pt_4);
     EXPECT_EQ(nearest_neighbor_4, Point(1., 1., 0.));
+}
+
+TEST(MatrixInterpolationTest, Find2NearestNeighborOnALine) {
+    std::vector<Point> points = {
+        Point(0., 0., 0.),  // point 1
+        Point(1., 0., 0.),  // point 2
+        Point(2., 0., 0.),  // point 3
+        Point(3., 0., 0.),  // point 4
+        Point(4., 0., 0.),  // point 5
+        Point(5., 0., 0.),  // point 6
+        Point(6., 0., 0.),  // point 7
+        Point(7., 0., 0.),  // point 8
+        Point(8., 0., 0.),  // point 9
+        Point(9., 0., 0.)   // point 10
+    };
+
+    Point pt_1(1.5, 0., 0.);
+    auto nearest_neighbors_1 = FindkNearestNeighbors(points, pt_1, 2);
+    std::vector<Point> expected_1 = {Point(1., 0., 0.), Point(2., 0., 0.)};
+    EXPECT_EQ(nearest_neighbors_1, expected_1);
+
+    Point pt_2(5.51, 0., 0.);
+    auto nearest_neighbors_2 = FindkNearestNeighbors(points, pt_2, 2);
+    std::vector<Point> expected_2 = {Point(6., 0., 0.), Point(5., 0., 0.)};
+    EXPECT_EQ(nearest_neighbors_2, expected_2);
+
+    Point pt_3(8.49, 0., 0.);
+    auto nearest_neighbors_3 = FindkNearestNeighbors(points, pt_3, 2);
+    std::vector<Point> expected_3 = {Point(8., 0., 0.), Point(9., 0., 0.)};
+    EXPECT_EQ(nearest_neighbors_3, expected_3);
+
+    Point pt_4(19.5, 0., 0.);
+    auto nearest_neighbors_4 = FindkNearestNeighbors(points, pt_4, 2);
+    std::vector<Point> expected_4 = {Point(9., 0., 0.), Point(8., 0., 0.)};
+    EXPECT_EQ(nearest_neighbors_4, expected_4);
 }
 
 }  // namespace openturbine::gebt_poc::tests

--- a/tests/unit_tests/gebt_poc/test_interpolation.cpp
+++ b/tests/unit_tests/gebt_poc/test_interpolation.cpp
@@ -1,6 +1,7 @@
 #include <gtest/gtest.h>
 
 #include "src/gebt_poc/interpolation.h"
+#include "tests/unit_tests/gen_alpha_poc/test_utilities.h"
 
 namespace openturbine::gebt_poc::tests {
 
@@ -93,6 +94,105 @@ TEST(MatrixInterpolationTest, Find2NearestNeighborOnALine) {
     auto nearest_neighbors_4 = FindkNearestNeighbors(points, pt_4, 2);
     std::vector<Point> expected_4 = {Point(9., 0., 0.), Point(8., 0., 0.)};
     EXPECT_EQ(nearest_neighbors_4, expected_4);
+}
+
+TEST(MatrixInterpolationTest, LinearlyInterpolate1x1Matrices) {
+    Kokkos::View<double**> m1("m1", 1, 1);
+    Kokkos::View<double**> m2("m2", 1, 1);
+    m1(0, 0) = 1.;
+    m2(0, 0) = 2.;
+
+    openturbine::gen_alpha_solver::tests::expect_kokkos_view_2D_equal(
+        LinearInterpolation(m1, m2, 0.), {{1.}}
+    );
+    openturbine::gen_alpha_solver::tests::expect_kokkos_view_2D_equal(
+        LinearInterpolation(m1, m2, 0.5), {{1.5}}
+    );
+    openturbine::gen_alpha_solver::tests::expect_kokkos_view_2D_equal(
+        LinearInterpolation(m1, m2, 0.25), {{1.25}}
+    );
+    openturbine::gen_alpha_solver::tests::expect_kokkos_view_2D_equal(
+        LinearInterpolation(m1, m2, 0.75), {{1.75}}
+    );
+    openturbine::gen_alpha_solver::tests::expect_kokkos_view_2D_equal(
+        LinearInterpolation(m1, m2, 1.), {{2.}}
+    );
+}
+
+TEST(MatrixInterpolationTest, LinearlyInterpolate6x6Matrices) {
+    Kokkos::View<double**> m1("m1", 6, 6);
+    Kokkos::deep_copy(m1, 0.);
+    m1(0, 0) = 1.;
+    m1(1, 1) = 2.;
+    m1(2, 2) = 3.;
+    m1(3, 3) = 4.;
+    m1(4, 4) = 5.;
+    m1(5, 5) = 6.;
+
+    Kokkos::View<double**> m2("m2", 6, 6);
+    Kokkos::deep_copy(m2, 0.);
+    m2(0, 0) = 7.;
+    m2(1, 1) = 8.;
+    m2(2, 2) = 9.;
+    m2(3, 3) = 10.;
+    m2(4, 4) = 11.;
+    m2(5, 5) = 12.;
+
+    openturbine::gen_alpha_solver::tests::expect_kokkos_view_2D_equal(
+        LinearInterpolation(m1, m2, 0.),
+        {
+            {1., 0., 0., 0., 0., 0.},  // row 1
+            {0., 2., 0., 0., 0., 0.},  // row 2
+            {0., 0., 3., 0., 0., 0.},  // row 3
+            {0., 0., 0., 4., 0., 0.},  // row 4
+            {0., 0., 0., 0., 5., 0.},  // row 5
+            {0., 0., 0., 0., 0., 6.}   // row 6
+        }
+    );
+    openturbine::gen_alpha_solver::tests::expect_kokkos_view_2D_equal(
+        LinearInterpolation(m1, m2, 0.25),
+        {
+            {2.5, 0., 0., 0., 0., 0.},  // row 1
+            {0., 3.5, 0., 0., 0., 0.},  // row 2
+            {0., 0., 4.5, 0., 0., 0.},  // row 3
+            {0., 0., 0., 5.5, 0., 0.},  // row 4
+            {0., 0., 0., 0., 6.5, 0.},  // row 5
+            {0., 0., 0., 0., 0., 7.5}   // row 6
+        }
+    );
+    openturbine::gen_alpha_solver::tests::expect_kokkos_view_2D_equal(
+        LinearInterpolation(m1, m2, 0.5),
+        {
+            {4., 0., 0., 0., 0., 0.},  // row 1
+            {0., 5., 0., 0., 0., 0.},  // row 2
+            {0., 0., 6., 0., 0., 0.},  // row 3
+            {0., 0., 0., 7., 0., 0.},  // row 4
+            {0., 0., 0., 0., 8., 0.},  // row 5
+            {0., 0., 0., 0., 0., 9.}   // row 6
+        }
+    );
+    openturbine::gen_alpha_solver::tests::expect_kokkos_view_2D_equal(
+        LinearInterpolation(m1, m2, 0.75),
+        {
+            {5.5, 0., 0., 0., 0., 0.},  // row 1
+            {0., 6.5, 0., 0., 0., 0.},  // row 2
+            {0., 0., 7.5, 0., 0., 0.},  // row 3
+            {0., 0., 0., 8.5, 0., 0.},  // row 4
+            {0., 0., 0., 0., 9.5, 0.},  // row 5
+            {0., 0., 0., 0., 0., 10.5}  // row 6
+        }
+    );
+    openturbine::gen_alpha_solver::tests::expect_kokkos_view_2D_equal(
+        LinearInterpolation(m1, m2, 1.),
+        {
+            {7., 0., 0., 0., 0., 0.},   // row 1
+            {0., 8., 0., 0., 0., 0.},   // row 2
+            {0., 0., 9., 0., 0., 0.},   // row 3
+            {0., 0., 0., 10., 0., 0.},  // row 4
+            {0., 0., 0., 0., 11., 0.},  // row 5
+            {0., 0., 0., 0., 0., 12.}   // row 6
+        }
+    );
 }
 
 }  // namespace openturbine::gebt_poc::tests

--- a/tests/unit_tests/gebt_poc/test_interpolation.cpp
+++ b/tests/unit_tests/gebt_poc/test_interpolation.cpp
@@ -97,49 +97,56 @@ TEST(MatrixInterpolationTest, Find2NearestNeighborOnALine) {
 }
 
 TEST(MatrixInterpolationTest, LinearlyInterpolate1x1Matrices) {
-    Kokkos::View<double**> m1("m1", 1, 1);
-    Kokkos::View<double**> m2("m2", 1, 1);
-    m1(0, 0) = 1.;
-    m2(0, 0) = 2.;
+    auto m1 = Kokkos::View<double**>("m1", 1, 1);
+    auto m1_host = Kokkos::create_mirror(m1);
+    m1_host(0, 0) = 1.;
+    Kokkos::deep_copy(m1, m1_host);
+
+    auto m2 = Kokkos::View<double**>("m2", 1, 1);
+    auto m2_host = Kokkos::create_mirror(m2);
+    m2_host(0, 0) = 2.;
+    Kokkos::deep_copy(m2, m2_host);
 
     openturbine::gen_alpha_solver::tests::expect_kokkos_view_2D_equal(
-        LinearInterpolation(m1, m2, 0.), {{1.}}
+        LinearlyInterpolateMatrices(m1, m2, 0.), {{1.}}
     );
     openturbine::gen_alpha_solver::tests::expect_kokkos_view_2D_equal(
-        LinearInterpolation(m1, m2, 0.5), {{1.5}}
+        LinearlyInterpolateMatrices(m1, m2, 0.5), {{1.5}}
     );
     openturbine::gen_alpha_solver::tests::expect_kokkos_view_2D_equal(
-        LinearInterpolation(m1, m2, 0.25), {{1.25}}
+        LinearlyInterpolateMatrices(m1, m2, 0.25), {{1.25}}
     );
     openturbine::gen_alpha_solver::tests::expect_kokkos_view_2D_equal(
-        LinearInterpolation(m1, m2, 0.75), {{1.75}}
+        LinearlyInterpolateMatrices(m1, m2, 0.75), {{1.75}}
     );
     openturbine::gen_alpha_solver::tests::expect_kokkos_view_2D_equal(
-        LinearInterpolation(m1, m2, 1.), {{2.}}
+        LinearlyInterpolateMatrices(m1, m2, 1.), {{2.}}
     );
 }
 
 TEST(MatrixInterpolationTest, LinearlyInterpolate6x6Matrices) {
-    Kokkos::View<double**> m1("m1", 6, 6);
-    Kokkos::deep_copy(m1, 0.);
-    m1(0, 0) = 1.;
-    m1(1, 1) = 2.;
-    m1(2, 2) = 3.;
-    m1(3, 3) = 4.;
-    m1(4, 4) = 5.;
-    m1(5, 5) = 6.;
+    auto m1 = Kokkos::View<double**>("m1", 6, 6);
+    auto m1_host = Kokkos::create_mirror(m1);
+    m1_host(0, 0) = 1.;
+    m1_host(1, 1) = 2.;
+    m1_host(2, 2) = 3.;
+    m1_host(3, 3) = 4.;
+    m1_host(4, 4) = 5.;
+    m1_host(5, 5) = 6.;
+    Kokkos::deep_copy(m1, m1_host);
 
-    Kokkos::View<double**> m2("m2", 6, 6);
-    Kokkos::deep_copy(m2, 0.);
-    m2(0, 0) = 7.;
-    m2(1, 1) = 8.;
-    m2(2, 2) = 9.;
-    m2(3, 3) = 10.;
-    m2(4, 4) = 11.;
-    m2(5, 5) = 12.;
+    auto m2 = Kokkos::View<double**>("m2", 6, 6);
+    auto m2_host = Kokkos::create_mirror(m2);
+    m2_host(0, 0) = 7.;
+    m2_host(1, 1) = 8.;
+    m2_host(2, 2) = 9.;
+    m2_host(3, 3) = 10.;
+    m2_host(4, 4) = 11.;
+    m2_host(5, 5) = 12.;
+    Kokkos::deep_copy(m2, m2_host);
 
     openturbine::gen_alpha_solver::tests::expect_kokkos_view_2D_equal(
-        LinearInterpolation(m1, m2, 0.),
+        LinearlyInterpolateMatrices(m1, m2, 0.),
         {
             {1., 0., 0., 0., 0., 0.},  // row 1
             {0., 2., 0., 0., 0., 0.},  // row 2
@@ -150,7 +157,7 @@ TEST(MatrixInterpolationTest, LinearlyInterpolate6x6Matrices) {
         }
     );
     openturbine::gen_alpha_solver::tests::expect_kokkos_view_2D_equal(
-        LinearInterpolation(m1, m2, 0.25),
+        LinearlyInterpolateMatrices(m1, m2, 0.25),
         {
             {2.5, 0., 0., 0., 0., 0.},  // row 1
             {0., 3.5, 0., 0., 0., 0.},  // row 2
@@ -161,7 +168,7 @@ TEST(MatrixInterpolationTest, LinearlyInterpolate6x6Matrices) {
         }
     );
     openturbine::gen_alpha_solver::tests::expect_kokkos_view_2D_equal(
-        LinearInterpolation(m1, m2, 0.5),
+        LinearlyInterpolateMatrices(m1, m2, 0.5),
         {
             {4., 0., 0., 0., 0., 0.},  // row 1
             {0., 5., 0., 0., 0., 0.},  // row 2
@@ -172,7 +179,7 @@ TEST(MatrixInterpolationTest, LinearlyInterpolate6x6Matrices) {
         }
     );
     openturbine::gen_alpha_solver::tests::expect_kokkos_view_2D_equal(
-        LinearInterpolation(m1, m2, 0.75),
+        LinearlyInterpolateMatrices(m1, m2, 0.75),
         {
             {5.5, 0., 0., 0., 0., 0.},  // row 1
             {0., 6.5, 0., 0., 0., 0.},  // row 2
@@ -183,7 +190,7 @@ TEST(MatrixInterpolationTest, LinearlyInterpolate6x6Matrices) {
         }
     );
     openturbine::gen_alpha_solver::tests::expect_kokkos_view_2D_equal(
-        LinearInterpolation(m1, m2, 1.),
+        LinearlyInterpolateMatrices(m1, m2, 1.),
         {
             {7., 0., 0., 0., 0., 0.},   // row 1
             {0., 8., 0., 0., 0., 0.},   // row 2


### PR DESCRIPTION
Fixes #62.

Two functionalities were added in this work
- Search for k-nearest neighbors of a point from a given list of points
- Linearly interpolate two matrices