### PR TITLE
Implements a simple field data structure for nodal/element data

### DIFF
--- a/src/gebt_poc/field_data.h
+++ b/src/gebt_poc/field_data.h
@@ -23,17 +23,19 @@ public:
     FieldData(const Mesh& mesh, int number_of_quadrature_points) {
         auto number_of_nodes = mesh.GetNumberOfNodes();
         auto number_of_elements = mesh.GetNumberOfElements();
+        auto lie_group_size = 7;
+        auto lie_algebra_size = 6;
 
-        coordinates_ = Kokkos::View<double**>("coordinates", number_of_nodes, 3);
-        velocity_ = Kokkos::View<double**>("velocity", number_of_nodes, 3);
-        acceleration_ = Kokkos::View<double**>("acceleration", number_of_nodes, 3);
+        coordinates_ = Kokkos::View<double**>("coordinates", number_of_nodes, lie_group_size);
+        velocity_ = Kokkos::View<double**>("velocity", number_of_nodes, lie_algebra_size);
+        acceleration_ = Kokkos::View<double**>("acceleration", number_of_nodes, lie_algebra_size);
         algorithmic_acceleration_ =
-            Kokkos::View<double**>("algorithmic_acceleration", number_of_nodes, 3);
+            Kokkos::View<double**>("algorithmic_acceleration", number_of_nodes, lie_algebra_size);
 
-        coordinates_next_ = Kokkos::View<double**>("coordinates_next", number_of_nodes, 3);
+        coordinates_next_ = Kokkos::View<double**>("coordinates_next", number_of_nodes, lie_group_size);
         algorithmic_acceleration_next_ =
-            Kokkos::View<double**>("algorithmic_acceleration_next", number_of_nodes, 3);
-        delta_coordinates_ = Kokkos::View<double**>("delta_coordinates", number_of_nodes, 3);
+            Kokkos::View<double**>("algorithmic_acceleration_next", number_of_nodes, lie_algebra_size);
+        delta_coordinates_ = Kokkos::View<double**>("delta_coordinates", number_of_nodes, lie_algebra_size);
 
         weight_ = Kokkos::View<double**>("weight", number_of_elements, number_of_quadrature_points);
         stiffness_matrix_ = Kokkos::View<double****>(

--- a/src/gebt_poc/field_data.h
+++ b/src/gebt_poc/field_data.h
@@ -32,10 +32,13 @@ public:
         algorithmic_acceleration_ =
             Kokkos::View<double**>("algorithmic_acceleration", number_of_nodes, lie_algebra_size);
 
-        coordinates_next_ = Kokkos::View<double**>("coordinates_next", number_of_nodes, lie_group_size);
-        algorithmic_acceleration_next_ =
-            Kokkos::View<double**>("algorithmic_acceleration_next", number_of_nodes, lie_algebra_size);
-        delta_coordinates_ = Kokkos::View<double**>("delta_coordinates", number_of_nodes, lie_algebra_size);
+        coordinates_next_ =
+            Kokkos::View<double**>("coordinates_next", number_of_nodes, lie_group_size);
+        algorithmic_acceleration_next_ = Kokkos::View<double**>(
+            "algorithmic_acceleration_next", number_of_nodes, lie_algebra_size
+        );
+        delta_coordinates_ =
+            Kokkos::View<double**>("delta_coordinates", number_of_nodes, lie_algebra_size);
 
         weight_ = Kokkos::View<double**>("weight", number_of_elements, number_of_quadrature_points);
         stiffness_matrix_ = Kokkos::View<double****>(
@@ -65,7 +68,8 @@ public:
     }
 
     template <Field field>
-    KOKKOS_FUNCTION auto ReadNodalData(int node) const -> typename decltype(GetNodalData<field>(node))::const_type {
+    KOKKOS_FUNCTION auto ReadNodalData(int node) const ->
+        typename decltype(GetNodalData<field>(node))::const_type {
         return GetNodalData<field>(node);
     }
 
@@ -84,7 +88,8 @@ public:
     }
 
     template <Field field>
-    KOKKOS_FUNCTION auto ReadElementData(int element) const -> typename decltype(GetElementData<field>(element))::const_type {
+    KOKKOS_FUNCTION auto ReadElementData(int element) const ->
+        typename decltype(GetElementData<field>(element))::const_type {
         return GetElementData<field>(element);
     }
 

--- a/src/gebt_poc/field_data.h
+++ b/src/gebt_poc/field_data.h
@@ -1,0 +1,102 @@
+#pragma once
+
+#include <Kokkos_Core.hpp>
+
+#include "mesh.h"
+
+namespace openturbine::gebt_poc {
+
+enum class Field {
+    Coordinates,
+    Velocity,
+    Acceleration,
+    AlgorithmicAcceleration,
+    CoordinatesNext,
+    AlgorithmicAccelerationNext,
+    DeltaCoordinates,
+    Weight,
+    StiffnessMatrix
+};
+
+class FieldData {
+public:
+    FieldData(const Mesh& mesh, int number_of_quadrature_points) {
+        auto number_of_nodes = mesh.GetNumberOfNodes();
+        auto number_of_elements = mesh.GetNumberOfElements();
+
+        coordinates_ = Kokkos::View<double**>("coordinates", number_of_nodes, 3);
+        velocity_ = Kokkos::View<double**>("velocity", number_of_nodes, 3);
+        acceleration_ = Kokkos::View<double**>("acceleration", number_of_nodes, 3);
+        algorithmic_acceleration_ =
+            Kokkos::View<double**>("algorithmic_acceleration", number_of_nodes, 3);
+
+        coordinates_next_ = Kokkos::View<double**>("coordinates_next", number_of_nodes, 3);
+        algorithmic_acceleration_next_ =
+            Kokkos::View<double**>("algorithmic_acceleration_next", number_of_nodes, 3);
+        delta_coordinates_ = Kokkos::View<double**>("delta_coordinates", number_of_nodes, 3);
+
+        weight_ = Kokkos::View<double**>("weight", number_of_elements, number_of_quadrature_points);
+        stiffness_matrix_ = Kokkos::View<double****>(
+            "stiffness", number_of_elements, number_of_quadrature_points, 6, 6
+        );
+    }
+
+    template <Field field>
+    KOKKOS_FUNCTION Kokkos::View<double*> GetNodalData(int node) const {
+        if constexpr (field == Field::Coordinates) {
+            return Kokkos::subview(coordinates_, node, Kokkos::ALL);
+        } else if constexpr (field == Field::Velocity) {
+            return Kokkos::subview(velocity_, node, Kokkos::ALL);
+        } else if constexpr (field == Field::Acceleration) {
+            return Kokkos::subview(acceleration_, node, Kokkos::ALL);
+        } else if constexpr (field == Field::AlgorithmicAcceleration) {
+            return Kokkos::subview(algorithmic_acceleration_, node, Kokkos::ALL);
+        } else if constexpr (field == Field::CoordinatesNext) {
+            return Kokkos::subview(coordinates_next_, node, Kokkos::ALL);
+        } else if constexpr (field == Field::AlgorithmicAccelerationNext) {
+            return Kokkos::subview(algorithmic_acceleration_next_, node, Kokkos::ALL);
+        } else if constexpr (field == Field::DeltaCoordinates) {
+            return Kokkos::subview(delta_coordinates_, node, Kokkos::ALL);
+        } else
+            Kokkos::abort("Provided Field is not a Nodal Field");
+    }
+
+    template <Field field>
+    KOKKOS_FUNCTION Kokkos::View<const double*> ReadNodalData(int node) const {
+        return GetNodalData<field>(node);
+    }
+
+    template <Field field>
+    KOKKOS_FUNCTION auto GetElementData(int element) const {
+        if constexpr (field == Field::Weight) {
+            return Kokkos::subview(weight_, element, Kokkos::ALL);
+        }
+        if constexpr (field == Field::StiffnessMatrix) {
+            return Kokkos::subview(
+                stiffness_matrix_, element, Kokkos::ALL, Kokkos::ALL, Kokkos::ALL
+            );
+        } else {
+            Kokkos::abort("Provided Field is not an Element Field");
+        }
+    }
+
+    template <Field field>
+    KOKKOS_FUNCTION auto ReadElementData(int element) const {
+        return GetElementData<field>(element);
+    }
+
+protected:
+    Kokkos::View<double**> coordinates_;
+    Kokkos::View<double**> velocity_;
+    Kokkos::View<double**> acceleration_;
+    Kokkos::View<double**> algorithmic_acceleration_;
+
+    Kokkos::View<double**> coordinates_next_;
+    Kokkos::View<double**> algorithmic_acceleration_next_;
+    Kokkos::View<double**> delta_coordinates_;
+
+    Kokkos::View<double**> weight_;
+    Kokkos::View<double****> stiffness_matrix_;
+};
+
+}  // namespace openturbine::gebt_poc

--- a/src/gebt_poc/field_data.h
+++ b/src/gebt_poc/field_data.h
@@ -42,7 +42,7 @@ public:
     }
 
     template <Field field>
-    KOKKOS_FUNCTION Kokkos::View<double*> GetNodalData(int node) const {
+    KOKKOS_FUNCTION auto GetNodalData(int node) const {
         if constexpr (field == Field::Coordinates) {
             return Kokkos::subview(coordinates_, node, Kokkos::ALL);
         } else if constexpr (field == Field::Velocity) {
@@ -57,12 +57,13 @@ public:
             return Kokkos::subview(algorithmic_acceleration_next_, node, Kokkos::ALL);
         } else if constexpr (field == Field::DeltaCoordinates) {
             return Kokkos::subview(delta_coordinates_, node, Kokkos::ALL);
-        } else
+        } else {
             Kokkos::abort("Provided Field is not a Nodal Field");
+        }
     }
 
     template <Field field>
-    KOKKOS_FUNCTION Kokkos::View<const double*> ReadNodalData(int node) const {
+    KOKKOS_FUNCTION auto ReadNodalData(int node) const -> typename decltype(GetNodalData<field>(node))::const_type {
         return GetNodalData<field>(node);
     }
 
@@ -81,7 +82,7 @@ public:
     }
 
     template <Field field>
-    KOKKOS_FUNCTION auto ReadElementData(int element) const {
+    KOKKOS_FUNCTION auto ReadElementData(int element) const -> typename decltype(GetElementData<field>(element))::const_type {
         return GetElementData<field>(element);
     }
 

--- a/tests/unit_tests/gebt_poc/CMakeLists.txt
+++ b/tests/unit_tests/gebt_poc/CMakeLists.txt
@@ -8,4 +8,5 @@ target_sources(
     test_point.cpp
     test_section.cpp
     test_mesh.cpp
+    test_field_data.cpp
 )

--- a/tests/unit_tests/gebt_poc/test_field_data.cpp
+++ b/tests/unit_tests/gebt_poc/test_field_data.cpp
@@ -12,9 +12,9 @@ void initializeNodalData(
         mesh.GetNumberOfNodes(),
         KOKKOS_LAMBDA(int node) {
             auto nodal_values = field_data.GetNodalData<field>(node);
-            nodal_values(0) = multiplier * (node * 3.);
-            nodal_values(1) = multiplier * (node * 3. + 1.);
-            nodal_values(2) = multiplier * (node * 3. + 2.);
+            for(std::size_t component = 0; component < nodal_values.extent(0); ++component) {
+              nodal_values(component) = multiplier * (node * nodal_values.extent(0) + component);
+            }
         }
     );
 }
@@ -26,12 +26,11 @@ void readNodalData(
 ) {
     for (int node = 0; node < mesh.GetNumberOfNodes(); ++node) {
         auto nodal_values = field_data.ReadNodalData<field>(node);
-        EXPECT_EQ(nodal_values.extent(0), 3);
         auto host_values = Kokkos::create_mirror(nodal_values);
         Kokkos::deep_copy(host_values, nodal_values);
-        EXPECT_EQ(host_values(0), multiplier * (node * 3.));
-        EXPECT_EQ(host_values(1), multiplier * (node * 3. + 1.));
-        EXPECT_EQ(host_values(2), multiplier * (node * 3. + 2.));
+        for(std::size_t component = 0; component < host_values.extent(0); ++ component) {
+          EXPECT_EQ(host_values(component), multiplier * (node * host_values.extent(0) + component));
+        }
     }
 }
 

--- a/tests/unit_tests/gebt_poc/test_field_data.cpp
+++ b/tests/unit_tests/gebt_poc/test_field_data.cpp
@@ -1,0 +1,121 @@
+#include <Kokkos_Core.hpp>
+#include <gtest/gtest.h>
+
+#include "src/gebt_poc/field_data.h"
+
+template <openturbine::gebt_poc::Field field>
+void initializeNodalData(
+    const openturbine::gebt_poc::Mesh& mesh, openturbine::gebt_poc::FieldData& field_data,
+    double multiplier
+) {
+    Kokkos::parallel_for(
+        mesh.GetNumberOfNodes(),
+        KOKKOS_LAMBDA(int node) {
+            auto nodal_values = field_data.GetNodalData<field>(node);
+            nodal_values(0) = multiplier * (node * 3.);
+            nodal_values(1) = multiplier * (node * 3. + 1.);
+            nodal_values(2) = multiplier * (node * 3. + 2.);
+        }
+    );
+}
+
+template <openturbine::gebt_poc::Field field>
+void readNodalData(
+    const openturbine::gebt_poc::Mesh& mesh, openturbine::gebt_poc::FieldData& field_data,
+    double multiplier
+) {
+    for (int node = 0; node < mesh.GetNumberOfNodes(); ++node) {
+        auto nodal_values = field_data.ReadNodalData<field>(node);
+        EXPECT_EQ(nodal_values.extent(0), 3);
+        auto host_values = Kokkos::create_mirror(nodal_values);
+        Kokkos::deep_copy(host_values, nodal_values);
+        EXPECT_EQ(host_values(0), multiplier * (node * 3.));
+        EXPECT_EQ(host_values(1), multiplier * (node * 3. + 1.));
+        EXPECT_EQ(host_values(2), multiplier * (node * 3. + 2.));
+    }
+}
+
+TEST(FieldDataTest, CreateNodalDataAndAccess) {
+    int number_of_elements = 2;
+    int nodes_per_element = 3;
+    auto mesh = openturbine::gebt_poc::Create1DMesh(number_of_elements, nodes_per_element);
+    auto field_data = openturbine::gebt_poc::FieldData(mesh, 1);
+    using openturbine::gebt_poc::Field;
+
+    initializeNodalData<Field::Coordinates>(mesh, field_data, 1.);
+    initializeNodalData<Field::Velocity>(mesh, field_data, 2.);
+    initializeNodalData<Field::Acceleration>(mesh, field_data, 3.);
+    initializeNodalData<Field::AlgorithmicAcceleration>(mesh, field_data, 4.);
+    initializeNodalData<Field::CoordinatesNext>(mesh, field_data, 5.);
+    initializeNodalData<Field::AlgorithmicAccelerationNext>(mesh, field_data, 6.);
+    initializeNodalData<Field::DeltaCoordinates>(mesh, field_data, 7.);
+
+    readNodalData<Field::Coordinates>(mesh, field_data, 1.);
+    readNodalData<Field::Velocity>(mesh, field_data, 2.);
+    readNodalData<Field::Acceleration>(mesh, field_data, 3.);
+    readNodalData<Field::AlgorithmicAcceleration>(mesh, field_data, 4.);
+    readNodalData<Field::CoordinatesNext>(mesh, field_data, 5.);
+    readNodalData<Field::AlgorithmicAccelerationNext>(mesh, field_data, 6.);
+    readNodalData<Field::DeltaCoordinates>(mesh, field_data, 7.);
+}
+
+TEST(FieldDataTest, CreateElementDataAndAccess) {
+    int number_of_elements = 2;
+    int nodes_per_element = 3;
+    int quadrature_points_per_element = 4;
+    auto mesh = openturbine::gebt_poc::Create1DMesh(number_of_elements, nodes_per_element);
+    auto field_data = openturbine::gebt_poc::FieldData(mesh, quadrature_points_per_element);
+    using openturbine::gebt_poc::Field;
+
+    Kokkos::parallel_for(
+        mesh.GetNumberOfElements(),
+        KOKKOS_LAMBDA(int element) {
+            auto weights = field_data.GetElementData<Field::Weight>(element);
+            weights(0) = element * 4.;
+            weights(1) = element * 4. + 1.;
+            weights(2) = element * 4. + 2.;
+            weights(3) = element * 4. + 3.;
+        }
+    );
+
+    for (int element = 0; element < number_of_elements; ++element) {
+        auto weights = field_data.ReadElementData<Field::Weight>(element);
+        EXPECT_EQ(weights.extent(0), 4);
+        auto host_weights = Kokkos::create_mirror(weights);
+        Kokkos::deep_copy(host_weights, weights);
+        EXPECT_EQ(host_weights(0), element * 4.);
+        EXPECT_EQ(host_weights(1), element * 4. + 1.);
+        EXPECT_EQ(host_weights(2), element * 4. + 2.);
+        EXPECT_EQ(host_weights(3), element * 4. + 3.);
+    }
+
+    Kokkos::parallel_for(
+        mesh.GetNumberOfElements(),
+        KOKKOS_LAMBDA(int element) {
+            auto stiffness = field_data.GetElementData<Field::StiffnessMatrix>(element);
+            for (int point = 0; point < quadrature_points_per_element; ++point) {
+                for (int row = 0; row < 6; ++row) {
+                    for (int column = 0; column < 6; ++column) {
+                        stiffness(point, row, column) = point * row * column;
+                    }
+                }
+            }
+        }
+    );
+
+    for (int element = 0; element < number_of_elements; ++element) {
+        auto stiffness = field_data.ReadElementData<Field::StiffnessMatrix>(element);
+        EXPECT_EQ(stiffness.extent(0), 4);
+        EXPECT_EQ(stiffness.extent(1), 6);
+        EXPECT_EQ(stiffness.extent(2), 6);
+        auto host_stiffness = Kokkos::create_mirror(stiffness);
+        Kokkos::deep_copy(host_stiffness, stiffness);
+        for (int point = 0; point < quadrature_points_per_element; ++point) {
+            for (int row = 0; row < 6; ++row) {
+                for (int column = 0; column < 6; ++column) {
+                    EXPECT_EQ(host_stiffness(point, row, column), point * row * column);
+                }
+            }
+        }
+    }
+}

--- a/tests/unit_tests/gebt_poc/test_field_data.cpp
+++ b/tests/unit_tests/gebt_poc/test_field_data.cpp
@@ -12,8 +12,8 @@ void initializeNodalData(
         mesh.GetNumberOfNodes(),
         KOKKOS_LAMBDA(int node) {
             auto nodal_values = field_data.GetNodalData<field>(node);
-            for(std::size_t component = 0; component < nodal_values.extent(0); ++component) {
-              nodal_values(component) = multiplier * (node * nodal_values.extent(0) + component);
+            for (std::size_t component = 0; component < nodal_values.extent(0); ++component) {
+                nodal_values(component) = multiplier * (node * nodal_values.extent(0) + component);
             }
         }
     );
@@ -28,8 +28,10 @@ void readNodalData(
         auto nodal_values = field_data.ReadNodalData<field>(node);
         auto host_values = Kokkos::create_mirror(nodal_values);
         Kokkos::deep_copy(host_values, nodal_values);
-        for(std::size_t component = 0; component < host_values.extent(0); ++ component) {
-          EXPECT_EQ(host_values(component), multiplier * (node * host_values.extent(0) + component));
+        for (std::size_t component = 0; component < host_values.extent(0); ++component) {
+            EXPECT_EQ(
+                host_values(component), multiplier * (node * host_values.extent(0) + component)
+            );
         }
     }
 }


### PR DESCRIPTION
This structure will hold our data and give us both read/write access (Get... methods) and read-only access (Read... methods). The current set of fields are placeholders, and more should be added as necessary.  Linear algebra objects (residual, iteration matrix, etc) should be stored outside of this structure.