### PR TITLE
Adds a simple mesh data structure for beam elements and a factory function

### DIFF
--- a/src/gebt_poc/mesh.h
+++ b/src/gebt_poc/mesh.h
@@ -3,49 +3,45 @@
 #include <Kokkos_Core.hpp>
 
 namespace openturbine {
-  class Mesh {
-  public:
-    int GetNumberOfElements() {
-      return number_of_elements_;
-    }
+class Mesh {
+public:
+    int GetNumberOfElements() { return number_of_elements_; }
 
-    int GetNumberOfNodes() {
-      return number_of_nodes_;
-    }
+    int GetNumberOfNodes() { return number_of_nodes_; }
 
     void SetNumberOfElements(int number_of_elements) { number_of_elements_ = number_of_elements; }
     void SetNumberOfNodes(int number_of_nodes) { number_of_nodes_ = number_of_nodes; }
 
     void InitializeElementNodeConnectivity(int number_of_elements, int nodes_per_element) {
-      connectivity_ = Kokkos::View<int**>("connectivity", number_of_elements, nodes_per_element);
+        connectivity_ = Kokkos::View<int**>("connectivity", number_of_elements, nodes_per_element);
     }
 
     KOKKOS_FUNCTION
     Kokkos::View<const int*> GetNodesForElement(int elementID) {
-      return Kokkos::subview(connectivity_, elementID, Kokkos::ALL);
+        return Kokkos::subview(connectivity_, elementID, Kokkos::ALL);
     }
 
     friend Mesh create1DMesh(int number_of_elements, int nodes_per_element);
-  protected:
+
+protected:
     int number_of_elements_;
     int number_of_nodes_;
     Kokkos::View<int**> connectivity_;
-  };
+};
 
-  
-  inline Mesh create1DMesh(int number_of_elements, int nodes_per_element) {
+inline Mesh create1DMesh(int number_of_elements, int nodes_per_element) {
     Mesh mesh;
     mesh.SetNumberOfElements(number_of_elements);
     mesh.SetNumberOfNodes(number_of_elements * nodes_per_element - (number_of_elements - 1));
     mesh.InitializeElementNodeConnectivity(number_of_elements, nodes_per_element);
 
     auto set_element_connectivity = KOKKOS_LAMBDA(int elementID) {
-      for(int node = 0; node < nodes_per_element; ++node) {
-        mesh.connectivity_(elementID, node) = node + (nodes_per_element-1)*(elementID);
-      }
+        for (int node = 0; node < nodes_per_element; ++node) {
+            mesh.connectivity_(elementID, node) = node + (nodes_per_element - 1) * (elementID);
+        }
     };
 
     Kokkos::parallel_for(number_of_elements, set_element_connectivity);
     return mesh;
-  }
 }
+}  // namespace openturbine

--- a/src/gebt_poc/mesh.h
+++ b/src/gebt_poc/mesh.h
@@ -1,0 +1,51 @@
+#pragma once
+
+#include <Kokkos_Core.hpp>
+
+namespace openturbine {
+  class Mesh {
+  public:
+    int GetNumberOfElements() {
+      return number_of_elements_;
+    }
+
+    int GetNumberOfNodes() {
+      return number_of_nodes_;
+    }
+
+    void SetNumberOfElements(int number_of_elements) { number_of_elements_ = number_of_elements; }
+    void SetNumberOfNodes(int number_of_nodes) { number_of_nodes_ = number_of_nodes; }
+
+    void InitializeElementNodeConnectivity(int number_of_elements, int nodes_per_element) {
+      connectivity_ = Kokkos::View<int**>("connectivity", number_of_elements, nodes_per_element);
+    }
+
+    KOKKOS_FUNCTION
+    Kokkos::View<const int*> GetNodesForElement(int elementID) {
+      return Kokkos::subview(connectivity_, elementID, Kokkos::ALL);
+    }
+
+    friend Mesh create1DMesh(int number_of_elements, int nodes_per_element);
+  protected:
+    int number_of_elements_;
+    int number_of_nodes_;
+    Kokkos::View<int**> connectivity_;
+  };
+
+  
+  inline Mesh create1DMesh(int number_of_elements, int nodes_per_element) {
+    Mesh mesh;
+    mesh.SetNumberOfElements(number_of_elements);
+    mesh.SetNumberOfNodes(number_of_elements * nodes_per_element - (number_of_elements - 1));
+    mesh.InitializeElementNodeConnectivity(number_of_elements, nodes_per_element);
+
+    auto set_element_connectivity = KOKKOS_LAMBDA(int elementID) {
+      for(int node = 0; node < nodes_per_element; ++node) {
+        mesh.connectivity_(elementID, node) = node + (nodes_per_element-1)*(elementID);
+      }
+    };
+
+    Kokkos::parallel_for(number_of_elements, set_element_connectivity);
+    return mesh;
+  }
+}

--- a/src/gebt_poc/mesh.h
+++ b/src/gebt_poc/mesh.h
@@ -2,7 +2,7 @@
 
 #include <Kokkos_Core.hpp>
 
-namespace openturbine {
+namespace openturbine::gebt_poc {
 class Mesh {
 public:
     int GetNumberOfElements() { return number_of_elements_; }

--- a/src/gebt_poc/mesh.h
+++ b/src/gebt_poc/mesh.h
@@ -97,4 +97,4 @@ inline Mesh create1DMesh(int number_of_elements, int nodes_per_element) {
     mesh.CheckConsistency();
     return mesh;
 }
-}  // namespace openturbine
+}  // namespace openturbine::gebt_poc

--- a/src/gebt_poc/mesh.h
+++ b/src/gebt_poc/mesh.h
@@ -5,12 +5,12 @@
 namespace openturbine::gebt_poc {
 class Mesh {
 public:
-    int GetNumberOfElements() { return number_of_elements_; }
+    int GetNumberOfElements() const { return number_of_elements_; }
 
-    int GetNumberOfNodes() { return number_of_nodes_; }
+    int GetNumberOfNodes() const { return number_of_nodes_; }
 
     KOKKOS_FUNCTION
-    Kokkos::View<const int*> GetNodesForElement(int elementID) {
+    Kokkos::View<const int*> GetNodesForElement(int elementID) const {
         return Kokkos::subview(connectivity_, elementID, Kokkos::ALL);
     }
 

--- a/src/gebt_poc/mesh.h
+++ b/src/gebt_poc/mesh.h
@@ -10,11 +10,11 @@ public:
     int GetNumberOfNodes() const { return number_of_nodes_; }
 
     KOKKOS_FUNCTION
-    Kokkos::View<const int*> GetNodesForElement(int elementID) const {
-        return Kokkos::subview(connectivity_, elementID, Kokkos::ALL);
+    Kokkos::View<const int*> GetNodesForElement(int element_id) const {
+        return Kokkos::subview(connectivity_, element_id, Kokkos::ALL);
     }
 
-    friend Mesh create1DMesh(int number_of_elements, int nodes_per_element);
+    friend Mesh Create1DMesh(int number_of_elements, int nodes_per_element);
 
 protected:
     Mesh() = default;
@@ -26,7 +26,7 @@ protected:
     }
 
     void CheckElementConsistency() {
-        if (static_cast<unsigned>(number_of_elements_) != connectivity_.extent(0)) {
+        if (static_cast<std::size_t>(number_of_elements_) != connectivity_.extent(0)) {
             throw std::domain_error("Connectivity does not contain expected number of elements");
         }
     }
@@ -80,15 +80,15 @@ protected:
     Kokkos::View<int**> connectivity_;
 };
 
-inline Mesh create1DMesh(int number_of_elements, int nodes_per_element) {
+inline Mesh Create1DMesh(int number_of_elements, int nodes_per_element) {
     Mesh mesh;
     mesh.SetNumberOfElements(number_of_elements);
     mesh.SetNumberOfNodes(number_of_elements * nodes_per_element - (number_of_elements - 1));
     mesh.InitializeElementNodeConnectivity(number_of_elements, nodes_per_element);
 
-    auto set_element_connectivity = KOKKOS_LAMBDA(int elementID) {
+    auto set_element_connectivity = KOKKOS_LAMBDA(int element_id) {
         for (int node = 0; node < nodes_per_element; ++node) {
-            mesh.connectivity_(elementID, node) = node + (nodes_per_element - 1) * (elementID);
+            mesh.connectivity_(element_id, node) = node + (nodes_per_element - 1) * (element_id);
         }
     };
 

--- a/src/gebt_poc/mesh.h
+++ b/src/gebt_poc/mesh.h
@@ -9,13 +9,6 @@ public:
 
     int GetNumberOfNodes() { return number_of_nodes_; }
 
-    void SetNumberOfElements(int number_of_elements) { number_of_elements_ = number_of_elements; }
-    void SetNumberOfNodes(int number_of_nodes) { number_of_nodes_ = number_of_nodes; }
-
-    void InitializeElementNodeConnectivity(int number_of_elements, int nodes_per_element) {
-        connectivity_ = Kokkos::View<int**>("connectivity", number_of_elements, nodes_per_element);
-    }
-
     KOKKOS_FUNCTION
     Kokkos::View<const int*> GetNodesForElement(int elementID) {
         return Kokkos::subview(connectivity_, elementID, Kokkos::ALL);
@@ -24,6 +17,63 @@ public:
     friend Mesh create1DMesh(int number_of_elements, int nodes_per_element);
 
 protected:
+    void SetNumberOfElements(int number_of_elements) { number_of_elements_ = number_of_elements; }
+    void SetNumberOfNodes(int number_of_nodes) { number_of_nodes_ = number_of_nodes; }
+
+    void InitializeElementNodeConnectivity(int number_of_elements, int nodes_per_element) {
+        connectivity_ = Kokkos::View<int**>("connectivity", number_of_elements, nodes_per_element);
+    }
+
+    void CheckElementConsistency() {
+        if (static_cast<unsigned>(number_of_elements_) != connectivity_.extent(0)) {
+            throw std::domain_error("Connectivity does not contain expected number of elements");
+        }
+    }
+
+    void CheckNodeIDConsistency() {
+        auto range_policy = Kokkos::MDRangePolicy<Kokkos::Rank<2>>(
+            {0, 0}, {connectivity_.extent(0), connectivity_.extent(1)}
+        );
+        int max_node_id;
+        Kokkos::parallel_reduce(
+            range_policy,
+            KOKKOS_LAMBDA(int i, int j, int& local_max) {
+                if (connectivity_(i, j) > local_max) {
+                    local_max = connectivity_(i, j);
+                }
+            },
+            Kokkos::Max<int>(max_node_id)
+        );
+
+        if (max_node_id >= number_of_nodes_) {
+            throw std::domain_error("Connectivity references node ID above the expected range");
+        }
+    }
+
+    void CheckNodeUniquenessConsistency() {
+        for (std::size_t element = 0; element < connectivity_.extent(0); ++element) {
+            auto node_list = GetNodesForElement(element);
+            auto host_node_list = Kokkos::create_mirror(node_list);
+            Kokkos::deep_copy(host_node_list, node_list);
+            auto node_list_vector = std::vector<int>(host_node_list.extent(0));
+            for (std::size_t node = 0; node < node_list_vector.size(); ++node) {
+                node_list_vector[node] = host_node_list(node);
+            }
+            std::sort(std::begin(node_list_vector), std::end(node_list_vector));
+            auto first_duplicate =
+                std::adjacent_find(std::begin(node_list_vector), std::end(node_list_vector));
+            if (first_duplicate != end(node_list_vector)) {
+                throw std::domain_error("Nodes within an element must be unique");
+            }
+        }
+    }
+
+    void CheckConsistency() {
+        CheckElementConsistency();
+        CheckNodeIDConsistency();
+        CheckNodeUniquenessConsistency();
+    }
+
     int number_of_elements_;
     int number_of_nodes_;
     Kokkos::View<int**> connectivity_;
@@ -42,6 +92,8 @@ inline Mesh create1DMesh(int number_of_elements, int nodes_per_element) {
     };
 
     Kokkos::parallel_for(number_of_elements, set_element_connectivity);
+
+    mesh.CheckConsistency();
     return mesh;
 }
 }  // namespace openturbine

--- a/src/gebt_poc/mesh.h
+++ b/src/gebt_poc/mesh.h
@@ -17,6 +17,7 @@ public:
     friend Mesh create1DMesh(int number_of_elements, int nodes_per_element);
 
 protected:
+    Mesh() = default;
     void SetNumberOfElements(int number_of_elements) { number_of_elements_ = number_of_elements; }
     void SetNumberOfNodes(int number_of_nodes) { number_of_nodes_ = number_of_nodes; }
 

--- a/tests/unit_tests/gebt_poc/CMakeLists.txt
+++ b/tests/unit_tests/gebt_poc/CMakeLists.txt
@@ -6,4 +6,5 @@ target_sources(
     test_model.cpp
     test_point.cpp
     test_section.cpp
+    test_mesh.cpp
 )

--- a/tests/unit_tests/gebt_poc/test_mesh.cpp
+++ b/tests/unit_tests/gebt_poc/test_mesh.cpp
@@ -6,7 +6,7 @@
 TEST(MeshTest, Create1DMesh_1Element_2Node) {
     int numberOfElements = 1;
     int nodesPerElement = 2;
-    auto mesh = openturbine::create1DMesh(numberOfElements, nodesPerElement);
+    auto mesh = openturbine::gebt_poc::create1DMesh(numberOfElements, nodesPerElement);
 
     EXPECT_EQ(mesh.GetNumberOfElements(), numberOfElements);
     EXPECT_EQ(mesh.GetNumberOfNodes(), 2);
@@ -23,7 +23,7 @@ TEST(MeshTest, Create1DMesh_1Element_2Node) {
 TEST(MeshTest, Create1DMesh_1Element_5Node) {
     int numberOfElements = 1;
     int nodesPerElement = 5;
-    auto mesh = openturbine::create1DMesh(numberOfElements, nodesPerElement);
+    auto mesh = openturbine::gebt_poc::create1DMesh(numberOfElements, nodesPerElement);
 
     EXPECT_EQ(mesh.GetNumberOfElements(), numberOfElements);
     EXPECT_EQ(mesh.GetNumberOfNodes(), 5);
@@ -43,7 +43,7 @@ TEST(MeshTest, Create1DMesh_1Element_5Node) {
 TEST(MeshTest, Create1DMesh_2Element_5Node) {
     int numberOfElements = 2;
     int nodesPerElement = 5;
-    auto mesh = openturbine::create1DMesh(numberOfElements, nodesPerElement);
+    auto mesh = openturbine::gebt_poc::create1DMesh(numberOfElements, nodesPerElement);
 
     EXPECT_EQ(mesh.GetNumberOfElements(), numberOfElements);
     EXPECT_EQ(mesh.GetNumberOfNodes(), 9);
@@ -78,7 +78,7 @@ TEST(MeshTest, Create1DMesh_2Element_5Node) {
 TEST(MeshTest, Create1DMesh_3Element_3Node) {
     int numberOfElements = 3;
     int nodesPerElement = 3;
-    auto mesh = openturbine::create1DMesh(numberOfElements, nodesPerElement);
+    auto mesh = openturbine::gebt_poc::create1DMesh(numberOfElements, nodesPerElement);
 
     EXPECT_EQ(mesh.GetNumberOfElements(), numberOfElements);
     EXPECT_EQ(mesh.GetNumberOfNodes(), 7);
@@ -117,8 +117,8 @@ TEST(MeshTest, Create1DMesh_3Element_3Node) {
     }
 }
 
-namespace openturbine::impl {
-class TestMesh : public openturbine::Mesh {
+namespace openturbine::gebt_poc::impl {
+class TestMesh : public openturbine::gebt_poc::Mesh {
 public:
     void TestSetNumberOfElements(int number_of_elements) { SetNumberOfElements(number_of_elements); }
     void TestSetNumberOfNodes(int number_of_nodes) { SetNumberOfNodes(number_of_nodes); }
@@ -131,10 +131,10 @@ public:
 
     Kokkos::View<int**> TestGetConnectivity() { return connectivity_; }
 };
-}  // namespace openturbine::impl
+}  // namespace openturbine::gebt_poc::impl
 
 TEST(MeshTest, CheckConsistency_WrongNumberOfElements) {
-    openturbine::impl::TestMesh mesh;
+    openturbine::gebt_poc::impl::TestMesh mesh;
 
     mesh.TestSetNumberOfElements(2);
     mesh.TestSetNumberOfNodes(5);
@@ -145,7 +145,7 @@ TEST(MeshTest, CheckConsistency_WrongNumberOfElements) {
 }
 
 TEST(MeshTest, CheckConsistency_InvalidNode) {
-    openturbine::impl::TestMesh mesh;
+    openturbine::gebt_poc::impl::TestMesh mesh;
 
     mesh.TestSetNumberOfElements(1);
     mesh.TestSetNumberOfNodes(2);
@@ -165,7 +165,7 @@ TEST(MeshTest, CheckConsistency_InvalidNode) {
 }
 
 TEST(MeshTest, CheckConsistency_NonUniqueNode) {
-    openturbine::impl::TestMesh mesh;
+    openturbine::gebt_poc::impl::TestMesh mesh;
 
     mesh.TestSetNumberOfElements(1);
     mesh.TestSetNumberOfNodes(3);
@@ -186,7 +186,7 @@ TEST(MeshTest, CheckConsistency_NonUniqueNode) {
 }
 
 TEST(MeshTest, CheckConsistency_NonUniqueNode_2Element) {
-    openturbine::impl::TestMesh mesh;
+    openturbine::gebt_poc::impl::TestMesh mesh;
 
     mesh.TestSetNumberOfElements(2);
     mesh.TestSetNumberOfNodes(5);
@@ -210,7 +210,7 @@ TEST(MeshTest, CheckConsistency_NonUniqueNode_2Element) {
 }
 
 TEST(MeshTest, CheckConsistency_Pass_Bar) {
-    openturbine::impl::TestMesh mesh;
+    openturbine::gebt_poc::impl::TestMesh mesh;
 
     mesh.TestSetNumberOfElements(2);
     mesh.TestSetNumberOfNodes(5);
@@ -234,7 +234,7 @@ TEST(MeshTest, CheckConsistency_Pass_Bar) {
 }
 
 TEST(MeshTest, CheckConsistency_Pass_Plus) {
-    openturbine::impl::TestMesh mesh;
+    openturbine::gebt_poc::impl::TestMesh mesh;
 
     mesh.TestSetNumberOfElements(4);
     mesh.TestSetNumberOfNodes(9);

--- a/tests/unit_tests/gebt_poc/test_mesh.cpp
+++ b/tests/unit_tests/gebt_poc/test_mesh.cpp
@@ -1,0 +1,117 @@
+#include <gtest/gtest.h>
+#include <Kokkos_Core.hpp>
+#include "src/gebt_poc/mesh.h" 
+
+TEST(MeshTest, Create1DMesh_1Element_2Node) {
+    int numberOfElements = 1;
+    int nodesPerElement = 2;
+    auto mesh = openturbine::create1DMesh(numberOfElements, nodesPerElement);
+
+    EXPECT_EQ(mesh.GetNumberOfElements(), numberOfElements);
+    EXPECT_EQ(mesh.GetNumberOfNodes(), 2);
+
+    auto nodeList = mesh.GetNodesForElement(0);
+    EXPECT_EQ(nodeList.extent(0), nodesPerElement);
+
+    auto hostNodeList = Kokkos::create_mirror(nodeList);
+    Kokkos::deep_copy(hostNodeList, nodeList);
+    EXPECT_EQ(hostNodeList(0), 0);
+    EXPECT_EQ(hostNodeList(1), 1);
+}
+
+TEST(MeshTest, Create1DMesh_1Element_5Node) {
+    int numberOfElements = 1;
+    int nodesPerElement = 5;
+    auto mesh = openturbine::create1DMesh(numberOfElements, nodesPerElement);
+
+    EXPECT_EQ(mesh.GetNumberOfElements(), numberOfElements);
+    EXPECT_EQ(mesh.GetNumberOfNodes(), 5);
+
+    auto nodeList = mesh.GetNodesForElement(0);
+    EXPECT_EQ(nodeList.extent(0), nodesPerElement);
+
+    auto hostNodeList = Kokkos::create_mirror(nodeList);
+    Kokkos::deep_copy(hostNodeList, nodeList);
+    EXPECT_EQ(hostNodeList(0), 0);
+    EXPECT_EQ(hostNodeList(1), 1);
+    EXPECT_EQ(hostNodeList(2), 2);
+    EXPECT_EQ(hostNodeList(3), 3);
+    EXPECT_EQ(hostNodeList(4), 4);
+}
+
+TEST(MeshTest, Create1DMesh_2Element_5Node) {
+    int numberOfElements = 2;
+    int nodesPerElement = 5;
+    auto mesh = openturbine::create1DMesh(numberOfElements, nodesPerElement);
+
+    EXPECT_EQ(mesh.GetNumberOfElements(), numberOfElements);
+    EXPECT_EQ(mesh.GetNumberOfNodes(), 9);
+    
+    {
+      auto nodeList = mesh.GetNodesForElement(0);
+      EXPECT_EQ(nodeList.extent(0), nodesPerElement);
+
+      auto hostNodeList = Kokkos::create_mirror(nodeList);
+      Kokkos::deep_copy(hostNodeList, nodeList);
+      EXPECT_EQ(hostNodeList(0), 0);
+      EXPECT_EQ(hostNodeList(1), 1);
+      EXPECT_EQ(hostNodeList(2), 2);
+      EXPECT_EQ(hostNodeList(3), 3);
+      EXPECT_EQ(hostNodeList(4), 4);
+    }
+    
+    {
+      auto nodeList = mesh.GetNodesForElement(1);
+      EXPECT_EQ(nodeList.extent(0), nodesPerElement);
+
+      auto hostNodeList = Kokkos::create_mirror(nodeList);
+      Kokkos::deep_copy(hostNodeList, nodeList);
+      EXPECT_EQ(hostNodeList(0), 4);
+      EXPECT_EQ(hostNodeList(1), 5);
+      EXPECT_EQ(hostNodeList(2), 6);
+      EXPECT_EQ(hostNodeList(3), 7);
+      EXPECT_EQ(hostNodeList(4), 8);
+    }
+}
+
+TEST(MeshTest, Create1DMesh_3Element_3Node) {
+    int numberOfElements = 3;
+    int nodesPerElement = 3;
+    auto mesh = openturbine::create1DMesh(numberOfElements, nodesPerElement);
+
+    EXPECT_EQ(mesh.GetNumberOfElements(), numberOfElements);
+    EXPECT_EQ(mesh.GetNumberOfNodes(), 7);
+    
+    {
+      auto nodeList = mesh.GetNodesForElement(0);
+      EXPECT_EQ(nodeList.extent(0), nodesPerElement);
+
+      auto hostNodeList = Kokkos::create_mirror(nodeList);
+      Kokkos::deep_copy(hostNodeList, nodeList);
+      EXPECT_EQ(hostNodeList(0), 0);
+      EXPECT_EQ(hostNodeList(1), 1);
+      EXPECT_EQ(hostNodeList(2), 2);
+    }
+    
+    {
+      auto nodeList = mesh.GetNodesForElement(1);
+      EXPECT_EQ(nodeList.extent(0), nodesPerElement);
+
+      auto hostNodeList = Kokkos::create_mirror(nodeList);
+      Kokkos::deep_copy(hostNodeList, nodeList);
+      EXPECT_EQ(hostNodeList(0), 2);
+      EXPECT_EQ(hostNodeList(1), 3);
+      EXPECT_EQ(hostNodeList(2), 4);
+    }
+
+    {
+      auto nodeList = mesh.GetNodesForElement(2);
+      EXPECT_EQ(nodeList.extent(0), nodesPerElement);
+
+      auto hostNodeList = Kokkos::create_mirror(nodeList);
+      Kokkos::deep_copy(hostNodeList, nodeList);
+      EXPECT_EQ(hostNodeList(0), 4);
+      EXPECT_EQ(hostNodeList(1), 5);
+      EXPECT_EQ(hostNodeList(2), 6);
+    }
+}

--- a/tests/unit_tests/gebt_poc/test_mesh.cpp
+++ b/tests/unit_tests/gebt_poc/test_mesh.cpp
@@ -6,7 +6,7 @@
 TEST(MeshTest, Create1DMesh_1Element_2Node) {
     int numberOfElements = 1;
     int nodesPerElement = 2;
-    auto mesh = openturbine::gebt_poc::create1DMesh(numberOfElements, nodesPerElement);
+    auto mesh = openturbine::gebt_poc::Create1DMesh(numberOfElements, nodesPerElement);
 
     EXPECT_EQ(mesh.GetNumberOfElements(), numberOfElements);
     EXPECT_EQ(mesh.GetNumberOfNodes(), 2);
@@ -23,7 +23,7 @@ TEST(MeshTest, Create1DMesh_1Element_2Node) {
 TEST(MeshTest, Create1DMesh_1Element_5Node) {
     int numberOfElements = 1;
     int nodesPerElement = 5;
-    auto mesh = openturbine::gebt_poc::create1DMesh(numberOfElements, nodesPerElement);
+    auto mesh = openturbine::gebt_poc::Create1DMesh(numberOfElements, nodesPerElement);
 
     EXPECT_EQ(mesh.GetNumberOfElements(), numberOfElements);
     EXPECT_EQ(mesh.GetNumberOfNodes(), 5);
@@ -43,7 +43,7 @@ TEST(MeshTest, Create1DMesh_1Element_5Node) {
 TEST(MeshTest, Create1DMesh_2Element_5Node) {
     int numberOfElements = 2;
     int nodesPerElement = 5;
-    auto mesh = openturbine::gebt_poc::create1DMesh(numberOfElements, nodesPerElement);
+    auto mesh = openturbine::gebt_poc::Create1DMesh(numberOfElements, nodesPerElement);
 
     EXPECT_EQ(mesh.GetNumberOfElements(), numberOfElements);
     EXPECT_EQ(mesh.GetNumberOfNodes(), 9);
@@ -78,7 +78,7 @@ TEST(MeshTest, Create1DMesh_2Element_5Node) {
 TEST(MeshTest, Create1DMesh_3Element_3Node) {
     int numberOfElements = 3;
     int nodesPerElement = 3;
-    auto mesh = openturbine::gebt_poc::create1DMesh(numberOfElements, nodesPerElement);
+    auto mesh = openturbine::gebt_poc::Create1DMesh(numberOfElements, nodesPerElement);
 
     EXPECT_EQ(mesh.GetNumberOfElements(), numberOfElements);
     EXPECT_EQ(mesh.GetNumberOfNodes(), 7);

--- a/tests/unit_tests/gebt_poc/test_mesh.cpp
+++ b/tests/unit_tests/gebt_poc/test_mesh.cpp
@@ -116,3 +116,149 @@ TEST(MeshTest, Create1DMesh_3Element_3Node) {
         EXPECT_EQ(hostNodeList(2), 6);
     }
 }
+
+namespace openturbine::impl {
+class TestMesh : public openturbine::Mesh {
+public:
+    void TestSetNumberOfElements(int number_of_elements) { SetNumberOfElements(number_of_elements); }
+    void TestSetNumberOfNodes(int number_of_nodes) { SetNumberOfNodes(number_of_nodes); }
+
+    void TestInitializeConnectivity(int number_of_elements, int nodes_per_element) {
+        InitializeElementNodeConnectivity(number_of_elements, nodes_per_element);
+    }
+
+    void TestCheckConsistency() { CheckConsistency(); }
+
+    Kokkos::View<int**> TestGetConnectivity() { return connectivity_; }
+};
+}  // namespace openturbine::impl
+
+TEST(MeshTest, CheckConsistency_WrongNumberOfElements) {
+    openturbine::impl::TestMesh mesh;
+
+    mesh.TestSetNumberOfElements(2);
+    mesh.TestSetNumberOfNodes(5);
+
+    mesh.TestInitializeConnectivity(1, 5);
+
+    EXPECT_THROW(mesh.TestCheckConsistency(), std::domain_error);
+}
+
+TEST(MeshTest, CheckConsistency_InvalidNode) {
+    openturbine::impl::TestMesh mesh;
+
+    mesh.TestSetNumberOfElements(1);
+    mesh.TestSetNumberOfNodes(2);
+
+    mesh.TestInitializeConnectivity(1, 2);
+
+    auto connectivity = mesh.TestGetConnectivity();
+    Kokkos::parallel_for(
+        1,
+        KOKKOS_LAMBDA(int) {
+            connectivity(0, 0) = 0;
+            connectivity(0, 1) = 2;
+        }
+    );
+
+    EXPECT_THROW(mesh.TestCheckConsistency(), std::domain_error);
+}
+
+TEST(MeshTest, CheckConsistency_NonUniqueNode) {
+    openturbine::impl::TestMesh mesh;
+
+    mesh.TestSetNumberOfElements(1);
+    mesh.TestSetNumberOfNodes(3);
+
+    mesh.TestInitializeConnectivity(1, 3);
+
+    auto connectivity = mesh.TestGetConnectivity();
+    Kokkos::parallel_for(
+        1,
+        KOKKOS_LAMBDA(int) {
+            connectivity(0, 0) = 0;
+            connectivity(0, 1) = 1;
+            connectivity(0, 2) = 0;
+        }
+    );
+
+    EXPECT_THROW(mesh.TestCheckConsistency(), std::domain_error);
+}
+
+TEST(MeshTest, CheckConsistency_NonUniqueNode_2Element) {
+    openturbine::impl::TestMesh mesh;
+
+    mesh.TestSetNumberOfElements(2);
+    mesh.TestSetNumberOfNodes(5);
+
+    mesh.TestInitializeConnectivity(2, 3);
+
+    auto connectivity = mesh.TestGetConnectivity();
+    Kokkos::parallel_for(
+        1,
+        KOKKOS_LAMBDA(int) {
+            connectivity(0, 0) = 0;
+            connectivity(0, 1) = 1;
+            connectivity(0, 2) = 2;
+            connectivity(1, 0) = 2;
+            connectivity(1, 1) = 3;
+            connectivity(1, 2) = 3;
+        }
+    );
+
+    EXPECT_THROW(mesh.TestCheckConsistency(), std::domain_error);
+}
+
+TEST(MeshTest, CheckConsistency_Pass_Bar) {
+    openturbine::impl::TestMesh mesh;
+
+    mesh.TestSetNumberOfElements(2);
+    mesh.TestSetNumberOfNodes(5);
+
+    mesh.TestInitializeConnectivity(2, 3);
+
+    auto connectivity = mesh.TestGetConnectivity();
+    Kokkos::parallel_for(
+        1,
+        KOKKOS_LAMBDA(int) {
+            connectivity(0, 0) = 0;
+            connectivity(0, 1) = 1;
+            connectivity(0, 2) = 2;
+            connectivity(1, 0) = 2;
+            connectivity(1, 1) = 3;
+            connectivity(1, 2) = 4;
+        }
+    );
+
+    EXPECT_NO_THROW(mesh.TestCheckConsistency());
+}
+
+TEST(MeshTest, CheckConsistency_Pass_Plus) {
+    openturbine::impl::TestMesh mesh;
+
+    mesh.TestSetNumberOfElements(4);
+    mesh.TestSetNumberOfNodes(9);
+
+    mesh.TestInitializeConnectivity(4, 3);
+
+    auto connectivity = mesh.TestGetConnectivity();
+    Kokkos::parallel_for(
+        1,
+        KOKKOS_LAMBDA(int) {
+            connectivity(0, 0) = 0;
+            connectivity(0, 1) = 1;
+            connectivity(0, 2) = 2;
+            connectivity(1, 0) = 2;
+            connectivity(1, 1) = 3;
+            connectivity(1, 2) = 4;
+            connectivity(2, 0) = 2;
+            connectivity(2, 1) = 5;
+            connectivity(2, 2) = 6;
+            connectivity(3, 0) = 2;
+            connectivity(3, 1) = 7;
+            connectivity(3, 2) = 8;
+        }
+    );
+
+    EXPECT_NO_THROW(mesh.TestCheckConsistency());
+}

--- a/tests/unit_tests/gebt_poc/test_mesh.cpp
+++ b/tests/unit_tests/gebt_poc/test_mesh.cpp
@@ -1,6 +1,7 @@
-#include <gtest/gtest.h>
 #include <Kokkos_Core.hpp>
-#include "src/gebt_poc/mesh.h" 
+#include <gtest/gtest.h>
+
+#include "src/gebt_poc/mesh.h"
 
 TEST(MeshTest, Create1DMesh_1Element_2Node) {
     int numberOfElements = 1;
@@ -46,31 +47,31 @@ TEST(MeshTest, Create1DMesh_2Element_5Node) {
 
     EXPECT_EQ(mesh.GetNumberOfElements(), numberOfElements);
     EXPECT_EQ(mesh.GetNumberOfNodes(), 9);
-    
-    {
-      auto nodeList = mesh.GetNodesForElement(0);
-      EXPECT_EQ(nodeList.extent(0), nodesPerElement);
 
-      auto hostNodeList = Kokkos::create_mirror(nodeList);
-      Kokkos::deep_copy(hostNodeList, nodeList);
-      EXPECT_EQ(hostNodeList(0), 0);
-      EXPECT_EQ(hostNodeList(1), 1);
-      EXPECT_EQ(hostNodeList(2), 2);
-      EXPECT_EQ(hostNodeList(3), 3);
-      EXPECT_EQ(hostNodeList(4), 4);
+    {
+        auto nodeList = mesh.GetNodesForElement(0);
+        EXPECT_EQ(nodeList.extent(0), nodesPerElement);
+
+        auto hostNodeList = Kokkos::create_mirror(nodeList);
+        Kokkos::deep_copy(hostNodeList, nodeList);
+        EXPECT_EQ(hostNodeList(0), 0);
+        EXPECT_EQ(hostNodeList(1), 1);
+        EXPECT_EQ(hostNodeList(2), 2);
+        EXPECT_EQ(hostNodeList(3), 3);
+        EXPECT_EQ(hostNodeList(4), 4);
     }
-    
-    {
-      auto nodeList = mesh.GetNodesForElement(1);
-      EXPECT_EQ(nodeList.extent(0), nodesPerElement);
 
-      auto hostNodeList = Kokkos::create_mirror(nodeList);
-      Kokkos::deep_copy(hostNodeList, nodeList);
-      EXPECT_EQ(hostNodeList(0), 4);
-      EXPECT_EQ(hostNodeList(1), 5);
-      EXPECT_EQ(hostNodeList(2), 6);
-      EXPECT_EQ(hostNodeList(3), 7);
-      EXPECT_EQ(hostNodeList(4), 8);
+    {
+        auto nodeList = mesh.GetNodesForElement(1);
+        EXPECT_EQ(nodeList.extent(0), nodesPerElement);
+
+        auto hostNodeList = Kokkos::create_mirror(nodeList);
+        Kokkos::deep_copy(hostNodeList, nodeList);
+        EXPECT_EQ(hostNodeList(0), 4);
+        EXPECT_EQ(hostNodeList(1), 5);
+        EXPECT_EQ(hostNodeList(2), 6);
+        EXPECT_EQ(hostNodeList(3), 7);
+        EXPECT_EQ(hostNodeList(4), 8);
     }
 }
 
@@ -81,37 +82,37 @@ TEST(MeshTest, Create1DMesh_3Element_3Node) {
 
     EXPECT_EQ(mesh.GetNumberOfElements(), numberOfElements);
     EXPECT_EQ(mesh.GetNumberOfNodes(), 7);
-    
-    {
-      auto nodeList = mesh.GetNodesForElement(0);
-      EXPECT_EQ(nodeList.extent(0), nodesPerElement);
 
-      auto hostNodeList = Kokkos::create_mirror(nodeList);
-      Kokkos::deep_copy(hostNodeList, nodeList);
-      EXPECT_EQ(hostNodeList(0), 0);
-      EXPECT_EQ(hostNodeList(1), 1);
-      EXPECT_EQ(hostNodeList(2), 2);
-    }
-    
     {
-      auto nodeList = mesh.GetNodesForElement(1);
-      EXPECT_EQ(nodeList.extent(0), nodesPerElement);
+        auto nodeList = mesh.GetNodesForElement(0);
+        EXPECT_EQ(nodeList.extent(0), nodesPerElement);
 
-      auto hostNodeList = Kokkos::create_mirror(nodeList);
-      Kokkos::deep_copy(hostNodeList, nodeList);
-      EXPECT_EQ(hostNodeList(0), 2);
-      EXPECT_EQ(hostNodeList(1), 3);
-      EXPECT_EQ(hostNodeList(2), 4);
+        auto hostNodeList = Kokkos::create_mirror(nodeList);
+        Kokkos::deep_copy(hostNodeList, nodeList);
+        EXPECT_EQ(hostNodeList(0), 0);
+        EXPECT_EQ(hostNodeList(1), 1);
+        EXPECT_EQ(hostNodeList(2), 2);
     }
 
     {
-      auto nodeList = mesh.GetNodesForElement(2);
-      EXPECT_EQ(nodeList.extent(0), nodesPerElement);
+        auto nodeList = mesh.GetNodesForElement(1);
+        EXPECT_EQ(nodeList.extent(0), nodesPerElement);
 
-      auto hostNodeList = Kokkos::create_mirror(nodeList);
-      Kokkos::deep_copy(hostNodeList, nodeList);
-      EXPECT_EQ(hostNodeList(0), 4);
-      EXPECT_EQ(hostNodeList(1), 5);
-      EXPECT_EQ(hostNodeList(2), 6);
+        auto hostNodeList = Kokkos::create_mirror(nodeList);
+        Kokkos::deep_copy(hostNodeList, nodeList);
+        EXPECT_EQ(hostNodeList(0), 2);
+        EXPECT_EQ(hostNodeList(1), 3);
+        EXPECT_EQ(hostNodeList(2), 4);
+    }
+
+    {
+        auto nodeList = mesh.GetNodesForElement(2);
+        EXPECT_EQ(nodeList.extent(0), nodesPerElement);
+
+        auto hostNodeList = Kokkos::create_mirror(nodeList);
+        Kokkos::deep_copy(hostNodeList, nodeList);
+        EXPECT_EQ(hostNodeList(0), 4);
+        EXPECT_EQ(hostNodeList(1), 5);
+        EXPECT_EQ(hostNodeList(2), 6);
     }
 }


### PR DESCRIPTION
This data structure provides an association of elements to nodes, so that we can loop elements and extract which nodes are owned by each one.  State data (positions, velocities, etc) will be stored externally and reference this structure for sizing/access.  The key assembly loops will be parallel over elements, then gather/scatter based on nodal indices.

This is a very simple mesh, but it should meet our needs for now.  One requirement is that all elements have the same number of nodes.