### PR TITLE
Calculate the static residual for a single beam element

### DIFF
--- a/src/gebt_poc/CMakeLists.txt
+++ b/src/gebt_poc/CMakeLists.txt
@@ -4,4 +4,5 @@ target_sources(${oturb_lib_name}
     interpolation.cpp
     model.cpp
     section.cpp
+    solver.cpp
 )

--- a/src/gebt_poc/solver.cpp
+++ b/src/gebt_poc/solver.cpp
@@ -1,0 +1,12 @@
+#include "src/gebt_poc/solver.h"
+
+namespace openturbine::gebt_poc {
+
+UserDefinedQuadratureRule::UserDefinedQuadratureRule(
+    std::vector<double> quadrature_points, std::vector<double> quadrature_weights
+)
+    : quadrature_points_(std::move(quadrature_points)),
+      quadrature_weights_(std::move(quadrature_weights)) {
+}
+
+}  // namespace openturbine::gebt_poc

--- a/src/gebt_poc/solver.cpp
+++ b/src/gebt_poc/solver.cpp
@@ -1,12 +1,166 @@
 #include "src/gebt_poc/solver.h"
 
+#include "src/gen_alpha_poc/quaternion.h"
+
 namespace openturbine::gebt_poc {
 
-UserDefinedQuadratureRule::UserDefinedQuadratureRule(
+UserDefinedQuadrature::UserDefinedQuadrature(
     std::vector<double> quadrature_points, std::vector<double> quadrature_weights
 )
     : quadrature_points_(std::move(quadrature_points)),
       quadrature_weights_(std::move(quadrature_weights)) {
+}
+
+Kokkos::View<double*> CalculateStaticResidual(
+    const Kokkos::View<double*> position_vectors, const Kokkos::View<double*> gen_coords,
+    const StiffnessMatrix& stiffness, const Quadrature& quadrature
+) {
+    const auto n_nodes = gen_coords.extent(0) / kNumberOfLieAlgebraComponents;
+    const auto order = n_nodes - 1;
+    const auto n_quad_pts = quadrature.GetNumberOfQuadraturePoints();
+
+    auto residual = Kokkos::View<double* [6]>("static_residual");
+    Kokkos::deep_copy(residual, 0.);
+    for (size_t i = 0; i < n_nodes; ++i) {
+        for (size_t j = 0; j < n_quad_pts; ++j) {
+            // Calculate the interpolated values at the quadrature point of the element
+            const auto qp = quadrature.GetQuadraturePoints()[j];
+            const auto qw = quadrature.GetQuadratureWeights()[j];
+            auto shape_function = LagrangePolynomial(order, qp);
+            auto shape_function_derivative = LagrangePolynomialDerivative(order, qp);
+
+            auto gen_coords_qp = Kokkos::View<double*>(
+                "gen_coords_at_quadrature_point", kNumberOfLieAlgebraComponents
+            );
+            auto gen_coords_derivatives_qp = Kokkos::View<double*>(
+                "gen_coords_derivatives_at_quadrature_point", kNumberOfLieAlgebraComponents
+            );
+            auto position_vector_qp = Kokkos::View<double*>(
+                "position_vector_at_quadrature_point", kNumberOfLieAlgebraComponents
+            );
+            auto position_vector_derivatives_qp = Kokkos::View<double*>(
+                "position_vector_derivatives_at_quadrature_point", kNumberOfLieAlgebraComponents
+            );
+            Kokkos::parallel_for(
+                Kokkos::MDRangePolicy<Kokkos::DefaultExecutionSpace, Kokkos::Rank<2>>(
+                    {0, 0}, {kNumberOfLieAlgebraComponents, n_nodes}
+                ),
+                KOKKOS_LAMBDA(const size_t i, const size_t j) {
+                    gen_coords_qp(i) += shape_function[j] * gen_coords(j * 7 + i);
+                    gen_coords_derivatives_qp(i) +=
+                        shape_function_derivative[j] * gen_coords(j * 7 + i);
+                    position_vector_qp(i) += shape_function[j] * position_vectors(j * 7 + i);
+                    position_vector_derivatives_qp(i) +=
+                        shape_function_derivative[j] * position_vectors(j * 7 + i);
+                }
+            );
+
+            // Calculate the curvature vector at the quadrature point
+            auto q = gen_alpha_solver::Quaternion(
+                gen_coords_qp(3), gen_coords_qp(4), gen_coords_qp(5), gen_coords_qp(6)
+            );
+            auto b_matrix_quaternion = gen_alpha_solver::BMatrixForQuaternions(q);
+            auto q_prime = gen_alpha_solver::create_vector(
+                {gen_coords_derivatives_qp(3), gen_coords_derivatives_qp(4),
+                 gen_coords_derivatives_qp(5), gen_coords_derivatives_qp(6)}
+            );
+            auto curvature =
+                gen_alpha_solver::multiply_matrix_with_vector(b_matrix_quaternion, q_prime);
+
+            // Calculate the strain vector at the quadrature point
+            auto strain = Kokkos::View<double*>("strain", 6);
+            Kokkos::parallel_for(
+                3,
+                KOKKOS_LAMBDA(const size_t k) {
+                    strain(k) = position_vector_derivatives_qp(k) + gen_coords_derivatives_qp(k);
+                    strain(k + 3) = curvature(k);
+                }
+            );
+
+            // Calculate the stiffness matrix at the quadrature point
+            auto rotation_0 =
+                gen_alpha_solver::quaternion_to_rotation_matrix(gen_alpha_solver::Quaternion(
+                    position_vector_qp(3), position_vector_qp(4), position_vector_qp(5),
+                    position_vector_qp(6)
+                ));
+            auto rotation = gen_alpha_solver::quaternion_to_rotation_matrix(q);
+            auto total_rotation = gen_alpha_solver::multiply_matrix_with_matrix(
+                rotation.GetRotationMatrix(), rotation_0.GetRotationMatrix()
+            );
+
+            auto stiffness_qp = gen_alpha_solver::multiply_matrix_with_matrix(
+                gen_alpha_solver::multiply_matrix_with_matrix(
+                    total_rotation, stiffness.GetStiffnessMatrix()
+                ),
+                gen_alpha_solver::transpose_matrix(total_rotation)
+            );
+
+            // Calculate F_c vector at the quadrature point
+            auto strain_next = Kokkos::View<double*>("strain_next", 6);
+            Kokkos::deep_copy(strain_next, strain);
+            auto R_x0 = gen_alpha_solver::multiply_matrix_with_vector(
+                rotation.GetRotationMatrix(),
+                gen_alpha_solver::create_vector(
+                    {position_vector_derivatives_qp(0), position_vector_derivatives_qp(1),
+                     position_vector_derivatives_qp(2)}
+                )
+            );
+            Kokkos::parallel_for(
+                3, KOKKOS_LAMBDA(const size_t k) { strain_next(k) -= R_x0(k); }
+            );
+
+            auto fc = gen_alpha_solver::multiply_matrix_with_vector(stiffness_qp, strain_next);
+
+            // Calculate F_d vector at the quadrature point
+            auto x0_prime_tilde =
+                gen_alpha_solver::create_cross_product_matrix(gen_alpha_solver::create_vector(
+                    {position_vector_qp(0), position_vector_qp(1), position_vector_qp(2)}
+                ));
+            auto u_prime_tilde =
+                gen_alpha_solver::create_cross_product_matrix(gen_alpha_solver::create_vector(
+                    {gen_coords_derivatives_qp(0), gen_coords_derivatives_qp(1),
+                     gen_coords_derivatives_qp(2)}
+                ));
+            auto fd_values = gen_alpha_solver::transpose_matrix(
+                gen_alpha_solver::add_matrix_with_matrix(x0_prime_tilde, u_prime_tilde)
+            );
+
+            auto fd = Kokkos::View<double*>("fd", 6);
+            Kokkos::deep_copy(fd, 0.);
+            Kokkos::parallel_for(
+                3,
+                KOKKOS_LAMBDA(const size_t k) {
+                    fd(k) =
+                        fd_values(k, 0) * fc(0) + fd_values(k, 1) * fc(1) + fd_values(k, 2) * fc(2);
+                }
+            );
+
+            // residual[[(i - 1)*6 + 1 ;; (i - 1)*6 + 6 ]] =
+            // residual[[(i - 1)*6 + 1 ;; (i - 1)*6 + 6 ]] + (FC*
+            //     Limit[Limit[hd[x, y], y -> \[Xi]j[[basis]]], x -> \[Xi]] +
+            //     Sqrt[Limit[jacsquared[x], x -> \[Xi]]]*FD*
+            //     Limit[Limit[h[x, y], y -> \[Xi]j[[basis]]], x -> \[Xi]]) \[Xi]w;
+
+            // Calculate the residual at the quadrature point
+            // auto phi_prime = gen_alpha_solver::create_vector(shape_function_derivative);
+            // auto first_part = Kokkos::View<double*>("first_part", 6);
+            // Kokkos::parallel_for(
+            //     6, KOKKOS_LAMBDA(const size_t k
+            //        ) { gen_coords_qp(k) += gen_alpha_solver::dot_product(phi_prime, fc) * qw; }
+            // );
+
+            // //  gen_coords_qp(i) += shape_function[j] * gen_coords(j * 7 + i);
+
+            // Kokkos::parallel_for(
+            //     Kokkos::MDRangePolicy<Kokkos::DefaultExecutionSpace, Kokkos::Rank<2>>(
+            //         {0, 0}, {kNumberOfLieGroupComponents, n_nodes}
+            //     ),
+            //     KOKKOS_LAMBDA(const size_t i, const size_t j) {
+            //         residual(i, j) += qw * (shape_function_derivative[j] * gen_coords_qp(i));
+            //     }
+            // );
+        }
+    }
 }
 
 }  // namespace openturbine::gebt_poc

--- a/src/gebt_poc/solver.h
+++ b/src/gebt_poc/solver.h
@@ -32,15 +32,15 @@ public:
         std::vector<double> quadrature_points, std::vector<double> quadrature_weights
     );
 
-    // Returns the number of quadrature points
+    /// Returns the number of quadrature points
     virtual size_t GetNumberOfQuadraturePoints() const override { return quadrature_points_.size(); }
 
-    // Returns the quadrature points (read only)
+    /// Returns the quadrature points (read only)
     virtual const std::vector<double>& GetQuadraturePoints() const override {
         return quadrature_points_;
     }
 
-    // Returns the quadrature weights (read only)
+    /// Returns the quadrature weights (read only)
     virtual const std::vector<double>& GetQuadratureWeights() const override {
         return quadrature_weights_;
     }
@@ -50,10 +50,11 @@ private:
     std::vector<double> quadrature_weights_;
 };
 
-/// Calculates the interpolated values for a nodal quantity (e.g. displacement or position vector) at
-/// a given quadrature point
+/// Calculates the interpolated values for a nodal quantity (e.g. displacement or position vector)
+/// at a given quadrature point
 Kokkos::View<double*> Interpolate(
-    Kokkos::View<double*> nodal_values, Kokkos::View<double*> interpolation_function
+    Kokkos::View<double*> nodal_values, Kokkos::View<double*> interpolation_function,
+    double jacobian = 1.
 );
 
 /// Calculates the curvature from generalized coordinates and their derivatives
@@ -62,16 +63,16 @@ Kokkos::View<double*> CalculateCurvature(
 );
 
 /// Calculates the given sectional stiffness matrix in inertial basis based on the given
-/// rotation matrix
+/// rotation matrices
 Kokkos::View<double**> CalculateSectionalStiffness(
-    const StiffnessMatrix& stiffness, gen_alpha_solver::RotationMatrix rotation_0,
-    gen_alpha_solver::RotationMatrix rotation
+    const StiffnessMatrix& stiffness, Kokkos::View<double**> rotation_0,
+    Kokkos::View<double**> rotation
 );
 
 /// Calculates the elastic forces based on the sectional strain, derivative of the position
 /// vector and the generalized coordinates, and the sectional stiffness matrix
 Kokkos::View<double*> CalculateElasticForces(
-    const Kokkos::View<double*> strain, gen_alpha_solver::RotationMatrix rotation,
+    const Kokkos::View<double*> strain, Kokkos::View<double**> rotation,
     const Kokkos::View<double*> position_vector_derivatives,
     const Kokkos::View<double*> gen_coords_derivatives,
     const Kokkos::View<double**> sectional_stiffness

--- a/src/gebt_poc/solver.h
+++ b/src/gebt_poc/solver.h
@@ -6,9 +6,9 @@
 
 namespace openturbine::gebt_poc {
 
-constexpr size_t kNumberOfLieAlgebraComponents = 7;
-constexpr size_t kNumberOfLieGroupComponents = 6;
-constexpr size_t kNumberOfVectorComponents = 3;
+constexpr std::size_t kNumberOfLieAlgebraComponents = 7;
+constexpr std::size_t kNumberOfLieGroupComponents = 6;
+constexpr std::size_t kNumberOfVectorComponents = 3;
 
 /// An abstract class for providing common interface to numerical quadrature rules
 class Quadrature {
@@ -73,7 +73,7 @@ Kokkos::View<double**> CalculateSectionalStiffness(
 /// vector and the generalized coordinates, and the sectional stiffness matrix
 Kokkos::View<double*> CalculateElasticForces(
     const Kokkos::View<double*> strain, Kokkos::View<double**> rotation,
-    const Kokkos::View<double*> position_vector_derivatives,
+    const Kokkos::View<double*> pos_vector_derivatives,
     const Kokkos::View<double*> gen_coords_derivatives,
     const Kokkos::View<double**> sectional_stiffness
 );

--- a/src/gebt_poc/solver.h
+++ b/src/gebt_poc/solver.h
@@ -1,0 +1,43 @@
+#pragma once
+
+#include "src/gebt_poc/element.h"
+
+namespace openturbine::gebt_poc {
+
+/// An abstract for providing common interface for numerical quadrature rules
+class QuadratureRule {
+public:
+    virtual ~QuadratureRule() = default;
+
+    /// Returns the number of quadrature points
+    virtual size_t GetNumQuadraturePoints() const = 0;
+
+    /// Returns the quadrature points
+    virtual std::vector<double> GetQuadraturePoints() const = 0;
+
+    /// Returns the quadrature weights
+    virtual std::vector<double> GetQuadratureWeights() const = 0;
+};
+
+/// A concrete quadrature rule where the quadrature points and weights are provided by the user
+class UserDefinedQuadratureRule : public QuadratureRule {
+public:
+    UserDefinedQuadratureRule(
+        std::vector<double> quadrature_points, std::vector<double> quadrature_weights
+    );
+
+    // Returns the number of quadrature points
+    virtual size_t GetNumQuadraturePoints() const override { return quadrature_points_.size(); }
+
+    // Returns the quadrature points
+    virtual std::vector<double> GetQuadraturePoints() const override { return quadrature_points_; }
+
+    // Returns the quadrature weights
+    virtual std::vector<double> GetQuadratureWeights() const override { return quadrature_weights_; }
+
+private:
+    std::vector<double> quadrature_points_;   //< Quadrature points
+    std::vector<double> quadrature_weights_;  //< Quadrature weights
+};
+
+}  // namespace openturbine::gebt_poc

--- a/src/gebt_poc/solver.h
+++ b/src/gebt_poc/solver.h
@@ -1,43 +1,58 @@
 #pragma once
 
 #include "src/gebt_poc/element.h"
+#include "src/gebt_poc/section.h"
 
 namespace openturbine::gebt_poc {
 
+constexpr size_t kNumberOfLieAlgebraComponents = 7;
+constexpr size_t kNumberOfLieGroupComponents = 6;
+constexpr size_t kNumberOfVectorComponents = 3;
+
 /// An abstract for providing common interface for numerical quadrature rules
-class QuadratureRule {
+class Quadrature {
 public:
-    virtual ~QuadratureRule() = default;
+    virtual ~Quadrature() = default;
 
     /// Returns the number of quadrature points
-    virtual size_t GetNumQuadraturePoints() const = 0;
+    virtual size_t GetNumberOfQuadraturePoints() const = 0;
 
-    /// Returns the quadrature points
-    virtual std::vector<double> GetQuadraturePoints() const = 0;
+    /// Returns the quadrature points (read only)
+    virtual const std::vector<double>& GetQuadraturePoints() const = 0;
 
-    /// Returns the quadrature weights
-    virtual std::vector<double> GetQuadratureWeights() const = 0;
+    /// Returns the quadrature weights (read only)
+    virtual const std::vector<double>& GetQuadratureWeights() const = 0;
 };
 
 /// A concrete quadrature rule where the quadrature points and weights are provided by the user
-class UserDefinedQuadratureRule : public QuadratureRule {
+class UserDefinedQuadrature : public Quadrature {
 public:
-    UserDefinedQuadratureRule(
+    UserDefinedQuadrature(
         std::vector<double> quadrature_points, std::vector<double> quadrature_weights
     );
 
     // Returns the number of quadrature points
-    virtual size_t GetNumQuadraturePoints() const override { return quadrature_points_.size(); }
+    virtual size_t GetNumberOfQuadraturePoints() const override { return quadrature_points_.size(); }
 
-    // Returns the quadrature points
-    virtual std::vector<double> GetQuadraturePoints() const override { return quadrature_points_; }
+    // Returns the quadrature points (read only)
+    virtual const std::vector<double>& GetQuadraturePoints() const override {
+        return quadrature_points_;
+    }
 
-    // Returns the quadrature weights
-    virtual std::vector<double> GetQuadratureWeights() const override { return quadrature_weights_; }
+    // Returns the quadrature weights (read only)
+    virtual const std::vector<double>& GetQuadratureWeights() const override {
+        return quadrature_weights_;
+    }
 
 private:
-    std::vector<double> quadrature_points_;   //< Quadrature points
-    std::vector<double> quadrature_weights_;  //< Quadrature weights
+    std::vector<double> quadrature_points_;
+    std::vector<double> quadrature_weights_;
 };
+
+/// Calculates the static residual vector for a beam element
+Kokkos::View<double*> CalculateStaticResidual(
+    const Kokkos::View<double*> position_vectors, const Kokkos::View<double*> gen_coords,
+    const StiffnessMatrix& stiffness, const Quadrature& quadrature
+);
 
 }  // namespace openturbine::gebt_poc

--- a/src/gebt_poc/solver.h
+++ b/src/gebt_poc/solver.h
@@ -53,6 +53,11 @@ private:
 /// a given quadrature point
 Kokkos::View<double*> Interpolate(Kokkos::View<double*> nodal_values, double quadrature_pt);
 
+/// Calculates the curvature from generalized coordinates and their derivatives
+Kokkos::View<double*> CalculateCurvature(
+    const Kokkos::View<double*> gen_coords, const Kokkos::View<double*> gen_coords_derivative
+);
+
 /// Calculates the static residual vector for a beam element
 Kokkos::View<double*> CalculateStaticResidual(
     const Kokkos::View<double*> position_vectors, const Kokkos::View<double*> gen_coords,

--- a/src/gebt_poc/solver.h
+++ b/src/gebt_poc/solver.h
@@ -2,6 +2,7 @@
 
 #include "src/gebt_poc/element.h"
 #include "src/gebt_poc/section.h"
+#include "src/gen_alpha_poc/rotation_matrix.h"
 
 namespace openturbine::gebt_poc {
 
@@ -59,6 +60,13 @@ Kokkos::View<double*> Interpolate(
 /// Calculates the curvature from generalized coordinates and their derivatives
 Kokkos::View<double*> CalculateCurvature(
     const Kokkos::View<double*> gen_coords, const Kokkos::View<double*> gen_coords_derivative
+);
+
+/// Calculates the given sectional stiffness matrix in inertial basis based on the given
+/// rotation matrix
+Kokkos::View<double**> CalculateSectionalStiffness(
+    const StiffnessMatrix& stiffness, gen_alpha_solver::RotationMatrix rotation_0,
+    gen_alpha_solver::RotationMatrix rotation
 );
 
 /// Calculates the static residual vector for a beam element

--- a/src/gebt_poc/solver.h
+++ b/src/gebt_poc/solver.h
@@ -53,8 +53,7 @@ private:
 /// Calculates the interpolated values for a nodal quantity (e.g. displacement or position vector) at
 /// a given quadrature point
 Kokkos::View<double*> Interpolate(
-    Kokkos::View<double*> nodal_values, Kokkos::View<double*> interpolation_function,
-    double quadrature_pt
+    Kokkos::View<double*> nodal_values, Kokkos::View<double*> interpolation_function
 );
 
 /// Calculates the curvature from generalized coordinates and their derivatives
@@ -67,6 +66,15 @@ Kokkos::View<double*> CalculateCurvature(
 Kokkos::View<double**> CalculateSectionalStiffness(
     const StiffnessMatrix& stiffness, gen_alpha_solver::RotationMatrix rotation_0,
     gen_alpha_solver::RotationMatrix rotation
+);
+
+/// Calculates the elastic forces based on the sectional strain, derivative of the position
+/// vector and the generalized coordinates, and the sectional stiffness matrix
+Kokkos::View<double*> CalculateElasticForces(
+    const Kokkos::View<double*> strain, gen_alpha_solver::RotationMatrix rotation,
+    const Kokkos::View<double*> position_vector_derivatives,
+    const Kokkos::View<double*> gen_coords_derivatives,
+    const Kokkos::View<double**> sectional_stiffness
 );
 
 /// Calculates the static residual vector for a beam element

--- a/src/gebt_poc/solver.h
+++ b/src/gebt_poc/solver.h
@@ -51,7 +51,10 @@ private:
 
 /// Calculates the interpolated values for a nodal quantity (e.g. displacement or position vector) at
 /// a given quadrature point
-Kokkos::View<double*> Interpolate(Kokkos::View<double*> nodal_values, double quadrature_pt);
+Kokkos::View<double*> Interpolate(
+    Kokkos::View<double*> nodal_values, Kokkos::View<double*> interpolation_function,
+    double quadrature_pt
+);
 
 /// Calculates the curvature from generalized coordinates and their derivatives
 Kokkos::View<double*> CalculateCurvature(

--- a/src/gebt_poc/solver.h
+++ b/src/gebt_poc/solver.h
@@ -9,7 +9,7 @@ constexpr size_t kNumberOfLieAlgebraComponents = 7;
 constexpr size_t kNumberOfLieGroupComponents = 6;
 constexpr size_t kNumberOfVectorComponents = 3;
 
-/// An abstract for providing common interface for numerical quadrature rules
+/// An abstract class for providing common interface to numerical quadrature rules
 class Quadrature {
 public:
     virtual ~Quadrature() = default;
@@ -48,6 +48,10 @@ private:
     std::vector<double> quadrature_points_;
     std::vector<double> quadrature_weights_;
 };
+
+/// Calculates the interpolated values for a nodal quantity (e.g. displacement or position vector) at
+/// a given quadrature point
+Kokkos::View<double*> Interpolate(Kokkos::View<double*> nodal_values, double quadrature_pt);
 
 /// Calculates the static residual vector for a beam element
 Kokkos::View<double*> CalculateStaticResidual(

--- a/src/gen_alpha_poc/quaternion.h
+++ b/src/gen_alpha_poc/quaternion.h
@@ -284,7 +284,7 @@ Quaternion rotation_matrix_to_quaternion(const RotationMatrix& rotation_matrix) 
     }
 }
 
-/// Returns the B derivative matrix given four Euler parameters, ie unit quaternions
+/// Returns the B derivative matrix given for Euler parameters, i.e. unit quaternions
 KOKKOS_INLINE_FUNCTION
 Kokkos::View<double**> BMatrixForQuaternions(const Quaternion& quaternion) {
     auto q0 = quaternion.GetScalarComponent();

--- a/src/gen_alpha_poc/rotation_matrix.h
+++ b/src/gen_alpha_poc/rotation_matrix.h
@@ -30,6 +30,28 @@ public:
     KOKKOS_FUNCTION
     double& operator()(int i, int j) { return data_[i][j]; }
 
+    /// Returns the rotation matrix as a Kokkos view (read-only)
+    KOKKOS_FUNCTION
+    Kokkos::View<const double**> GetRotationMatrix() {
+        Kokkos::View<double**> rotation_matrix("rotation_matrix", 3, 3);
+        auto populate_rotation_matrix = KOKKOS_LAMBDA(size_t) {
+            rotation_matrix(0, 0) = data_[0][0];
+            rotation_matrix(0, 1) = data_[0][1];
+            rotation_matrix(0, 2) = data_[0][2];
+
+            rotation_matrix(1, 0) = data_[1][0];
+            rotation_matrix(1, 1) = data_[1][1];
+            rotation_matrix(1, 2) = data_[1][2];
+
+            rotation_matrix(2, 0) = data_[2][0];
+            rotation_matrix(2, 1) = data_[2][1];
+            rotation_matrix(2, 2) = data_[2][2];
+        };
+        Kokkos::parallel_for(1, populate_rotation_matrix);
+
+        return rotation_matrix;
+    }
+
 private:
     double data_[3][3];
 };

--- a/src/gen_alpha_poc/utilities.cpp
+++ b/src/gen_alpha_poc/utilities.cpp
@@ -111,6 +111,20 @@ Kokkos::View<double**> create_cross_product_matrix(const Kokkos::View<double*> v
     return matrix;
 }
 
+Kokkos::View<double*> multiply_vector_with_scalar(
+    const Kokkos::View<double*> vector, double scalar
+) {
+    auto result = Kokkos::View<double*>("result", vector.extent(0));
+    auto entries = Kokkos::RangePolicy<Kokkos::DefaultExecutionSpace>(0, vector.extent(0));
+    auto multiply_entry = KOKKOS_LAMBDA(size_t index) {
+        result(index) = vector(index) * scalar;
+    };
+
+    Kokkos::parallel_for(entries, multiply_entry);
+
+    return result;
+}
+
 Kokkos::View<double**> multiply_matrix_with_scalar(
     const Kokkos::View<double**> matrix, double scalar
 ) {

--- a/src/gen_alpha_poc/utilities.cpp
+++ b/src/gen_alpha_poc/utilities.cpp
@@ -111,6 +111,22 @@ Kokkos::View<double**> create_cross_product_matrix(const Kokkos::View<double*> v
     return matrix;
 }
 
+Kokkos::View<double**> multiply_matrix_with_scalar(
+    const Kokkos::View<double**> matrix, double scalar
+) {
+    auto result = Kokkos::View<double**>("result", matrix.extent(0), matrix.extent(1));
+    auto entries = Kokkos::MDRangePolicy<Kokkos::DefaultExecutionSpace, Kokkos::Rank<2>>(
+        {0, 0}, {matrix.extent(0), matrix.extent(1)}
+    );
+    auto multiply_row_column = KOKKOS_LAMBDA(size_t row, size_t column) {
+        result(row, column) = matrix(row, column) * scalar;
+    };
+
+    Kokkos::parallel_for(entries, multiply_row_column);
+
+    return result;
+}
+
 Kokkos::View<double*> multiply_matrix_with_vector(
     const Kokkos::View<double**> matrix, const Kokkos::View<double*> vector
 ) {
@@ -133,6 +149,16 @@ Kokkos::View<double*> multiply_matrix_with_vector(
     Kokkos::parallel_for(entries, multiply_row);
 
     return result;
+}
+
+Kokkos::View<double*> multiply_matrix_with_vector(
+    const Kokkos::View<const double**> matrix, const Kokkos::View<double*> vector
+) {
+    // Convert Kokkos view -> non-const
+    auto matrix_copy = Kokkos::View<double**>("matrix_copy", matrix.extent(0), matrix.extent(1));
+    Kokkos::deep_copy(matrix_copy, matrix);
+
+    return multiply_matrix_with_vector(matrix_copy, vector);
 }
 
 Kokkos::View<double**> multiply_matrix_with_matrix(
@@ -167,18 +193,69 @@ Kokkos::View<double**> multiply_matrix_with_matrix(
     return result;
 }
 
-Kokkos::View<double**> multiply_matrix_with_scalar(
-    const Kokkos::View<double**> matrix, double scalar
+Kokkos::View<double**> multiply_matrix_with_matrix(
+    const Kokkos::View<const double**> matrix_a, const Kokkos::View<const double**> matrix_b
 ) {
-    auto result = Kokkos::View<double**>("result", matrix.extent(0), matrix.extent(1));
+    // Convert Kokkos view -> non-const
+    auto matrix_a_copy =
+        Kokkos::View<double**>("matrix_a_copy", matrix_a.extent(0), matrix_a.extent(1));
+    Kokkos::deep_copy(matrix_a_copy, matrix_a);
+
+    auto matrix_b_copy =
+        Kokkos::View<double**>("matrix_b_copy", matrix_b.extent(0), matrix_b.extent(1));
+    Kokkos::deep_copy(matrix_b_copy, matrix_b);
+
+    return multiply_matrix_with_matrix(matrix_a_copy, matrix_b_copy);
+}
+
+Kokkos::View<double**> add_matrix_with_matrix(
+    const Kokkos::View<double**> matrix_a, const Kokkos::View<double**> matrix_b
+) {
+    if (matrix_a.extent(0) != matrix_b.extent(0) || matrix_a.extent(1) != matrix_b.extent(1)) {
+        throw std::invalid_argument("The dimensions of the matrices must be equal to each other");
+    }
+
+    auto result = Kokkos::View<double**>("result", matrix_a.extent(0), matrix_a.extent(1));
     auto entries = Kokkos::MDRangePolicy<Kokkos::DefaultExecutionSpace, Kokkos::Rank<2>>(
-        {0, 0}, {matrix.extent(0), matrix.extent(1)}
+        {0, 0}, {matrix_a.extent(0), matrix_a.extent(1)}
     );
-    auto multiply_row_column = KOKKOS_LAMBDA(size_t row, size_t column) {
-        result(row, column) = matrix(row, column) * scalar;
+    auto add_row_column = KOKKOS_LAMBDA(size_t row, size_t column) {
+        result(row, column) = matrix_a(row, column) + matrix_b(row, column);
     };
 
-    Kokkos::parallel_for(entries, multiply_row_column);
+    Kokkos::parallel_for(entries, add_row_column);
+
+    return result;
+}
+
+Kokkos::View<double**> add_matrix_with_matrix(
+    const Kokkos::View<const double**> matrix_a, const Kokkos::View<const double**> matrix_b
+) {
+    // Convert Kokkos view -> non-const
+    auto matrix_a_copy =
+        Kokkos::View<double**>("matrix_a_copy", matrix_a.extent(0), matrix_a.extent(1));
+    Kokkos::deep_copy(matrix_a_copy, matrix_a);
+
+    auto matrix_b_copy =
+        Kokkos::View<double**>("matrix_b_copy", matrix_b.extent(0), matrix_b.extent(1));
+    Kokkos::deep_copy(matrix_b_copy, matrix_b);
+
+    return add_matrix_with_matrix(matrix_a_copy, matrix_b_copy);
+}
+
+Kokkos::View<double[1]> dot_product(
+    const Kokkos::View<double*> vector_a, const Kokkos::View<double*> vector_b
+) {
+    if (vector_a.extent(0) != vector_b.extent(0)) {
+        throw std::invalid_argument("The dimensions of the vectors must be equal to each other");
+    }
+
+    auto result = Kokkos::View<double[1]>("result", 1);
+    auto entries = Kokkos::RangePolicy<Kokkos::DefaultExecutionSpace>(0, vector_a.extent(0));
+    auto dot_product = KOKKOS_LAMBDA(size_t index) {
+        result(0) += vector_a(index) * vector_b(index);
+    };
+    Kokkos::parallel_for(entries, dot_product);
 
     return result;
 }

--- a/src/gen_alpha_poc/utilities.h
+++ b/src/gen_alpha_poc/utilities.h
@@ -62,8 +62,24 @@ Kokkos::View<double**> multiply_matrix_with_scalar(const Kokkos::View<double**>,
 Kokkos::View<double*>
 multiply_matrix_with_vector(const Kokkos::View<double**>, const Kokkos::View<double*>);
 
+Kokkos::View<double*>
+multiply_matrix_with_vector(const Kokkos::View<const double**>, const Kokkos::View<double*>);
+
 /// Multiplies an m x n matrix with an n x p matrix and returns an m x p matrix
 Kokkos::View<double**>
 multiply_matrix_with_matrix(const Kokkos::View<double**>, const Kokkos::View<double**>);
+
+Kokkos::View<double**>
+multiply_matrix_with_matrix(const Kokkos::View<const double**>, const Kokkos::View<const double**>);
+
+/// Adds an m x n matrix with an m x n matrix and returns an m x n matrix
+Kokkos::View<double**>
+add_matrix_with_matrix(const Kokkos::View<double**>, const Kokkos::View<double**>);
+
+Kokkos::View<double**>
+add_matrix_with_matrix(const Kokkos::View<const double**>, const Kokkos::View<const double**>);
+
+/// Multiplies an 1 x n vector with an n x 1 vector and returns a double
+Kokkos::View<double[1]> dot_product(const Kokkos::View<double*>, const Kokkos::View<double*>);
 
 }  // namespace openturbine::gen_alpha_solver

--- a/src/gen_alpha_poc/utilities.h
+++ b/src/gen_alpha_poc/utilities.h
@@ -55,6 +55,9 @@ Kokkos::View<double**> transpose_matrix(const Kokkos::View<double**>);
 /// Generates and returns the 3 x 3 cross product matrix from a provided 3D vector
 Kokkos::View<double**> create_cross_product_matrix(const Kokkos::View<double*>);
 
+/// Multiplies an n x 1 vector with a scalar and returns an n x 1 vector
+Kokkos::View<double*> multiply_vector_with_scalar(const Kokkos::View<double*>, double);
+
 /// Multiplies an m x n matrix with a scalar and returns an m x n matrix
 Kokkos::View<double**> multiply_matrix_with_scalar(const Kokkos::View<double**>, double);
 

--- a/tests/unit_tests/gebt_poc/CMakeLists.txt
+++ b/tests/unit_tests/gebt_poc/CMakeLists.txt
@@ -4,8 +4,9 @@ target_sources(
     PRIVATE
     test_element.cpp
     test_interpolation.cpp
+    test_mesh.cpp
     test_model.cpp
     test_point.cpp
     test_section.cpp
-    test_mesh.cpp
+    test_solver.cpp
 )

--- a/tests/unit_tests/gebt_poc/test_solver.cpp
+++ b/tests/unit_tests/gebt_poc/test_solver.cpp
@@ -101,6 +101,33 @@ TEST(SolverTest, CalculateCurvature) {
     EXPECT_NEAR(curvature(2), 0.15023478838786522, 1e-6);
 }
 
+TEST(SolverTest, CalculateSectionalStiffness) {
+    auto rotation_0 = gen_alpha_solver::RotationMatrix(1., 2., 3., 4., 5., 6., 7., 8., 9.);
+    auto rotation = gen_alpha_solver::RotationMatrix(1., 0., 0., 0., 1., 0., 0., 0., 1.);
+    auto stiffness = StiffnessMatrix(gen_alpha_solver::create_matrix({
+        {1., 2., 3., 4., 5., 6.},       // row 1
+        {2., 4., 6., 8., 10., 12.},     // row 2
+        {3., 6., 9., 12., 15., 18.},    // row 3
+        {4., 8., 12., 16., 20., 24.},   // row 4
+        {5., 10., 15., 20., 25., 30.},  // row 5
+        {6., 12., 18., 24., 30., 36.}   // row 6
+    }));
+
+    auto sectional_stiffness = CalculateSectionalStiffness(stiffness, rotation_0, rotation);
+
+    openturbine::gen_alpha_solver::tests::expect_kokkos_view_2D_equal(
+        sectional_stiffness,
+        {
+            {196., 448., 700., 448., 1078., 1708.},      // row 1
+            {448., 1024., 1600., 1024., 2464., 3904.},   // row 2
+            {700., 1600., 2500., 1600., 3850., 6100.},   // row 3
+            {448., 1024., 1600., 1024., 2464., 3904.},   // row 4
+            {1078., 2464., 3850., 2464., 5929., 9394.},  // row 5
+            {1708., 3904., 6100., 3904., 9394., 14884.}  // row 6
+        }
+    );
+}
+
 TEST(SolverTest, CalculateStaticResidual) {
     auto position_vectors = Kokkos::View<double*>("position_vectors", 35);
     auto populate_position_vector = KOKKOS_LAMBDA(size_t) {

--- a/tests/unit_tests/gebt_poc/test_solver.cpp
+++ b/tests/unit_tests/gebt_poc/test_solver.cpp
@@ -305,36 +305,41 @@ TEST(SolverTest, CalculateStaticResidual) {
     auto residual =
         CalculateStaticResidual(position_vectors, generalized_coords, stiffness, quadrature);
 
-    EXPECT_NEAR(residual(0), -0.111227, 1e-6);
-    EXPECT_NEAR(residual(1), -0.161488, 1e-6);
-    EXPECT_NEAR(residual(2), -0.304395, 1e-6);
-    EXPECT_NEAR(residual(3), -0.403897, 1e-6);
-    EXPECT_NEAR(residual(4), -0.292703, 1e-6);
-    EXPECT_NEAR(residual(5), -0.683898, 1e-6);
-    EXPECT_NEAR(residual(6), -0.0526776, 1e-6);
-    EXPECT_NEAR(residual(7), -0.0988211, 1e-6);
-    EXPECT_NEAR(residual(8), -0.103198, 1e-6);
-    EXPECT_NEAR(residual(9), -0.0469216, 1e-6);
-    EXPECT_NEAR(residual(10), 0.20028, 1e-6);
-    EXPECT_NEAR(residual(11), -0.493743, 1e-6);
-    EXPECT_NEAR(residual(12), 0.11946, 1e-6);
-    EXPECT_NEAR(residual(13), 0.143433, 1e-6);
-    EXPECT_NEAR(residual(14), 0.278972, 1e-6);
-    EXPECT_NEAR(residual(15), 0.288189, 1e-6);
-    EXPECT_NEAR(residual(16), 0.903484, 1e-6);
-    EXPECT_NEAR(residual(17), 0.213179, 1e-6);
-    EXPECT_NEAR(residual(18), 0.0854734, 1e-6);
-    EXPECT_NEAR(residual(19), 0.2978, 1e-6);
-    EXPECT_NEAR(residual(20), 0.307201, 1e-6);
-    EXPECT_NEAR(residual(21), 0.34617, 1e-6);
-    EXPECT_NEAR(residual(22), 0.752895, 1e-6);
-    EXPECT_NEAR(residual(23), 0.592624, 1e-6);
-    EXPECT_NEAR(residual(24), -0.0410293, 1e-6);
-    EXPECT_NEAR(residual(25), -0.180923, 1e-6);
-    EXPECT_NEAR(residual(26), -0.17858, 1e-6);
-    EXPECT_NEAR(residual(27), -0.0631152, 1e-6);
-    EXPECT_NEAR(residual(28), -0.561707, 1e-6);
-    EXPECT_NEAR(residual(29), -0.259986, 1e-6);
+    openturbine::gen_alpha_solver::tests::expect_kokkos_view_1D_equal(
+        residual,
+        {
+            -0.11122699207269554,   // node 1, generalized_coords 1
+            -0.16148820316250462,   // node 1, generalized_coords 2
+            -0.304394950802795,     // node 1, generalized_coords 3
+            -0.4038973586442003,    // node 1, generalized_coords 4
+            -0.29270280250404546,   // node 1, generalized_coords 5
+            -0.6838980603426406,    // node 1, generalized_coords 6
+            -0.05267755488345887,   // node 1, generalized_coords 7
+            -0.09882114478157883,   // node 2, generalized_coords 1
+            -0.10319848820842535,   // node 2, generalized_coords 2
+            -0.046921581717388396,  // node 2, generalized_coords 3
+            0.20028020169482658,    // node 2, generalized_coords 4
+            -0.49374296507736715,   // node 2, generalized_coords 5
+            0.11946039620134324,    // node 2, generalized_coords 6
+            0.1434326233631381,     // node 2, generalized_coords 7
+            0.2789717998424498,     // node 3, generalized_coords 1
+            0.28818850009642966,    // node 3, generalized_coords 2
+            0.9034841540190914,     // node 3, generalized_coords 3
+            0.21317918283700327,    // node 3, generalized_coords 4
+            0.08547342278468156,    // node 3, generalized_coords 5
+            0.2977996717461346,     // node 3, generalized_coords 6
+            0.30720135556692413,    // node 3, generalized_coords 7
+            0.34617026813588375,    // node 4, generalized_coords 1
+            0.7528946278642024,     // node 4, generalized_coords 2
+            0.5926242286597619,     // node 4, generalized_coords 3
+            -0.04102927202987112,   // node 4, generalized_coords 4
+            -0.18092294716519058,   // node 4, generalized_coords 5
+            -0.17857971639815556,   // node 4, generalized_coords 6
+            -0.06311517325798338,   // node 4, generalized_coords 7
+            -0.5617067154657261,    // node 5, generalized_coords 1
+            -0.259985875498865      // node 5, generalized_coords 2
+        }
+    );
 }
 
 }  // namespace openturbine::gebt_poc::tests

--- a/tests/unit_tests/gebt_poc/test_solver.cpp
+++ b/tests/unit_tests/gebt_poc/test_solver.cpp
@@ -1,0 +1,76 @@
+#include <gtest/gtest.h>
+
+#include "src/gebt_poc/solver.h"
+#include "src/gen_alpha_poc/quaternion.h"
+#include "tests/unit_tests/gen_alpha_poc/test_utilities.h"
+
+namespace openturbine::gebt_poc::tests {
+
+Kokkos::View<double*> CreateGeneralizedCoordinates(double t) {
+    auto scale = 0.1;
+    auto ux = scale * (t * t);
+    auto uy = scale * (t * t * t - t * t);
+    auto uz = scale * (t * t + 0.2 * t * t * t);
+    auto quaternions =
+        gen_alpha_solver::rotation_matrix_to_quaternion(gen_alpha_solver::RotationMatrix{
+            1., 0., 0.,                                     // row 1
+            0., std::cos(scale * t), -std::sin(scale * t),  // row 2
+            0., std::sin(scale * t), std::cos(scale * t)    // row 3
+        });
+
+    Kokkos::View<double*> generalized_coords("generalized_coords", 7);
+    generalized_coords(0) = ux;
+    generalized_coords(1) = uy;
+    generalized_coords(2) = uz;
+    generalized_coords(3) = quaternions.GetScalarComponent();
+    generalized_coords(4) = quaternions.GetXComponent();
+    generalized_coords(5) = quaternions.GetYComponent();
+    generalized_coords(6) = quaternions.GetZComponent();
+
+    return generalized_coords;
+}
+
+TEST(SolverTest, CreateGeneralizedCoordinates) {
+    {
+        auto generalized_coords = CreateGeneralizedCoordinates(0.);
+
+        EXPECT_DOUBLE_EQ(generalized_coords(0), 0.);
+        EXPECT_DOUBLE_EQ(generalized_coords(1), 0.);
+        EXPECT_DOUBLE_EQ(generalized_coords(2), 0.);
+        // Corresponding to rotation matrix {{1.,0,0}, {0,1.,0}, {0,0,1.}}
+        EXPECT_DOUBLE_EQ(generalized_coords(3), 1.);
+        EXPECT_DOUBLE_EQ(generalized_coords(4), 0.);
+        EXPECT_DOUBLE_EQ(generalized_coords(5), 0.);
+        EXPECT_DOUBLE_EQ(generalized_coords(6), 0.);
+    }
+
+    {
+        auto generalized_coords = CreateGeneralizedCoordinates(1.);
+
+        EXPECT_DOUBLE_EQ(generalized_coords(0), 0.1);
+        EXPECT_DOUBLE_EQ(generalized_coords(1), 0.);
+        EXPECT_DOUBLE_EQ(generalized_coords(2), 0.12);
+        // Corresponding to rotation matrix
+        // {{1.,0,0}, {0,0.995004,-0.0998334}, {0,0.0998334,0.995004}}
+        EXPECT_DOUBLE_EQ(generalized_coords(3), 0.99875026039496628);
+        EXPECT_DOUBLE_EQ(generalized_coords(4), 0.049979169270678324);
+        EXPECT_DOUBLE_EQ(generalized_coords(5), 0.);
+        EXPECT_DOUBLE_EQ(generalized_coords(6), 0.);
+    }
+
+    {
+        auto generalized_coords = CreateGeneralizedCoordinates(2.);
+
+        EXPECT_DOUBLE_EQ(generalized_coords(0), 0.4);
+        EXPECT_DOUBLE_EQ(generalized_coords(1), 0.4);
+        EXPECT_DOUBLE_EQ(generalized_coords(2), 0.56);
+        // Corresponding to rotation matrix
+        // {{1.,0,0}, {0,0.980067,-0.198669}, {0,0.198669,0.980067}}
+        EXPECT_DOUBLE_EQ(generalized_coords(3), 0.99500416527802571);
+        EXPECT_DOUBLE_EQ(generalized_coords(4), 0.099833416646828155);
+        EXPECT_DOUBLE_EQ(generalized_coords(5), 0.);
+        EXPECT_DOUBLE_EQ(generalized_coords(6), 0.);
+    }
+}
+
+}  // namespace openturbine::gebt_poc::tests

--- a/tests/unit_tests/gebt_poc/test_solver.cpp
+++ b/tests/unit_tests/gebt_poc/test_solver.cpp
@@ -101,8 +101,16 @@ TEST(SolverTest, CalculateCurvature) {
 }
 
 TEST(SolverTest, CalculateSectionalStiffness) {
-    auto rotation_0 = gen_alpha_solver::RotationMatrix(1., 2., 3., 4., 5., 6., 7., 8., 9.);
-    auto rotation = gen_alpha_solver::RotationMatrix(1., 0., 0., 0., 1., 0., 0., 0., 1.);
+    auto rotation_0 = gen_alpha_solver::create_matrix({
+        {1., 2., 3.},  // row 1
+        {4., 5., 6.},  // row 2
+        {7., 8., 9.}   // row 3
+    });
+    auto rotation = gen_alpha_solver::create_matrix({
+        {1., 0., 0.},  // row 1
+        {0., 1., 0.},  // row 2
+        {0., 0., 1.}   // row 3
+    });
     auto stiffness = StiffnessMatrix(gen_alpha_solver::create_matrix({
         {1., 2., 3., 4., 5., 6.},       // row 1
         {2., 4., 6., 8., 10., 12.},     // row 2
@@ -139,7 +147,11 @@ TEST(SolverTest, CalculateElasticForces) {
     };
     Kokkos::parallel_for(1, populate_sectional_strain);
 
-    auto rotation = gen_alpha_solver::RotationMatrix(1., 2., 3., 4., 5., 6., 7., 8., 9.);
+    auto rotation = gen_alpha_solver::create_matrix({
+        {1., 2., 3.},  // row 1
+        {4., 5., 6.},  // row 2
+        {7., 8., 9.}   // row 3
+    });
 
     auto position_vector_derivatives = Kokkos::View<double*>("position_vector_derivatives", 7);
     auto populate_position_vector_derivatives = KOKKOS_LAMBDA(size_t) {
@@ -248,7 +260,7 @@ TEST(SolverTest, CalculateStaticResidual) {
         generalized_coords(13) = 0.;
         // node 3
         generalized_coords(14) = 0.025;
-        generalized_coords(15) = 0.0125;
+        generalized_coords(15) = -0.0125;
         generalized_coords(16) = 0.027500000000000004;
         generalized_coords(17) = 0.9996875162757026;
         generalized_coords(18) = 0.024997395914712332;
@@ -290,39 +302,39 @@ TEST(SolverTest, CalculateStaticResidual) {
         0.3818300505051189, 0.2797053914892766, 0.1294849661688697};
     auto quadrature = UserDefinedQuadrature(quadrature_points, quadrature_weights);
 
-    // auto residual =
-    //     CalculateStaticResidual(position_vectors, generalized_coords, stiffness, quadrature);
+    auto residual =
+        CalculateStaticResidual(position_vectors, generalized_coords, stiffness, quadrature);
 
-    // EXPECT_NEAR(residual(0), -0.111227, 1e-6);
-    // EXPECT_NEAR(residual(1), -0.161488, 1e-6);
-    // EXPECT_NEAR(residual(2), -0.304395, 1e-6);
-    // EXPECT_NEAR(residual(3), -0.403897, 1e-6);
-    // EXPECT_NEAR(residual(4), -0.292703, 1e-6);
-    // EXPECT_NEAR(residual(5), -0.683898, 1e-6);
-    // EXPECT_NEAR(residual(6), -0.0526776, 1e-6);
-    // EXPECT_NEAR(residual(7), -0.0988211, 1e-6);
-    // EXPECT_NEAR(residual(8), -0.103198, 1e-6);
-    // EXPECT_NEAR(residual(9), -0.0469216, 1e-6);
-    // EXPECT_NEAR(residual(10), 0.20028, 1e-6);
-    // EXPECT_NEAR(residual(11), -0.493743, 1e-6);
-    // EXPECT_NEAR(residual(12), 0.11946, 1e-6);
-    // EXPECT_NEAR(residual(13), 0.143433, 1e-6);
-    // EXPECT_NEAR(residual(14), 0.278972, 1e-6);
-    // EXPECT_NEAR(residual(15), 0.288189, 1e-6);
-    // EXPECT_NEAR(residual(16), 0.903484, 1e-6);
-    // EXPECT_NEAR(residual(17), 0.213179, 1e-6);
-    // EXPECT_NEAR(residual(18), 0.0854734, 1e-6);
-    // EXPECT_NEAR(residual(19), 0.2978, 1e-6);
-    // EXPECT_NEAR(residual(20), 0.307201, 1e-6);
-    // EXPECT_NEAR(residual(21), 0.34617, 1e-6);
-    // EXPECT_NEAR(residual(22), 0.752895, 1e-6);
-    // EXPECT_NEAR(residual(23), 0.592624, 1e-6);
-    // EXPECT_NEAR(residual(24), -0.0410293, 1e-6);
-    // EXPECT_NEAR(residual(25), -0.180923, 1e-6);
-    // EXPECT_NEAR(residual(26), -0.17858, 1e-6);
-    // EXPECT_NEAR(residual(27), -0.0631152, 1e-6);
-    // EXPECT_NEAR(residual(28), -0.561707, 1e-6);
-    // EXPECT_NEAR(residual(29), -0.259986, 1e-6);
+    EXPECT_NEAR(residual(0), -0.111227, 1e-6);
+    EXPECT_NEAR(residual(1), -0.161488, 1e-6);
+    EXPECT_NEAR(residual(2), -0.304395, 1e-6);
+    EXPECT_NEAR(residual(3), -0.403897, 1e-6);
+    EXPECT_NEAR(residual(4), -0.292703, 1e-6);
+    EXPECT_NEAR(residual(5), -0.683898, 1e-6);
+    EXPECT_NEAR(residual(6), -0.0526776, 1e-6);
+    EXPECT_NEAR(residual(7), -0.0988211, 1e-6);
+    EXPECT_NEAR(residual(8), -0.103198, 1e-6);
+    EXPECT_NEAR(residual(9), -0.0469216, 1e-6);
+    EXPECT_NEAR(residual(10), 0.20028, 1e-6);
+    EXPECT_NEAR(residual(11), -0.493743, 1e-6);
+    EXPECT_NEAR(residual(12), 0.11946, 1e-6);
+    EXPECT_NEAR(residual(13), 0.143433, 1e-6);
+    EXPECT_NEAR(residual(14), 0.278972, 1e-6);
+    EXPECT_NEAR(residual(15), 0.288189, 1e-6);
+    EXPECT_NEAR(residual(16), 0.903484, 1e-6);
+    EXPECT_NEAR(residual(17), 0.213179, 1e-6);
+    EXPECT_NEAR(residual(18), 0.0854734, 1e-6);
+    EXPECT_NEAR(residual(19), 0.2978, 1e-6);
+    EXPECT_NEAR(residual(20), 0.307201, 1e-6);
+    EXPECT_NEAR(residual(21), 0.34617, 1e-6);
+    EXPECT_NEAR(residual(22), 0.752895, 1e-6);
+    EXPECT_NEAR(residual(23), 0.592624, 1e-6);
+    EXPECT_NEAR(residual(24), -0.0410293, 1e-6);
+    EXPECT_NEAR(residual(25), -0.180923, 1e-6);
+    EXPECT_NEAR(residual(26), -0.17858, 1e-6);
+    EXPECT_NEAR(residual(27), -0.0631152, 1e-6);
+    EXPECT_NEAR(residual(28), -0.561707, 1e-6);
+    EXPECT_NEAR(residual(29), -0.259986, 1e-6);
 }
 
 }  // namespace openturbine::gebt_poc::tests

--- a/tests/unit_tests/gebt_poc/test_solver.cpp
+++ b/tests/unit_tests/gebt_poc/test_solver.cpp
@@ -54,9 +54,11 @@ TEST(SolverTest, CalculateInterpolatedValues) {
     };
     Kokkos::parallel_for(1, populate_generalized_coords);
     auto quadrature_pt = 0.;
+    auto shape_function = gen_alpha_solver::create_vector(LagrangePolynomial(1, quadrature_pt));
 
     openturbine::gen_alpha_solver::tests::expect_kokkos_view_1D_equal(
-        Interpolate(generalized_coords, quadrature_pt), {1.5, 2.5, 3.5, 0., 0., 1., 3.}
+        Interpolate(generalized_coords, shape_function, quadrature_pt),
+        {1.5, 2.5, 3.5, 0., 0., 1., 3.}
     );
 }
 

--- a/tests/unit_tests/gebt_poc/test_solver.cpp
+++ b/tests/unit_tests/gebt_poc/test_solver.cpp
@@ -6,207 +6,6 @@
 
 namespace openturbine::gebt_poc::tests {
 
-Kokkos::View<double*> CreateGeneralizedCoordinates(double t) {
-    auto scale = 0.1;
-    auto ux = scale * (t * t);
-    auto uy = scale * (t * t * t - t * t);
-    auto uz = scale * (t * t + 0.2 * t * t * t);
-    auto quaternions =
-        gen_alpha_solver::rotation_matrix_to_quaternion(gen_alpha_solver::RotationMatrix{
-            1., 0., 0.,                                     // row 1
-            0., std::cos(scale * t), -std::sin(scale * t),  // row 2
-            0., std::sin(scale * t), std::cos(scale * t)    // row 3
-        });
-
-    Kokkos::View<double*> generalized_coords("generalized_coords", 7);
-    generalized_coords(0) = ux;
-    generalized_coords(1) = uy;
-    generalized_coords(2) = uz;
-    generalized_coords(3) = quaternions.GetScalarComponent();
-    generalized_coords(4) = quaternions.GetXComponent();
-    generalized_coords(5) = quaternions.GetYComponent();
-    generalized_coords(6) = quaternions.GetZComponent();
-
-    return generalized_coords;
-}
-
-TEST(SolverTest, CreateGeneralizedCoordinates) {
-    {
-        auto generalized_coords = CreateGeneralizedCoordinates(0.);
-
-        EXPECT_DOUBLE_EQ(generalized_coords(0), 0.);
-        EXPECT_DOUBLE_EQ(generalized_coords(1), 0.);
-        EXPECT_DOUBLE_EQ(generalized_coords(2), 0.);
-        // Corresponding to rotation matrix {{1.,0,0}, {0,1.,0}, {0,0,1.}}
-        EXPECT_DOUBLE_EQ(generalized_coords(3), 1.);
-        EXPECT_DOUBLE_EQ(generalized_coords(4), 0.);
-        EXPECT_DOUBLE_EQ(generalized_coords(5), 0.);
-        EXPECT_DOUBLE_EQ(generalized_coords(6), 0.);
-    }
-
-    {
-        auto generalized_coords = CreateGeneralizedCoordinates(1.);
-
-        EXPECT_DOUBLE_EQ(generalized_coords(0), 0.1);
-        EXPECT_DOUBLE_EQ(generalized_coords(1), 0.);
-        EXPECT_DOUBLE_EQ(generalized_coords(2), 0.12);
-        // Corresponding to rotation matrix
-        // {{1.,0,0}, {0,0.995004,-0.0998334}, {0,0.0998334,0.995004}}
-        EXPECT_DOUBLE_EQ(generalized_coords(3), 0.99875026039496628);
-        EXPECT_DOUBLE_EQ(generalized_coords(4), 0.049979169270678324);
-        EXPECT_DOUBLE_EQ(generalized_coords(5), 0.);
-        EXPECT_DOUBLE_EQ(generalized_coords(6), 0.);
-    }
-
-    {
-        auto generalized_coords = CreateGeneralizedCoordinates(2.);
-
-        EXPECT_DOUBLE_EQ(generalized_coords(0), 0.4);
-        EXPECT_DOUBLE_EQ(generalized_coords(1), 0.4);
-        EXPECT_DOUBLE_EQ(generalized_coords(2), 0.56);
-        // Corresponding to rotation matrix
-        // {{1.,0,0}, {0,0.980067,-0.198669}, {0,0.198669,0.980067}}
-        EXPECT_DOUBLE_EQ(generalized_coords(3), 0.99500416527802571);
-        EXPECT_DOUBLE_EQ(generalized_coords(4), 0.099833416646828155);
-        EXPECT_DOUBLE_EQ(generalized_coords(5), 0.);
-        EXPECT_DOUBLE_EQ(generalized_coords(6), 0.);
-    }
-}
-
-Kokkos::View<double**> AssignGeneralizedCoordinatesToNodes(std::size_t order) {
-    auto nodes = GenerateGLLPoints(order);
-    auto generalized_coords = Kokkos::View<double**>("generalized_coords", order + 1, 7);
-    for (std::size_t i = 0; i < order + 1; ++i) {
-        auto xi = (nodes[i] + 1.) / 2.;
-        auto gen_coords = CreateGeneralizedCoordinates(xi);
-        Kokkos::parallel_for(
-            Kokkos::RangePolicy<Kokkos::DefaultExecutionSpace>(0, 7),
-            KOKKOS_LAMBDA(const int j) { generalized_coords(i, j) = gen_coords(j); }
-        );
-    }
-    return generalized_coords;
-}
-
-TEST(SolverTest, AssignGeneralizedCoordinatesToNodes) {
-    auto generalized_coords = AssignGeneralizedCoordinatesToNodes(4);
-
-    // Node 1
-    EXPECT_DOUBLE_EQ(generalized_coords(0, 0), 0.);
-    EXPECT_DOUBLE_EQ(generalized_coords(0, 1), 0.);
-    EXPECT_DOUBLE_EQ(generalized_coords(0, 2), 0.);
-    // Corresponding to rotation matrix {{1.,0,0}, {0,1.,0}, {0,0,1.}}
-    EXPECT_DOUBLE_EQ(generalized_coords(0, 3), 1.);
-    EXPECT_DOUBLE_EQ(generalized_coords(0, 4), 0.);
-    EXPECT_DOUBLE_EQ(generalized_coords(0, 5), 0.);
-    EXPECT_DOUBLE_EQ(generalized_coords(0, 6), 0.);
-
-    // Node 2
-    EXPECT_DOUBLE_EQ(generalized_coords(1, 0), 0.0029816021788868566);
-    EXPECT_DOUBLE_EQ(generalized_coords(1, 1), -0.00246675949494302);
-    EXPECT_DOUBLE_EQ(generalized_coords(1, 2), 0.0030845707156756234);
-    // Corresponding to rotation matrix
-    // {{1.,0,0}, {0,0.999851,-0.0172665}, {0,0.0172665,0.999851}}
-    EXPECT_DOUBLE_EQ(generalized_coords(1, 3), 0.99996273020427251);
-    EXPECT_DOUBLE_EQ(generalized_coords(1, 4), 0.008633550973807835);
-    EXPECT_DOUBLE_EQ(generalized_coords(1, 5), 0.);
-    EXPECT_DOUBLE_EQ(generalized_coords(1, 6), 0.);
-
-    // Node 3
-    EXPECT_DOUBLE_EQ(generalized_coords(2, 0), 0.025);
-    EXPECT_DOUBLE_EQ(generalized_coords(2, 1), -0.0125);
-    EXPECT_DOUBLE_EQ(generalized_coords(2, 2), 0.0275);
-    // Corresponding to rotation matrix
-    // {{1.,0,0}, {0,0.99875,-0.0499792}, {0,0.0499792,0.99875}}
-    EXPECT_DOUBLE_EQ(generalized_coords(2, 3), 0.99968751627570251);
-    EXPECT_DOUBLE_EQ(generalized_coords(2, 4), 0.024997395914712332);
-    EXPECT_DOUBLE_EQ(generalized_coords(2, 5), 0.);
-    EXPECT_DOUBLE_EQ(generalized_coords(2, 6), 0.);
-
-    // Node 4
-    EXPECT_DOUBLE_EQ(generalized_coords(3, 0), 0.068446969249684589);
-    EXPECT_DOUBLE_EQ(generalized_coords(3, 1), -0.011818954790771262);
-    EXPECT_DOUBLE_EQ(generalized_coords(3, 2), 0.079772572141467255);
-    // Corresponding to rotation matrix
-    // {{1.,0,0},{0,0.99658,-0.0826383},{0,0.0826383,0.99658}
-    EXPECT_DOUBLE_EQ(generalized_coords(3, 3), 0.99914453488230548);
-    EXPECT_DOUBLE_EQ(generalized_coords(3, 4), 0.041354545274025191);
-    EXPECT_DOUBLE_EQ(generalized_coords(3, 5), 0.);
-    EXPECT_DOUBLE_EQ(generalized_coords(3, 6), 0.);
-
-    // Node 5
-    EXPECT_DOUBLE_EQ(generalized_coords(4, 0), 0.1);
-    EXPECT_DOUBLE_EQ(generalized_coords(4, 1), 0.);
-    EXPECT_DOUBLE_EQ(generalized_coords(4, 2), 0.12);
-    // Corresponding to rotation matrix
-    // {{1.,0,0}, {0,0.995004,-0.0998334}, {0,0.0998334,0.995004}}
-    EXPECT_DOUBLE_EQ(generalized_coords(4, 3), 0.99875026039496628);
-    EXPECT_DOUBLE_EQ(generalized_coords(4, 4), 0.049979169270678324);
-    EXPECT_DOUBLE_EQ(generalized_coords(4, 5), 0.);
-    EXPECT_DOUBLE_EQ(generalized_coords(4, 6), 0.);
-}
-
-Kokkos::View<double*> CreatePositionVectors(double t) {
-    auto rx = 5. * t;
-    auto ry = -2. * t + 3. * t * t;
-    auto rz = t - 2. * (t * t);
-
-    Kokkos::View<double*> position_vector("position_vector", 3);
-    position_vector(0) = rx;
-    position_vector(1) = ry;
-    position_vector(2) = rz;
-
-    return position_vector;
-}
-
-TEST(SolverTest, CreatePositionVectors) {
-    // Use linear shape functions to interpolate the position vector
-    auto pt_1 = LagrangePolynomial(1, -1.);
-    auto pt_2 = LagrangePolynomial(1, -0.6546536707079771);
-    auto pt_3 = LagrangePolynomial(1, 0.);
-    auto pt_4 = LagrangePolynomial(1, 0.6546536707079771);
-    auto pt_5 = LagrangePolynomial(1, 1.);
-
-    {
-        auto position_vector = CreatePositionVectors(pt_1[1]);
-
-        EXPECT_DOUBLE_EQ(position_vector(0), 0.);
-        EXPECT_DOUBLE_EQ(position_vector(1), 0.);
-        EXPECT_DOUBLE_EQ(position_vector(2), 0.);
-    }
-
-    {
-        auto position_vector = CreatePositionVectors(pt_2[1]);
-
-        EXPECT_DOUBLE_EQ(position_vector(0), 0.86336582323005728);
-        EXPECT_DOUBLE_EQ(position_vector(1), -0.25589826392541715);
-        EXPECT_DOUBLE_EQ(position_vector(2), 0.1130411210682743);
-    }
-
-    {
-        auto position_vector = CreatePositionVectors(pt_3[1]);
-
-        EXPECT_DOUBLE_EQ(position_vector(0), 2.5);
-        EXPECT_DOUBLE_EQ(position_vector(1), -0.25);
-        EXPECT_DOUBLE_EQ(position_vector(2), 0.);
-    }
-
-    {
-        auto position_vector = CreatePositionVectors(pt_4[1]);
-
-        EXPECT_DOUBLE_EQ(position_vector(0), 4.1366341767699426);
-        EXPECT_DOUBLE_EQ(position_vector(1), 0.39875540678255983);
-        EXPECT_DOUBLE_EQ(position_vector(2), -0.54161254963970273);
-    }
-
-    {
-        auto position_vector = CreatePositionVectors(pt_5[1]);
-
-        EXPECT_DOUBLE_EQ(position_vector(0), 5.);
-        EXPECT_DOUBLE_EQ(position_vector(1), 1.);
-        EXPECT_DOUBLE_EQ(position_vector(2), -1.);
-    }
-}
-
 TEST(SolverTest, UserDefinedQuadrature) {
     auto quadrature_points = std::vector<double>{
         -0.9491079123427585,  // point 1
@@ -226,38 +25,94 @@ TEST(SolverTest, UserDefinedQuadrature) {
         0.2797053914892766,  // weight 6
         0.1294849661688697   // weight 7
     };
-    auto quadrature_rule = UserDefinedQuadrature(quadrature_points, quadrature_weights);
+    auto quadrature = UserDefinedQuadrature(quadrature_points, quadrature_weights);
 
-    EXPECT_EQ(quadrature_rule.GetNumberOfQuadraturePoints(), 7);
-    EXPECT_EQ(quadrature_rule.GetQuadraturePoints(), quadrature_points);
-    EXPECT_EQ(quadrature_rule.GetQuadratureWeights(), quadrature_weights);
+    EXPECT_EQ(quadrature.GetNumberOfQuadraturePoints(), 7);
+    EXPECT_EQ(quadrature.GetQuadraturePoints(), quadrature_points);
+    EXPECT_EQ(quadrature.GetQuadratureWeights(), quadrature_weights);
 }
 
 TEST(SolverTest, CalculateStaticResidual) {
-    auto order = 4;
-    auto gll_points = GenerateGLLPoints(order);
-    auto position_vectors = Kokkos::View<double*>("position_vectors", (order + 1) * 7);
-    Kokkos::parallel_for(
-        Kokkos::RangePolicy<Kokkos::DefaultExecutionSpace>(0, order + 1),
-        KOKKOS_LAMBDA(const int i) {
-            auto xi = (gll_points[i] + 1.) / 2.;
-            auto position_vector = CreatePositionVectors(xi);
-            for (std::size_t j = 0; j < 7; ++j) {
-                position_vectors(i * 7 + j) = position_vector(j);
-            }
-        }
-    );
-    auto generalized_coords = Kokkos::View<double*>("generalized_coords", (order + 1) * 7);
-    Kokkos::parallel_for(
-        Kokkos::RangePolicy<Kokkos::DefaultExecutionSpace>(0, order + 1),
-        KOKKOS_LAMBDA(const int i) {
-            auto xi = (gll_points[i] + 1.) / 2.;
-            auto gen_coords = CreateGeneralizedCoordinates(xi);
-            for (std::size_t j = 0; j < 7; ++j) {
-                generalized_coords(i * 7 + j) = gen_coords(j);
-            }
-        }
-    );
+    auto position_vectors = Kokkos::View<double*>("position_vectors", 35);
+    auto populate_position_vector = KOKKOS_LAMBDA(size_t) {
+        position_vectors(0) = 0.;
+        position_vectors(1) = 0.;
+        position_vectors(2) = 0.;
+        position_vectors(3) = 0.9778215200524469;
+        position_vectors(4) = -0.01733607539094763;
+        position_vectors(5) = -0.09001900002195001;
+        position_vectors(6) = -0.18831121859148398;
+        position_vectors(7) = 0.8633658232300573;
+        position_vectors(8) = -0.25589826392541715;
+        position_vectors(9) = 0.1130411210682743;
+        position_vectors(10) = 0.9950113028068008;
+        position_vectors(11) = -0.002883848832932071;
+        position_vectors(12) = -0.030192109815745303;
+        position_vectors(13) = -0.09504013471947484;
+        position_vectors(14) = 2.5;
+        position_vectors(15) = -0.25;
+        position_vectors(16) = 0.;
+        position_vectors(17) = 0.9904718430204884;
+        position_vectors(18) = -0.009526411091536478;
+        position_vectors(19) = 0.09620741150793366;
+        position_vectors(20) = 0.09807604012323785;
+        position_vectors(21) = 4.136634176769943;
+        position_vectors(22) = 0.39875540678255983;
+        position_vectors(23) = -0.5416125496397027;
+        position_vectors(24) = 0.9472312341234699;
+        position_vectors(25) = -0.049692141629315074;
+        position_vectors(26) = 0.18127630174800594;
+        position_vectors(27) = 0.25965858850765167;
+        position_vectors(28) = 5.;
+        position_vectors(29) = 1.;
+        position_vectors(30) = -1.;
+        position_vectors(31) = 0.9210746582719719;
+        position_vectors(32) = -0.07193653093139739;
+        position_vectors(33) = 0.20507529985516368;
+        position_vectors(34) = 0.32309554437664584;
+    };
+    Kokkos::parallel_for(1, populate_position_vector);
+
+    auto generalized_coords = Kokkos::View<double*>("generalized_coords", 35);
+    auto populate_generalized_coords = KOKKOS_LAMBDA(size_t) {
+        generalized_coords(0) = 0.;
+        generalized_coords(1) = 0.;
+        generalized_coords(2) = 0.;
+        generalized_coords(3) = 1.;
+        generalized_coords(4) = 0.;
+        generalized_coords(5) = 0.;
+        generalized_coords(6) = 0.;
+        generalized_coords(7) = 0.0029816021788868583;
+        generalized_coords(8) = -0.0024667594949430213;
+        generalized_coords(9) = 0.0030845707156756256;
+        generalized_coords(10) = 0.9999627302042724;
+        generalized_coords(11) = 0.008633550973807838;
+        generalized_coords(12) = 0.;
+        generalized_coords(13) = 0.;
+        generalized_coords(14) = 0.025;
+        generalized_coords(15) = 0.0125;
+        generalized_coords(16) = 0.027500000000000004;
+        generalized_coords(17) = 0.9996875162757026;
+        generalized_coords(18) = 0.024997395914712332;
+        generalized_coords(19) = 0.;
+        generalized_coords(20) = 0.;
+        generalized_coords(21) = 0.06844696924968456;
+        generalized_coords(22) = -0.011818954790771264;
+        generalized_coords(23) = 0.07977257214146723;
+        generalized_coords(24) = 0.9991445348823056;
+        generalized_coords(25) = 0.04135454527402519;
+        generalized_coords(26) = 0.;
+        generalized_coords(27) = 0.;
+        generalized_coords(28) = 0.1;
+        generalized_coords(29) = 0.;
+        generalized_coords(30) = 0.12;
+        generalized_coords(31) = 0.9987502603949662;
+        generalized_coords(32) = 0.049979169270678324;
+        generalized_coords(33) = 0.;
+        generalized_coords(34) = 0.;
+    };
+    Kokkos::parallel_for(1, populate_generalized_coords);
+
     auto stiffness = StiffnessMatrix(gen_alpha_solver::create_matrix({
         {1., 2., 3., 4., 5., 6.},       // row 1
         {2., 4., 6., 8., 10., 12.},     // row 2
@@ -266,16 +121,17 @@ TEST(SolverTest, CalculateStaticResidual) {
         {5., 10., 15., 20., 25., 30.},  // row 5
         {6., 12., 18., 24., 30., 36.}   // row 6
     }));
+
     auto quadrature_points =
         std::vector<double>{-0.9491079123427585, -0.7415311855993945, -0.4058451513773972, 0.,
                             0.4058451513773972,  0.7415311855993945,  0.9491079123427585};
     auto quadrature_weights = std::vector<double>{
         0.1294849661688697, 0.2797053914892766, 0.3818300505051189, 0.4179591836734694,
         0.3818300505051189, 0.2797053914892766, 0.1294849661688697};
-    auto quadrature_rule = UserDefinedQuadrature(quadrature_points, quadrature_weights);
+    auto quadrature = UserDefinedQuadrature(quadrature_points, quadrature_weights);
 
     // auto residual =
-    //     CalculateStaticResidual(position_vectors, generalized_coords, stiffness, quadrature_rule);
+    //     CalculateStaticResidual(position_vectors, generalized_coords, stiffness, quadrature);
 
     // EXPECT_NEAR(residual(0), -0.111227, 1e-6);
     // EXPECT_NEAR(residual(1), -0.161488, 1e-6);

--- a/tests/unit_tests/gebt_poc/test_solver.cpp
+++ b/tests/unit_tests/gebt_poc/test_solver.cpp
@@ -145,14 +145,88 @@ TEST(SolverTest, AssignGeneralizedCoordinatesToNodes) {
     EXPECT_DOUBLE_EQ(generalized_coords(4, 6), 0.);
 }
 
-TEST(SolverTest, UserDefinedQuadratureRule) {
-    auto quadrature_points =
-        std::vector<double>{-0.9491079123427585, -0.7415311855993945, -0.4058451513773972, 0.,
-                            0.4058451513773972,  0.7415311855993945,  0.9491079123427585};
+Kokkos::View<double*> CreatePositionVectors(double t) {
+    auto rx = 5. * t;
+    auto ry = -2. * t + 3. * t * t;
+    auto rz = t - 2. * (t * t);
+
+    Kokkos::View<double*> position_vector("position_vector", 3);
+    position_vector(0) = rx;
+    position_vector(1) = ry;
+    position_vector(2) = rz;
+
+    return position_vector;
+}
+
+TEST(SolverTest, CreatePositionVectors) {
+    // Use linear shape functions to interpolate the position vector
+    auto pt_1 = LagrangePolynomial(1, -1.);
+    auto pt_2 = LagrangePolynomial(1, -0.6546536707079771);
+    auto pt_3 = LagrangePolynomial(1, 0.);
+    auto pt_4 = LagrangePolynomial(1, 0.6546536707079771);
+    auto pt_5 = LagrangePolynomial(1, 1.);
+
+    {
+        auto position_vector = CreatePositionVectors(pt_1[1]);
+
+        EXPECT_DOUBLE_EQ(position_vector(0), 0.);
+        EXPECT_DOUBLE_EQ(position_vector(1), 0.);
+        EXPECT_DOUBLE_EQ(position_vector(2), 0.);
+    }
+
+    {
+        auto position_vector = CreatePositionVectors(pt_2[1]);
+
+        EXPECT_DOUBLE_EQ(position_vector(0), 0.86336582323005728);
+        EXPECT_DOUBLE_EQ(position_vector(1), -0.25589826392541715);
+        EXPECT_DOUBLE_EQ(position_vector(2), 0.1130411210682743);
+    }
+
+    {
+        auto position_vector = CreatePositionVectors(pt_3[1]);
+
+        EXPECT_DOUBLE_EQ(position_vector(0), 2.5);
+        EXPECT_DOUBLE_EQ(position_vector(1), -0.25);
+        EXPECT_DOUBLE_EQ(position_vector(2), 0.);
+    }
+
+    {
+        auto position_vector = CreatePositionVectors(pt_4[1]);
+
+        EXPECT_DOUBLE_EQ(position_vector(0), 4.1366341767699426);
+        EXPECT_DOUBLE_EQ(position_vector(1), 0.39875540678255983);
+        EXPECT_DOUBLE_EQ(position_vector(2), -0.54161254963970273);
+    }
+
+    {
+        auto position_vector = CreatePositionVectors(pt_5[1]);
+
+        EXPECT_DOUBLE_EQ(position_vector(0), 5.);
+        EXPECT_DOUBLE_EQ(position_vector(1), 1.);
+        EXPECT_DOUBLE_EQ(position_vector(2), -1.);
+    }
+}
+
+TEST(SolverTest, UserDefinedQuadrature) {
+    auto quadrature_points = std::vector<double>{
+        -0.9491079123427585,  // point 1
+        -0.7415311855993945,  // point 2
+        -0.4058451513773972,  // point 3
+        0.,                   // point 4
+        0.4058451513773972,   // point 5
+        0.7415311855993945,   // point 6
+        0.9491079123427585    // point 7
+    };
     auto quadrature_weights = std::vector<double>{
-        0.1294849661688697, 0.2797053914892766, 0.3818300505051189, 0.4179591836734694,
-        0.3818300505051189, 0.2797053914892766, 0.1294849661688697};
-    auto quadrature_rule = UserDefinedQuadratureRule(quadrature_points, quadrature_weights);
+        0.1294849661688697,  // weight 1
+        0.2797053914892766,  // weight 2
+        0.3818300505051189,  // weight 3
+        0.4179591836734694,  // weight 4
+        0.3818300505051189,  // weight 5
+        0.2797053914892766,  // weight 6
+        0.1294849661688697   // weight 7
+    };
+    auto quadrature_rule = UserDefinedQuadrature(quadrature_points, quadrature_weights);
 
     EXPECT_EQ(quadrature_rule.GetNumQuadraturePoints(), 7);
     EXPECT_EQ(quadrature_rule.GetQuadraturePoints(), quadrature_points);

--- a/tests/unit_tests/gebt_poc/test_solver.cpp
+++ b/tests/unit_tests/gebt_poc/test_solver.cpp
@@ -73,4 +73,76 @@ TEST(SolverTest, CreateGeneralizedCoordinates) {
     }
 }
 
+Kokkos::View<double**> AssignGeneralizedCoordinatesToNodes(std::size_t order) {
+    auto nodes = GenerateGLLPoints(order);
+    auto generalized_coords = Kokkos::View<double**>("generalized_coords", order + 1, 7);
+    for (std::size_t i = 0; i < order + 1; ++i) {
+        auto xi = (nodes[i] + 1.) / 2.;
+        auto gen_coords = CreateGeneralizedCoordinates(xi);
+        Kokkos::parallel_for(
+            Kokkos::RangePolicy<Kokkos::DefaultExecutionSpace>(0, 7),
+            KOKKOS_LAMBDA(const int j) { generalized_coords(i, j) = gen_coords(j); }
+        );
+    }
+    return generalized_coords;
+}
+
+TEST(SolverTest, AssignGeneralizedCoordinatesToNodes) {
+    auto generalized_coords = AssignGeneralizedCoordinatesToNodes(4);
+
+    // Node 1
+    EXPECT_DOUBLE_EQ(generalized_coords(0, 0), 0.);
+    EXPECT_DOUBLE_EQ(generalized_coords(0, 1), 0.);
+    EXPECT_DOUBLE_EQ(generalized_coords(0, 2), 0.);
+    // Corresponding to rotation matrix {{1.,0,0}, {0,1.,0}, {0,0,1.}}
+    EXPECT_DOUBLE_EQ(generalized_coords(0, 3), 1.);
+    EXPECT_DOUBLE_EQ(generalized_coords(0, 4), 0.);
+    EXPECT_DOUBLE_EQ(generalized_coords(0, 5), 0.);
+    EXPECT_DOUBLE_EQ(generalized_coords(0, 6), 0.);
+
+    // Node 2
+    EXPECT_DOUBLE_EQ(generalized_coords(1, 0), 0.0029816021788868566);
+    EXPECT_DOUBLE_EQ(generalized_coords(1, 1), -0.00246675949494302);
+    EXPECT_DOUBLE_EQ(generalized_coords(1, 2), 0.0030845707156756234);
+    // Corresponding to rotation matrix
+    // {{1.,0,0}, {0,0.999851,-0.0172665}, {0,0.0172665,0.999851}}
+    EXPECT_DOUBLE_EQ(generalized_coords(1, 3), 0.99996273020427251);
+    EXPECT_DOUBLE_EQ(generalized_coords(1, 4), 0.008633550973807835);
+    EXPECT_DOUBLE_EQ(generalized_coords(1, 5), 0.);
+    EXPECT_DOUBLE_EQ(generalized_coords(1, 6), 0.);
+
+    // Node 3
+    EXPECT_DOUBLE_EQ(generalized_coords(2, 0), 0.025);
+    EXPECT_DOUBLE_EQ(generalized_coords(2, 1), -0.0125);
+    EXPECT_DOUBLE_EQ(generalized_coords(2, 2), 0.0275);
+    // Corresponding to rotation matrix
+    // {{1.,0,0}, {0,0.99875,-0.0499792}, {0,0.0499792,0.99875}}
+    EXPECT_DOUBLE_EQ(generalized_coords(2, 3), 0.99968751627570251);
+    EXPECT_DOUBLE_EQ(generalized_coords(2, 4), 0.024997395914712332);
+    EXPECT_DOUBLE_EQ(generalized_coords(2, 5), 0.);
+    EXPECT_DOUBLE_EQ(generalized_coords(2, 6), 0.);
+
+    // Node 4
+    EXPECT_DOUBLE_EQ(generalized_coords(3, 0), 0.068446969249684589);
+    EXPECT_DOUBLE_EQ(generalized_coords(3, 1), -0.011818954790771262);
+    EXPECT_DOUBLE_EQ(generalized_coords(3, 2), 0.079772572141467255);
+    // Corresponding to rotation matrix
+    // {{1.,0,0},{0,0.99658,-0.0826383},{0,0.0826383,0.99658}
+    EXPECT_DOUBLE_EQ(generalized_coords(3, 3), 0.99914453488230548);
+    EXPECT_DOUBLE_EQ(generalized_coords(3, 4), 0.041354545274025191);
+    EXPECT_DOUBLE_EQ(generalized_coords(3, 5), 0.);
+    EXPECT_DOUBLE_EQ(generalized_coords(3, 6), 0.);
+
+    // Node 5
+    EXPECT_DOUBLE_EQ(generalized_coords(4, 0), 0.1);
+    EXPECT_DOUBLE_EQ(generalized_coords(4, 1), 0.);
+    EXPECT_DOUBLE_EQ(generalized_coords(4, 2), 0.12);
+    // Corresponding to rotation matrix
+    // {{1.,0,0}, {0,0.995004,-0.0998334}, {0,0.0998334,0.995004}}
+    EXPECT_DOUBLE_EQ(generalized_coords(4, 3), 0.99875026039496628);
+    EXPECT_DOUBLE_EQ(generalized_coords(4, 4), 0.049979169270678324);
+    EXPECT_DOUBLE_EQ(generalized_coords(4, 5), 0.);
+    EXPECT_DOUBLE_EQ(generalized_coords(4, 6), 0.);
+}
+
 }  // namespace openturbine::gebt_poc::tests

--- a/tests/unit_tests/gebt_poc/test_solver.cpp
+++ b/tests/unit_tests/gebt_poc/test_solver.cpp
@@ -274,8 +274,8 @@ TEST(SolverTest, CalculateStaticResidual) {
         0.3818300505051189, 0.2797053914892766, 0.1294849661688697};
     auto quadrature_rule = UserDefinedQuadrature(quadrature_points, quadrature_weights);
 
-    auto residual =
-        CalculateStaticResidual(position_vectors, generalized_coords, stiffness, quadrature_rule);
+    // auto residual =
+    //     CalculateStaticResidual(position_vectors, generalized_coords, stiffness, quadrature_rule);
 
     // EXPECT_NEAR(residual(0), -0.111227, 1e-6);
     // EXPECT_NEAR(residual(1), -0.161488, 1e-6);

--- a/tests/unit_tests/gebt_poc/test_solver.cpp
+++ b/tests/unit_tests/gebt_poc/test_solver.cpp
@@ -145,4 +145,18 @@ TEST(SolverTest, AssignGeneralizedCoordinatesToNodes) {
     EXPECT_DOUBLE_EQ(generalized_coords(4, 6), 0.);
 }
 
+TEST(SolverTest, UserDefinedQuadratureRule) {
+    auto quadrature_points =
+        std::vector<double>{-0.9491079123427585, -0.7415311855993945, -0.4058451513773972, 0.,
+                            0.4058451513773972,  0.7415311855993945,  0.9491079123427585};
+    auto quadrature_weights = std::vector<double>{
+        0.1294849661688697, 0.2797053914892766, 0.3818300505051189, 0.4179591836734694,
+        0.3818300505051189, 0.2797053914892766, 0.1294849661688697};
+    auto quadrature_rule = UserDefinedQuadratureRule(quadrature_points, quadrature_weights);
+
+    EXPECT_EQ(quadrature_rule.GetNumQuadraturePoints(), 7);
+    EXPECT_EQ(quadrature_rule.GetQuadraturePoints(), quadrature_points);
+    EXPECT_EQ(quadrature_rule.GetQuadratureWeights(), quadrature_weights);
+}
+
 }  // namespace openturbine::gebt_poc::tests

--- a/tests/unit_tests/gebt_poc/test_solver.cpp
+++ b/tests/unit_tests/gebt_poc/test_solver.cpp
@@ -32,6 +32,34 @@ TEST(SolverTest, UserDefinedQuadrature) {
     EXPECT_EQ(quadrature.GetQuadratureWeights(), quadrature_weights);
 }
 
+TEST(SolverTest, CalculateInterpolatedValues) {
+    auto generalized_coords = Kokkos::View<double*>("generalized_coords", 14);
+    auto populate_generalized_coords = KOKKOS_LAMBDA(size_t) {
+        // node 1
+        generalized_coords(0) = 1.;
+        generalized_coords(1) = 2.;
+        generalized_coords(2) = 3.;
+        generalized_coords(3) = 0.;
+        generalized_coords(4) = -1.;
+        generalized_coords(5) = -2.;
+        generalized_coords(6) = -3.;
+        // node 2
+        generalized_coords(7) = 2.;
+        generalized_coords(8) = 3.;
+        generalized_coords(9) = 4.;
+        generalized_coords(10) = 0.;
+        generalized_coords(11) = 1.;
+        generalized_coords(12) = 4.;
+        generalized_coords(13) = 9.;
+    };
+    Kokkos::parallel_for(1, populate_generalized_coords);
+    auto quadrature_pt = 0.;
+
+    openturbine::gen_alpha_solver::tests::expect_kokkos_view_1D_equal(
+        Interpolate(generalized_coords, quadrature_pt), {1.5, 2.5, 3.5, 0., 0., 1., 3.}
+    );
+}
+
 TEST(SolverTest, CalculateStaticResidual) {
     auto position_vectors = Kokkos::View<double*>("position_vectors", 35);
     auto populate_position_vector = KOKKOS_LAMBDA(size_t) {

--- a/tests/unit_tests/gen_alpha_poc/test_math_utilities.cpp
+++ b/tests/unit_tests/gen_alpha_poc/test_math_utilities.cpp
@@ -310,6 +310,13 @@ TEST(MathUtilitiesTest, Multiply3x3MatrixWith3x3Matrix) {
     expect_kokkos_view_2D_equal(result, {{30., 36., 42.}, {66., 81., 96.}, {102., 126., 150.}});
 }
 
+TEST(MathUtilitiesTest, Multiply3x1VectorWithAScalar) {
+    auto vector = create_vector({1., 2., 3.});
+    auto result = multiply_vector_with_scalar(vector, 2.);
+
+    expect_kokkos_view_1D_equal(result, {2., 4., 6.});
+}
+
 TEST(MathUtilitiesTest, Multiply3x3MatrixWithAScalar) {
     auto matrix = create_matrix({{1., 2., 3.}, {4., 5., 6.}, {7., 8., 9.}});
     auto result = multiply_matrix_with_scalar(matrix, 2.);

--- a/tests/unit_tests/gen_alpha_poc/test_math_utilities.cpp
+++ b/tests/unit_tests/gen_alpha_poc/test_math_utilities.cpp
@@ -317,4 +317,20 @@ TEST(MathUtilitiesTest, Multiply3x3MatrixWithAScalar) {
     expect_kokkos_view_2D_equal(result, {{2., 4., 6.}, {8., 10., 12.}, {14., 16., 18.}});
 }
 
+TEST(MathUtilitiesTest, Add3x3MatrixTo3x3Matrix) {
+    auto matrix_a = create_matrix({{1., 2., 3.}, {4., 5., 6.}, {7., 8., 9.}});
+    auto matrix_b = create_matrix({{1., 2., 3.}, {4., 5., 6.}, {7., 8., 9.}});
+    auto result = add_matrix_with_matrix(matrix_a, matrix_b);
+
+    expect_kokkos_view_2D_equal(result, {{2., 4., 6.}, {8., 10., 12.}, {14., 16., 18.}});
+}
+
+TEST(MathUtilitiesTest, CalculateDotProduct) {
+    auto vector_a = create_vector({1., 2., 3.});
+    auto vector_b = create_vector({4., 5., 6.});
+    auto result = dot_product(vector_a, vector_b);
+
+    expect_kokkos_view_1D_equal(result, {32.});
+}
+
 }  // namespace openturbine::gen_alpha_solver::tests

--- a/tests/unit_tests/gen_alpha_poc/test_quaternions.cpp
+++ b/tests/unit_tests/gen_alpha_poc/test_quaternions.cpp
@@ -488,4 +488,28 @@ INSTANTIATE_TEST_SUITE_P(
     )
 );
 
+TEST(QuaternionTest, CreateBMatrixForUnitQuaternions) {
+    {
+        Quaternion q(1., 0., 0., 0.);
+        auto bmatrix = BMatrixForQuaternions(q);
+
+        expect_kokkos_view_2D_equal(
+            bmatrix, {{0., 1., 0., 0.}, {0., 0., 1., -0.}, {0., 0., 0., 1.}}
+        );
+    }
+    {
+        auto l = std::sqrt(30.);
+        auto q0 = 1. / l;
+        auto q1 = 2. / l;
+        auto q2 = 3. / l;
+        auto q3 = 4. / l;
+        Quaternion q(q0, q1, q2, q3);
+        auto bmatrix = BMatrixForQuaternions(q);
+
+        expect_kokkos_view_2D_equal(
+            bmatrix, {{-q1, q0, -q3, q2}, {-q2, q3, q0, -q1}, {-q3, -q2, q1, q0}}
+        );
+    }
+}
+
 }  // namespace openturbine::gen_alpha_solver::tests

--- a/tests/unit_tests/gen_alpha_poc/test_rotation_matrix.cpp
+++ b/tests/unit_tests/gen_alpha_poc/test_rotation_matrix.cpp
@@ -1,6 +1,7 @@
 #include <gtest/gtest.h>
 
 #include "src/gen_alpha_poc/rotation_matrix.h"
+#include "tests/unit_tests/gen_alpha_poc/test_utilities.h"
 
 namespace openturbine::gen_alpha_solver::tests {
 
@@ -32,6 +33,19 @@ TEST(RotationMatrixTest, CreateFromComponents) {
     ASSERT_EQ(matrix(2, 0), 7.);
     ASSERT_EQ(matrix(2, 1), 8.);
     ASSERT_EQ(matrix(2, 2), 9.);
+}
+
+TEST(RotationMatrixTest, GetComponents) {
+    RotationMatrix matrix(1., 2., 3., 4., 5., 6., 7., 8., 9.);
+
+    openturbine::gen_alpha_solver::tests::expect_kokkos_view_2D_equal(
+        matrix.GetRotationMatrix(),
+        {
+            {1., 2., 3.},  // row 1
+            {4., 5., 6.},  // row 2
+            {7., 8., 9.}   // row 3
+        }
+    );
 }
 
 }  // namespace openturbine::gen_alpha_solver::tests


### PR DESCRIPTION
Fixes #72.

This one got a little bit out of hand with the pull request size, we could have broken this work down into more granular pieces. However, all the components are unit tested based on the preliminary work on mathematica notebooks found [here](https://github.com/michaelasprague/OpenTurbineTheory/tree/main/mathematica). 

N.B: We would like to tweak the logic a little bit to work with finite element mesh consisting of several elements (as opposed to just one as assumed here), however it shouldn't be anything major development effort-wise.