### PR TITLE
Generate Gauss-Lobatto-Legendre points

### DIFF
--- a/src/gebt_poc/interpolation.cpp
+++ b/src/gebt_poc/interpolation.cpp
@@ -1,10 +1,12 @@
 #include "src/gebt_poc/interpolation.h"
 
+#include "src/utilities/log.h"
+
 namespace openturbine::gebt_poc {
 
 Point FindNearestNeighbor(const std::vector<Point>& points_list, const Point& point) {
     if (points_list.empty()) {
-        throw std::invalid_argument("points_list list must not be empty");
+        throw std::invalid_argument("points list must not be empty");
     }
 
     auto nearest_neighbor = std::min_element(
@@ -58,6 +60,62 @@ Kokkos::View<double**> LinearlyInterpolateMatrices(
     Kokkos::parallel_for(entries, interpolate_row_column);
 
     return interpolated_matrix;
+}
+
+double LegendrePolynomial(const size_t n, const double x) {
+    if (n == 0) {
+        return 1.;
+    }
+    if (n == 1) {
+        return x;
+    }
+    return (
+        ((2 * n - 1) * x * LegendrePolynomial(n - 1, x) - (n - 1) * LegendrePolynomial(n - 2, x)) / n
+    );
+}
+
+std::vector<Point> GenerateGLLPoints(const size_t order) {
+    if (order < 1) {
+        throw std::invalid_argument("Polynomial order must be greater than or equal to 1");
+    }
+
+    auto n_nodes = order + 1;  // number of nodes = order + 1
+    std::vector<Point> gll_points(n_nodes);
+    gll_points[0] = Point(-1., 0., 0.);     // left end point
+    gll_points[order] = Point(1., 0., 0.);  // right end point
+
+    for (size_t i = 1; i < n_nodes; ++i) {
+        // Use the Chebyshev-Gauss-Lobatto nodes as the initial guess
+        auto x_it = -std::cos(static_cast<double>(i) * M_PI / order);
+
+        // Use Newton's method to find the roots of the Legendre polynomial
+        for (size_t j = 0; j < kMaxIterations; ++j) {
+            auto x_old = x_it;
+
+            auto legendre_poly = std::vector<double>(n_nodes);
+            for (size_t k = 0; k < n_nodes; ++k) {
+                legendre_poly[k] = LegendrePolynomial(k, x_it);
+            }
+
+            x_it -= (x_it * legendre_poly[n_nodes - 1] - legendre_poly[n_nodes - 2]) /
+                    (n_nodes * legendre_poly[n_nodes - 1]);
+
+            if (std::abs(x_it - x_old) <= kTolerance) {
+                break;
+            }
+        }
+        gll_points[i] = Point(x_it, 0., 0.);
+    }
+
+    auto log = util::Log::Get();
+    for (size_t i = 0; i <= order; ++i) {
+        log->Debug(
+            "GLL point " + std::to_string(i + 1) + ": " +
+            std::to_string(gll_points[i].GetXComponent()) + "\n"
+        );
+    }
+
+    return gll_points;
 }
 
 }  // namespace openturbine::gebt_poc

--- a/src/gebt_poc/interpolation.h
+++ b/src/gebt_poc/interpolation.h
@@ -4,21 +4,41 @@
 
 namespace openturbine::gebt_poc {
 
-/// Find the nearest neighbor of a point from a list
+///< Maximum number of iterations allowed for Newton's method
+static constexpr size_t kMaxIterations{1000};
+
+///< Tolerance for Newton's method to machine precision
+static constexpr double kTolerance{1e-15};
+
+/// Finds the nearest neighbor of a point from a list
 Point FindNearestNeighbor(const std::vector<Point>&, const Point&);
 
 /*!
- * @brief  Find the k nearest neighbors of a point from a list
+ * @brief  Finds the k nearest neighbors of a point from a list
  * @param  k: Number of nearest neighbors to find
  */
 std::vector<Point> FindkNearestNeighbors(const std::vector<Point>&, const Point&, const size_t k);
 
 /*!
- * @brief  Perform linear interpolation between two matrices with the same dimensions
+ * @brief  Performs linear interpolation between two matrices with the same dimensions
  * @param  alpha: Normalized distance of the interpolation point from the first matrix
  */
 Kokkos::View<double**> LinearlyInterpolateMatrices(
     const Kokkos::View<double**>, const Kokkos::View<double**>, const double alpha
 );
+
+/*!
+ * @brief  Calculates the value of Legendre polynomial of order n at point x recursively
+ * @param  n: Order of the Legendre polynomial
+ * @param  x: Point at which the Legendre polynomial is to be evaluated
+ */
+double LegendrePolynomial(const size_t n, const double x);
+
+/*!
+ * @brief  Determines the (n+1) Gauss-Lobatto-Legendre points required for nodal locations
+ *         using polynomial shape/interpolation functions of order n
+ * @param  order: Order of the polynomial shape/interpolation functions
+ */
+std::vector<Point> GenerateGLLPoints(const size_t order);
 
 }  // namespace openturbine::gebt_poc

--- a/tests/unit_tests/gebt_poc/test_interpolation.cpp
+++ b/tests/unit_tests/gebt_poc/test_interpolation.cpp
@@ -202,4 +202,81 @@ TEST(MatrixInterpolationTest, LinearlyInterpolate6x6Matrices) {
     );
 }
 
+TEST(ShapeFunctionsTest, LegendrePolynomialForZeroOrder) {
+    EXPECT_EQ(LegendrePolynomial(0, -1.), 1.);
+    EXPECT_EQ(LegendrePolynomial(0, 0.), 1.);
+    EXPECT_EQ(LegendrePolynomial(0, 1.), 1.);
+}
+
+TEST(ShapeFunctionsTest, LegendrePolynomialForFirstOrder) {
+    EXPECT_EQ(LegendrePolynomial(1, -1.), -1.);
+    EXPECT_EQ(LegendrePolynomial(1, 0.), 0.);
+    EXPECT_EQ(LegendrePolynomial(1, 1.), 1.);
+}
+
+TEST(ShapeFunctionsTest, LegendrePolynomialForSecondOrder) {
+    EXPECT_EQ(LegendrePolynomial(2, -1.), 1.);
+    EXPECT_EQ(LegendrePolynomial(2, 0.), -0.5);
+    EXPECT_EQ(LegendrePolynomial(2, 1.), 1.);
+}
+
+TEST(ShapeFunctionsTest, LegendrePolynomialForN3) {
+    EXPECT_EQ(LegendrePolynomial(3, -1.), -1.);
+    EXPECT_EQ(LegendrePolynomial(3, 0.), 0.);
+    EXPECT_EQ(LegendrePolynomial(3, 1.), 1.);
+}
+
+TEST(ShapeFunctionsTest, FindGLLPointsForFirstOrderPolynomial) {
+    auto gll_points = GenerateGLLPoints(1);
+    std::vector<Point> expected = {Point(-1., 0., 0.), Point(1., 0., 0.)};
+
+    EXPECT_EQ(gll_points.size(), expected.size());
+    for (size_t i = 0; i < gll_points.size(); ++i) {
+        EXPECT_NEAR(gll_points[i].GetXComponent(), expected[i].GetXComponent(), 1e-15);
+        EXPECT_NEAR(gll_points[i].GetYComponent(), expected[i].GetYComponent(), 1e-15);
+        EXPECT_NEAR(gll_points[i].GetZComponent(), expected[i].GetZComponent(), 1e-15);
+    }
+}
+
+TEST(ShapeFunctionsTest, FindGLLPointsForSecondOrderPolynomial) {
+    auto gll_points = GenerateGLLPoints(2);
+    std::vector<Point> expected = {Point(-1., 0., 0.), Point(0., 0., 0.), Point(1., 0., 0.)};
+
+    EXPECT_EQ(gll_points.size(), expected.size());
+    for (size_t i = 0; i < gll_points.size(); ++i) {
+        EXPECT_NEAR(gll_points[i].GetXComponent(), expected[i].GetXComponent(), 1e-15);
+        EXPECT_NEAR(gll_points[i].GetYComponent(), expected[i].GetYComponent(), 1e-15);
+        EXPECT_NEAR(gll_points[i].GetZComponent(), expected[i].GetZComponent(), 1e-15);
+    }
+}
+
+TEST(ShapeFunctionsTest, FindGLLPointsForFourthOrderPolynomial) {
+    auto gll_points = GenerateGLLPoints(4);
+    std::vector<Point> expected = {
+        Point(-1., 0., 0.), Point(-0.6546536707079771437983, 0., 0.), Point(0., 0., 0.),
+        Point(0.654653670707977143798, 0., 0.), Point(1., 0., 0.)};
+
+    EXPECT_EQ(gll_points.size(), expected.size());
+    for (size_t i = 0; i < gll_points.size(); ++i) {
+        EXPECT_NEAR(gll_points[i].GetXComponent(), expected[i].GetXComponent(), 1e-15);
+        EXPECT_NEAR(gll_points[i].GetYComponent(), expected[i].GetYComponent(), 1e-15);
+        EXPECT_NEAR(gll_points[i].GetZComponent(), expected[i].GetZComponent(), 1e-15);
+    }
+}
+
+TEST(ShapeFunctionsTest, FindGLLPointsForSixthOrderPolynomial) {
+    auto gll_points = GenerateGLLPoints(6);
+    std::vector<Point> expected = {
+        Point(-1., 0., 0.), Point(-0.8302238962785669, 0., 0.), Point(-0.46884879347071423, 0., 0.),
+        Point(0., 0., 0.),  Point(0.46884879347071423, 0., 0.), Point(0.8302238962785669, 0., 0.),
+        Point(1., 0., 0.)};
+
+    EXPECT_EQ(gll_points.size(), expected.size());
+    for (size_t i = 0; i < gll_points.size(); ++i) {
+        EXPECT_NEAR(gll_points[i].GetXComponent(), expected[i].GetXComponent(), 1e-15);
+        EXPECT_NEAR(gll_points[i].GetYComponent(), expected[i].GetYComponent(), 1e-15);
+        EXPECT_NEAR(gll_points[i].GetZComponent(), expected[i].GetZComponent(), 1e-15);
+    }
+}
+
 }  // namespace openturbine::gebt_poc::tests


### PR DESCRIPTION
Partially resolves #61.

In this work, Gauss-Lobatto-Legendre (GLL) points required for nodal locations using polynomial shape/interpolation functions of order n.