### PR TITLE
Implement Lagrange polynomial basis functions to support LSFE based beam element

### DIFF
--- a/src/gebt_poc/interpolation.cpp
+++ b/src/gebt_poc/interpolation.cpp
@@ -118,4 +118,17 @@ std::vector<Point> GenerateGLLPoints(const size_t order) {
     return gll_points;
 }
 
+double LegendrePolynomialDerivative(const size_t n, const double x) {
+    if (n == 0) {
+        return 0.;
+    }
+    if (n == 1) {
+        return 1.;
+    }
+    if (n == 2) {
+        return (3. * x);
+    }
+    return ((2 * n - 1) * LegendrePolynomial(n - 1, x) + LegendrePolynomialDerivative(n - 2, x));
+}
+
 }  // namespace openturbine::gebt_poc

--- a/src/gebt_poc/interpolation.cpp
+++ b/src/gebt_poc/interpolation.cpp
@@ -74,6 +74,19 @@ double LegendrePolynomial(const size_t n, const double x) {
     );
 }
 
+double LegendrePolynomialDerivative(const size_t n, const double x) {
+    if (n == 0) {
+        return 0.;
+    }
+    if (n == 1) {
+        return 1.;
+    }
+    if (n == 2) {
+        return (3. * x);
+    }
+    return ((2 * n - 1) * LegendrePolynomial(n - 1, x) + LegendrePolynomialDerivative(n - 2, x));
+}
+
 std::vector<double> GenerateGLLPoints(const size_t order) {
     if (order < 1) {
         throw std::invalid_argument("Polynomial order must be greater than or equal to 1");
@@ -100,7 +113,7 @@ std::vector<double> GenerateGLLPoints(const size_t order) {
             x_it -= (x_it * legendre_poly[n_nodes - 1] - legendre_poly[n_nodes - 2]) /
                     (n_nodes * legendre_poly[n_nodes - 1]);
 
-            if (std::abs(x_it - x_old) <= kTolerance) {
+            if (std::abs(x_it - x_old) <= kConvergenceTolerance) {
                 break;
             }
         }
@@ -110,25 +123,13 @@ std::vector<double> GenerateGLLPoints(const size_t order) {
     return gll_points;
 }
 
-double LegendrePolynomialDerivative(const size_t n, const double x) {
-    if (n == 0) {
-        return 0.;
-    }
-    if (n == 1) {
-        return 1.;
-    }
-    if (n == 2) {
-        return (3. * x);
-    }
-    return ((2 * n - 1) * LegendrePolynomial(n - 1, x) + LegendrePolynomialDerivative(n - 2, x));
-}
-
 std::vector<double> LagrangePolynomial(const size_t n, const double x) {
-    auto gll_points = GenerateGLLPoints(n);
+    auto gll_points = GenerateGLLPoints(n);  // n+1 GLL points for n+1 nodes
     auto lagrange_poly = std::vector<double>(n + 1, 1.);
 
     for (size_t i = 0; i < n + 1; ++i) {
         if (gen_alpha_solver::close_to(gll_points[i], x)) {
+            // If x is close to a GLL point, then Lagrange polynomial is 1.0 at that point
             continue;
         }
         lagrange_poly[i] =

--- a/src/gebt_poc/interpolation.h
+++ b/src/gebt_poc/interpolation.h
@@ -41,4 +41,11 @@ double LegendrePolynomial(const size_t n, const double x);
  */
 std::vector<Point> GenerateGLLPoints(const size_t order);
 
+/*!
+ * @brief  Evaluates the first derivative of Legendre polynomial of order n at point x recursively
+ * @param  n: Order of the Legendre polynomial
+ * @param  x: Point at which the derivative of the Legendre polynomial is to be evaluated
+ */
+double LegendrePolynomialDerivative(const size_t n, const double x);
+
 }  // namespace openturbine::gebt_poc

--- a/src/gebt_poc/interpolation.h
+++ b/src/gebt_poc/interpolation.h
@@ -39,7 +39,7 @@ double LegendrePolynomial(const size_t n, const double x);
  *         using polynomial shape/interpolation functions of order n
  * @param  order: Order of the polynomial shape/interpolation functions
  */
-std::vector<Point> GenerateGLLPoints(const size_t order);
+std::vector<double> GenerateGLLPoints(const size_t order);
 
 /*!
  * @brief  Evaluates the first derivative of Legendre polynomial of order n at point x recursively
@@ -47,5 +47,12 @@ std::vector<Point> GenerateGLLPoints(const size_t order);
  * @param  x: Point at which the derivative of the Legendre polynomial is to be evaluated
  */
 double LegendrePolynomialDerivative(const size_t n, const double x);
+
+/*!
+ * @brief Calculates the Lagrangian interpolation functions for order n at a given point x
+ * @param n: Order of the Legendre polynomial
+ * @param x: Point at which the Lagrangian interpolation function is to be evaluated
+ */
+std::vector<double> LagrangePolynomial(const size_t n, const double x);
 
 }  // namespace openturbine::gebt_poc

--- a/src/gebt_poc/interpolation.h
+++ b/src/gebt_poc/interpolation.h
@@ -1,14 +1,16 @@
 #pragma once
 
+#include <limits>
+
 #include "src/gebt_poc/point.h"
 
 namespace openturbine::gebt_poc {
 
-///< Maximum number of iterations allowed for Newton's method
+/// Maximum number of iterations allowed for Newton's method
 static constexpr size_t kMaxIterations{1000};
 
-///< Tolerance for Newton's method to machine precision
-static constexpr double kTolerance{1e-15};
+/// Tolerance for Newton's method to machine precision
+static constexpr double kConvergenceTolerance{std::numeric_limits<double>::epsilon()};
 
 /// Finds the nearest neighbor of a point from a list
 Point FindNearestNeighbor(const std::vector<Point>&, const Point&);
@@ -29,27 +31,41 @@ Kokkos::View<double**> LinearlyInterpolateMatrices(
 
 /*!
  * @brief  Calculates the value of Legendre polynomial of order n at point x recursively
+   @details  Uses the recurrence relation for Legendre polynomials provided in
+             Eq. B.1.15 (Page 446) of "High-Order Methods for Incompressible Fluid Flow"
+             by Deville et al. 2002
+             Ref: https://doi.org/10.1017/CBO9780511546792
  * @param  n: Order of the Legendre polynomial
  * @param  x: Point at which the Legendre polynomial is to be evaluated
  */
 double LegendrePolynomial(const size_t n, const double x);
 
 /*!
- * @brief  Determines the (n+1) Gauss-Lobatto-Legendre points required for nodal locations
- *         using polynomial shape/interpolation functions of order n
- * @param  order: Order of the polynomial shape/interpolation functions
- */
-std::vector<double> GenerateGLLPoints(const size_t order);
-
-/*!
  * @brief  Evaluates the first derivative of Legendre polynomial of order n at point x recursively
+ * @details  Uses the recurrence relation for Legendre polynomials provided in
+             Eq. B.1.20 (Page 446) of "High-Order Methods for Incompressible Fluid Flow"
+             by Deville et al. 2002
+             Ref: https://doi.org/10.1017/CBO9780511546792
  * @param  n: Order of the Legendre polynomial
  * @param  x: Point at which the derivative of the Legendre polynomial is to be evaluated
  */
 double LegendrePolynomialDerivative(const size_t n, const double x);
 
 /*!
+ * @brief  Determines the (n+1) Gauss-Lobatto-Legendre points required for nodal locations
+ *         using polynomial shape/interpolation functions of order n
+ * @details  Uses the Newton's method to find the roots of the Legendre polynomial which are
+             the Gauss-Lobatto-Legendre points
+ * @param  order: Order of the polynomial shape/interpolation functions
+ */
+std::vector<double> GenerateGLLPoints(const size_t order);
+
+/*!
  * @brief Calculates the Lagrangian interpolation functions for order n at a given point x
+   @details  Uses the relationship based on GLL points, Legendre polynomials and its
+             derivative provided in Eq. 2.4.3 (Page 63) of "High-Order Methods for Incompressible
+             Fluid Flow" by Deville et al. 2002
+             Ref: https://doi.org/10.1017/CBO9780511546792
  * @param n: Order of the Legendre polynomial
  * @param x: Point at which the Lagrangian interpolation function is to be evaluated
  */

--- a/tests/unit_tests/gebt_poc/test_interpolation.cpp
+++ b/tests/unit_tests/gebt_poc/test_interpolation.cpp
@@ -202,25 +202,25 @@ TEST(MatrixInterpolationTest, LinearlyInterpolate6x6Matrices) {
     );
 }
 
-TEST(ShapeFunctionsTest, LegendrePolynomialForZeroOrder) {
+TEST(ShapeFunctionsTest, ZerothOrderLegendrePolynomial) {
     EXPECT_EQ(LegendrePolynomial(0, -1.), 1.);
     EXPECT_EQ(LegendrePolynomial(0, 0.), 1.);
     EXPECT_EQ(LegendrePolynomial(0, 1.), 1.);
 }
 
-TEST(ShapeFunctionsTest, LegendrePolynomialForFirstOrder) {
+TEST(ShapeFunctionsTest, FirstOrderLegendrePolynomial) {
     EXPECT_EQ(LegendrePolynomial(1, -1.), -1.);
     EXPECT_EQ(LegendrePolynomial(1, 0.), 0.);
     EXPECT_EQ(LegendrePolynomial(1, 1.), 1.);
 }
 
-TEST(ShapeFunctionsTest, LegendrePolynomialForSecondOrder) {
+TEST(ShapeFunctionsTest, SecondOrderLegendrePolynomial) {
     EXPECT_EQ(LegendrePolynomial(2, -1.), 1.);
     EXPECT_EQ(LegendrePolynomial(2, 0.), -0.5);
     EXPECT_EQ(LegendrePolynomial(2, 1.), 1.);
 }
 
-TEST(ShapeFunctionsTest, LegendrePolynomialForN3) {
+TEST(ShapeFunctionsTest, ThirdOrderLegendrePolynomial) {
     EXPECT_EQ(LegendrePolynomial(3, -1.), -1.);
     EXPECT_EQ(LegendrePolynomial(3, 0.), 0.);
     EXPECT_EQ(LegendrePolynomial(3, 1.), 1.);
@@ -277,6 +277,36 @@ TEST(ShapeFunctionsTest, FindGLLPointsForSixthOrderPolynomial) {
         EXPECT_NEAR(gll_points[i].GetYComponent(), expected[i].GetYComponent(), 1e-15);
         EXPECT_NEAR(gll_points[i].GetZComponent(), expected[i].GetZComponent(), 1e-15);
     }
+}
+
+TEST(ShapeFunctionsTest, ZerothOrderLegendrePolynomialDerivative) {
+    EXPECT_EQ(LegendrePolynomialDerivative(0, -1.), 0.);
+    EXPECT_EQ(LegendrePolynomialDerivative(0, 0.), 0.);
+    EXPECT_EQ(LegendrePolynomialDerivative(0, 1.), 0.);
+}
+
+TEST(ShapeFunctionsTest, FirstOrderLegendrePolynomialDerivative) {
+    EXPECT_EQ(LegendrePolynomialDerivative(1, -1.), 1.);
+    EXPECT_EQ(LegendrePolynomialDerivative(1, 0.), 1.);
+    EXPECT_EQ(LegendrePolynomialDerivative(1, 1.), 1.);
+}
+
+TEST(ShapeFunctionsTest, SecondOrderLegendrePolynomialDerivative) {
+    EXPECT_EQ(LegendrePolynomialDerivative(2, -1.), -3.);
+    EXPECT_EQ(LegendrePolynomialDerivative(2, 0.), 0.);
+    EXPECT_EQ(LegendrePolynomialDerivative(2, 1.), 3.);
+}
+
+TEST(ShapeFunctionsTest, ThirdOrderLegendrePolynomialDerivative) {
+    EXPECT_EQ(LegendrePolynomialDerivative(3, -1.), 6.);
+    EXPECT_EQ(LegendrePolynomialDerivative(3, 0.), -1.5);
+    EXPECT_EQ(LegendrePolynomialDerivative(3, 1.), 6.);
+}
+
+TEST(ShapeFunctionsTest, SixthOrderLegendrePolynomialDerivative) {
+    EXPECT_EQ(LegendrePolynomialDerivative(6, -1.), -21.);
+    EXPECT_EQ(LegendrePolynomialDerivative(6, 0.), 0.);
+    EXPECT_EQ(LegendrePolynomialDerivative(6, 1.), 21.);
 }
 
 }  // namespace openturbine::gebt_poc::tests

--- a/tests/unit_tests/gebt_poc/test_interpolation.cpp
+++ b/tests/unit_tests/gebt_poc/test_interpolation.cpp
@@ -228,54 +228,43 @@ TEST(ShapeFunctionsTest, ThirdOrderLegendrePolynomial) {
 
 TEST(ShapeFunctionsTest, FindGLLPointsForFirstOrderPolynomial) {
     auto gll_points = GenerateGLLPoints(1);
-    std::vector<Point> expected = {Point(-1., 0., 0.), Point(1., 0., 0.)};
+    std::vector<double> expected = {-1., 1.};
 
     EXPECT_EQ(gll_points.size(), expected.size());
     for (size_t i = 0; i < gll_points.size(); ++i) {
-        EXPECT_NEAR(gll_points[i].GetXComponent(), expected[i].GetXComponent(), 1e-15);
-        EXPECT_NEAR(gll_points[i].GetYComponent(), expected[i].GetYComponent(), 1e-15);
-        EXPECT_NEAR(gll_points[i].GetZComponent(), expected[i].GetZComponent(), 1e-15);
+        EXPECT_NEAR(gll_points[i], expected[i], 1e-15);
     }
 }
 
 TEST(ShapeFunctionsTest, FindGLLPointsForSecondOrderPolynomial) {
     auto gll_points = GenerateGLLPoints(2);
-    std::vector<Point> expected = {Point(-1., 0., 0.), Point(0., 0., 0.), Point(1., 0., 0.)};
+    std::vector<double> expected = {-1., 0., 1.};
 
     EXPECT_EQ(gll_points.size(), expected.size());
     for (size_t i = 0; i < gll_points.size(); ++i) {
-        EXPECT_NEAR(gll_points[i].GetXComponent(), expected[i].GetXComponent(), 1e-15);
-        EXPECT_NEAR(gll_points[i].GetYComponent(), expected[i].GetYComponent(), 1e-15);
-        EXPECT_NEAR(gll_points[i].GetZComponent(), expected[i].GetZComponent(), 1e-15);
+        EXPECT_NEAR(gll_points[i], expected[i], 1e-15);
     }
 }
 
 TEST(ShapeFunctionsTest, FindGLLPointsForFourthOrderPolynomial) {
     auto gll_points = GenerateGLLPoints(4);
-    std::vector<Point> expected = {
-        Point(-1., 0., 0.), Point(-0.6546536707079771437983, 0., 0.), Point(0., 0., 0.),
-        Point(0.654653670707977143798, 0., 0.), Point(1., 0., 0.)};
+    std::vector<double> expected = {-1., -0.6546536707079771437983, 0., 0.654653670707977143798, 1.};
 
     EXPECT_EQ(gll_points.size(), expected.size());
     for (size_t i = 0; i < gll_points.size(); ++i) {
-        EXPECT_NEAR(gll_points[i].GetXComponent(), expected[i].GetXComponent(), 1e-15);
-        EXPECT_NEAR(gll_points[i].GetYComponent(), expected[i].GetYComponent(), 1e-15);
-        EXPECT_NEAR(gll_points[i].GetZComponent(), expected[i].GetZComponent(), 1e-15);
+        EXPECT_NEAR(gll_points[i], expected[i], 1e-15);
     }
 }
 
 TEST(ShapeFunctionsTest, FindGLLPointsForSixthOrderPolynomial) {
     auto gll_points = GenerateGLLPoints(6);
-    std::vector<Point> expected = {
-        Point(-1., 0., 0.), Point(-0.8302238962785669, 0., 0.), Point(-0.46884879347071423, 0., 0.),
-        Point(0., 0., 0.),  Point(0.46884879347071423, 0., 0.), Point(0.8302238962785669, 0., 0.),
-        Point(1., 0., 0.)};
+    std::vector<double> expected = {-1., -0.8302238962785669, -0.46884879347071423,
+                                    0.,  0.46884879347071423, 0.8302238962785669,
+                                    1.};
 
     EXPECT_EQ(gll_points.size(), expected.size());
     for (size_t i = 0; i < gll_points.size(); ++i) {
-        EXPECT_NEAR(gll_points[i].GetXComponent(), expected[i].GetXComponent(), 1e-15);
-        EXPECT_NEAR(gll_points[i].GetYComponent(), expected[i].GetYComponent(), 1e-15);
-        EXPECT_NEAR(gll_points[i].GetZComponent(), expected[i].GetZComponent(), 1e-15);
+        EXPECT_NEAR(gll_points[i], expected[i], 1e-15);
     }
 }
 
@@ -307,6 +296,128 @@ TEST(ShapeFunctionsTest, SixthOrderLegendrePolynomialDerivative) {
     EXPECT_EQ(LegendrePolynomialDerivative(6, -1.), -21.);
     EXPECT_EQ(LegendrePolynomialDerivative(6, 0.), 0.);
     EXPECT_EQ(LegendrePolynomialDerivative(6, 1.), 21.);
+}
+
+TEST(ShapeFunctionsTest, FirstOrderLagrangePolynomial) {
+    auto lagrange_poly_1 = LagrangePolynomial(1, -1.);
+    std::vector<double> expected = {1., 0.};
+
+    EXPECT_EQ(lagrange_poly_1.size(), expected.size());
+    for (size_t i = 0; i < lagrange_poly_1.size(); ++i) {
+        EXPECT_NEAR(lagrange_poly_1[i], expected[i], 1e-15);
+    }
+
+    auto lagrange_poly_2 = LagrangePolynomial(1, 0.);
+    std::vector<double> expected_2 = {0.5, 0.5};
+
+    EXPECT_EQ(lagrange_poly_2.size(), expected_2.size());
+    for (size_t i = 0; i < lagrange_poly_2.size(); ++i) {
+        EXPECT_NEAR(lagrange_poly_2[i], expected_2[i], 1e-15);
+    }
+
+    auto lagrange_poly_3 = LagrangePolynomial(1, 1.);
+    std::vector<double> expected_3 = {0., 1.};
+
+    EXPECT_EQ(lagrange_poly_3.size(), expected_3.size());
+    for (size_t i = 0; i < lagrange_poly_3.size(); ++i) {
+        EXPECT_NEAR(lagrange_poly_3[i], expected_3[i], 1e-15);
+    }
+}
+
+TEST(ShapeFunctionsTest, SecondOrderLagrangePolynomial) {
+    auto lagrange_poly_1 = LagrangePolynomial(2, -1.);
+    std::vector<double> expected = {1., 0., 0.};
+
+    EXPECT_EQ(lagrange_poly_1.size(), expected.size());
+    for (size_t i = 0; i < lagrange_poly_1.size(); ++i) {
+        EXPECT_NEAR(lagrange_poly_1[i], expected[i], 1e-15);
+    }
+
+    auto lagrange_poly_2 = LagrangePolynomial(2, 0.);
+    std::vector<double> expected_2 = {0., 1., 0.};
+
+    EXPECT_EQ(lagrange_poly_2.size(), expected_2.size());
+    for (size_t i = 0; i < lagrange_poly_2.size(); ++i) {
+        EXPECT_NEAR(lagrange_poly_2[i], expected_2[i], 1e-15);
+    }
+
+    auto lagrange_poly_3 = LagrangePolynomial(2, 1.);
+    std::vector<double> expected_3 = {0., 0., 1.};
+
+    EXPECT_EQ(lagrange_poly_3.size(), expected_3.size());
+    for (size_t i = 0; i < lagrange_poly_3.size(); ++i) {
+        EXPECT_NEAR(lagrange_poly_3[i], expected_3[i], 1e-15);
+    }
+}
+
+TEST(ShapeFunctionsTest, FourthOrderLagrangePolynomial) {
+    auto lagrange_poly_1 = LagrangePolynomial(4, -1.);
+    std::vector<double> expected = {1., 0., 0., 0., 0.};
+
+    EXPECT_EQ(lagrange_poly_1.size(), expected.size());
+    for (size_t i = 0; i < lagrange_poly_1.size(); ++i) {
+        EXPECT_NEAR(lagrange_poly_1[i], expected[i], 1e-15);
+    }
+
+    auto lagrange_poly_2 = LagrangePolynomial(4, -0.6546536707079771);
+    std::vector<double> expected_2 = {0., 1., 0., 0., 0.};
+
+    EXPECT_EQ(lagrange_poly_2.size(), expected_2.size());
+    for (size_t i = 0; i < lagrange_poly_2.size(); ++i) {
+        EXPECT_NEAR(lagrange_poly_2[i], expected_2[i], 1e-15);
+    }
+
+    auto lagrange_poly_3 = LagrangePolynomial(4, 0.);
+    std::vector<double> expected_3 = {0., 0., 1., 0., 0.};
+
+    EXPECT_EQ(lagrange_poly_3.size(), expected_3.size());
+    for (size_t i = 0; i < lagrange_poly_3.size(); ++i) {
+        EXPECT_NEAR(lagrange_poly_3[i], expected_3[i], 1e-15);
+    }
+
+    auto lagrange_poly_4 = LagrangePolynomial(4, 0.6546536707079771);
+    std::vector<double> expected_4 = {0., 0., 0., 1., 0.};
+
+    EXPECT_EQ(lagrange_poly_4.size(), expected_4.size());
+    for (size_t i = 0; i < lagrange_poly_4.size(); ++i) {
+        EXPECT_NEAR(lagrange_poly_4[i], expected_4[i], 1e-15);
+    }
+
+    auto lagrange_poly_5 = LagrangePolynomial(4, 1.);
+    std::vector<double> expected_5 = {0., 0., 0., 0., 1.};
+
+    EXPECT_EQ(lagrange_poly_5.size(), expected_5.size());
+    for (size_t i = 0; i < lagrange_poly_5.size(); ++i) {
+        EXPECT_NEAR(lagrange_poly_5[i], expected_5[i], 1e-15);
+    }
+
+    auto lagrange_poly_6 = LagrangePolynomial(4, -0.8);
+    std::vector<double> expected_6 = {
+        0.266400000000000, 0.855336358376291, -0.1776000000000001, 0.0854636416237095,
+        -0.0296000000000000};
+
+    EXPECT_EQ(lagrange_poly_6.size(), expected_6.size());
+    for (size_t i = 0; i < lagrange_poly_6.size(); ++i) {
+        EXPECT_NEAR(lagrange_poly_6[i], expected_6[i], 1e-15);
+    }
+
+    auto lagrange_poly_7 = LagrangePolynomial(4, 0.1);
+    std::vector<double> expected_7 = {
+        0.0329625, -0.1121093731918499, 0.9669, 0.1525343731918499, -0.0402875};
+
+    EXPECT_EQ(lagrange_poly_7.size(), expected_7.size());
+    for (size_t i = 0; i < lagrange_poly_7.size(); ++i) {
+        EXPECT_NEAR(lagrange_poly_7[i], expected_7[i], 1e-15);
+    }
+
+    auto lagrange_poly_8 = LagrangePolynomial(4, 0.4);
+    std::vector<double> expected_8 = {
+        0.0564, -0.1746924181056723, 0.5263999999999998, 0.7234924181056726, -0.1316};
+
+    EXPECT_EQ(lagrange_poly_8.size(), expected_8.size());
+    for (size_t i = 0; i < lagrange_poly_8.size(); ++i) {
+        EXPECT_NEAR(lagrange_poly_8[i], expected_8[i], 1e-15);
+    }
 }
 
 }  // namespace openturbine::gebt_poc::tests


### PR DESCRIPTION
Implements the requirements described in #61. Specifically, general n-th order Lagrange polynomial basis function was implemented based on n-th order GLL points, Legedre polynomials, and its derivatives.