### PR TITLE
Modified Generalized alpha solver to use the field_data and mesh data structures

### DIFF
--- a/src/gebt_poc/gebt_generalized_alpha_time_integrator.h
+++ b/src/gebt_poc/gebt_generalized_alpha_time_integrator.h
@@ -158,9 +158,7 @@ public:
                     auto orientation_vector =
                         Kokkos::subview(delta_coordinates, Kokkos::pair<int, int>(3, 6));
                     auto updated_orientation = Kokkos::View<double[4]>("updated_orientation");
-                    exponential_mapping_with_scale(
-                        updated_orientation, orientation_vector, h
-                    );  
+                    exponential_mapping_with_scale(updated_orientation, orientation_vector, h);
                     auto current_orientation =
                         Kokkos::subview(coordinates, Kokkos::pair<int, int>(3, 7));
                     auto next_orientation =
@@ -235,7 +233,9 @@ public:
     }
 
     friend GeneralizedAlphaStepper CreateBasicStepper();
-    friend GeneralizedAlphaStepper CreateUnityStepper(double alpha_f, double alpha_m, double beta, double gamma, bool preconditioner);
+    friend GeneralizedAlphaStepper CreateUnityStepper(
+        double alpha_f, double alpha_m, double beta, double gamma, bool preconditioner
+    );
 
 protected:
     GeneralizedAlphaStepper() = default;
@@ -266,7 +266,9 @@ protected:
     bool is_preconditioned_;
 };
 
-GeneralizedAlphaStepper CreateUnityStepper(double alpha_f, double alpha_m, double beta, double gamma, bool preconditioner) {
+GeneralizedAlphaStepper CreateUnityStepper(
+    double alpha_f, double alpha_m, double beta, double gamma, bool preconditioner
+) {
     GeneralizedAlphaStepper stepper;
     stepper.SetParameters(alpha_f, alpha_m, beta, gamma);
     stepper.SetPreconditioner(preconditioner);
@@ -276,8 +278,7 @@ GeneralizedAlphaStepper CreateUnityStepper(double alpha_f, double alpha_m, doubl
     return stepper;
 }
 GeneralizedAlphaStepper CreateBasicStepper() {
-  return CreateUnityStepper(0., 0., .5, 1., false);
+    return CreateUnityStepper(0., 0., .5, 1., false);
 }
-
 
 }  // namespace openturbine::gebt_poc

--- a/src/gebt_poc/gebt_generalized_alpha_time_integrator.h
+++ b/src/gebt_poc/gebt_generalized_alpha_time_integrator.h
@@ -1,231 +1,281 @@
 #pragma once
 
-#include <KokkosBlas1_scal.hpp>
 #include <KokkosBlas1_axpby.hpp>
-#include <KokkosBlas1_nrm2.hpp>
 #include <KokkosBlas1_fill.hpp>
+#include <KokkosBlas1_nrm2.hpp>
+#include <KokkosBlas1_scal.hpp>
 #include <KokkosBlas3_gemm.hpp>
- 
-#include "src/gen_alpha_poc/solver.h"
- 
-#include "src/gebt_poc/mesh.h"
+
 #include "src/gebt_poc/field_data.h"
+#include "src/gebt_poc/mesh.h"
+#include "src/gen_alpha_poc/solver.h"
 
 namespace openturbine::gebt_poc {
 
 class LinearizationParameters {
 public:
-virtual void ComputeResidualVector(Kokkos::View<double*> residuals, Mesh& mesh, FieldData& field_data, Kokkos::View<double*> lagrange_mults) = 0;
+    virtual void ComputeResidualVector(
+        Kokkos::View<double*> residuals, Mesh& mesh, FieldData& field_data,
+        Kokkos::View<double*> lagrange_mults
+    ) = 0;
 
-virtual void ComputeIterationMatrix(Kokkos::View<double**> iteration_matrix, double h, double betaPrime, double gammaPrime, Mesh& mesh, FieldData& field_data, Kokkos::View<double*> lagrange_mults) = 0;
+    virtual void ComputeIterationMatrix(
+        Kokkos::View<double**> iteration_matrix, double h, double betaPrime, double gammaPrime,
+        Mesh& mesh, FieldData& field_data, Kokkos::View<double*> lagrange_mults
+    ) = 0;
 };
 
-class UnityLinearizationParameters : public LinearizationParameters{
+class UnityLinearizationParameters : public LinearizationParameters {
 public:
-void ComputeResidualVector(Kokkos::View<double*> residuals, Mesh& mesh, FieldData& field_data, Kokkos::View<double*> lagrange_mults) {
-  KokkosBlas::fill(residuals, 1.);
-}
-
-void ComputeIterationMatrix(Kokkos::View<double**> iteration_matrix, double h, double betaPrime, double gammaPrime, Mesh& mesh, FieldData& field_data, Kokkos::View<double*> lagrange_mults) {
-  Kokkos::parallel_for(iteration_matrix.extent(0), KOKKOS_LAMBDA(std::size_t i) {
-    for(std::size_t j = 0; j < iteration_matrix.extent(1); ++j) {
-      iteration_matrix(i, j) = (i == j);
+    void ComputeResidualVector(
+        Kokkos::View<double*> residuals, Mesh& mesh, FieldData& field_data,
+        Kokkos::View<double*> lagrange_mults
+    ) {
+        KokkosBlas::fill(residuals, 1.);
     }
-  });
-}
 
+    void ComputeIterationMatrix(
+        Kokkos::View<double**> iteration_matrix, double h, double betaPrime, double gammaPrime,
+        Mesh& mesh, FieldData& field_data, Kokkos::View<double*> lagrange_mults
+    ) {
+        Kokkos::parallel_for(
+            iteration_matrix.extent(0),
+            KOKKOS_LAMBDA(std::size_t i) {
+                for (std::size_t j = 0; j < iteration_matrix.extent(1); ++j) {
+                    iteration_matrix(i, j) = (i == j);
+                }
+            }
+        );
+    }
 };
 
 KOKKOS_FUNCTION
-void exponential_mapping_with_scale(Kokkos::View<double*> quaternion, Kokkos::View<double*> vector, double scale) {
-  auto a = openturbine::gen_alpha_solver::Vector(vector(0) * scale, vector(1) * scale, vector(2) * scale);
-  auto b = openturbine::gen_alpha_solver::quaternion_from_rotation_vector(a);
-  quaternion(0) = b.GetScalarComponent();
-  quaternion(1) = b.GetXComponent();
-  quaternion(2) = b.GetYComponent();
-  quaternion(3) = b.GetZComponent();
+void exponential_mapping_with_scale(
+    Kokkos::View<double*> quaternion, Kokkos::View<double*> vector, double scale
+) {
+    auto a = openturbine::gen_alpha_solver::Vector(
+        vector(0) * scale, vector(1) * scale, vector(2) * scale
+    );
+    auto b = openturbine::gen_alpha_solver::quaternion_from_rotation_vector(a);
+    quaternion(0) = b.GetScalarComponent();
+    quaternion(1) = b.GetXComponent();
+    quaternion(2) = b.GetYComponent();
+    quaternion(3) = b.GetZComponent();
 }
 
 KOKKOS_FUNCTION
 void quaternion_mult(Kokkos::View<double*> out, Kokkos::View<double*> q1, Kokkos::View<double*> q2) {
-  auto a = openturbine::gen_alpha_solver::Quaternion(q1(0), q1(1), q1(2), q1(3));
-  auto b = openturbine::gen_alpha_solver::Quaternion(q2(0), q2(1), q2(2), q2(3));
-  auto c = a * b;
-  out(0) = c.GetScalarComponent();
-  out(1) = c.GetXComponent();
-  out(2) = c.GetYComponent();
-  out(3) = c.GetZComponent();
+    auto a = openturbine::gen_alpha_solver::Quaternion(q1(0), q1(1), q1(2), q1(3));
+    auto b = openturbine::gen_alpha_solver::Quaternion(q2(0), q2(1), q2(2), q2(3));
+    auto c = a * b;
+    out(0) = c.GetScalarComponent();
+    out(1) = c.GetXComponent();
+    out(2) = c.GetYComponent();
+    out(3) = c.GetZComponent();
 }
 
 class GeneralizedAlphaStepper {
 public:
-  bool Step(Mesh& mesh, FieldData& field_data, std::size_t lagrange_multipliers, double time_step_size, std::size_t max_iterations) {
-    constexpr auto lie_algebra_size = 6;
-    constexpr auto lie_group_size = 7;
-    auto alphaF = alphaF_;
-    auto alphaM = alphaM_;
-    auto beta = beta_;
-    auto gamma = gamma_;
-    auto h = time_step_size;
+    bool Step(
+        Mesh& mesh, FieldData& field_data, std::size_t lagrange_multipliers, double time_step_size,
+        std::size_t max_iterations
+    ) {
+        constexpr auto lie_algebra_size = 6;
+        constexpr auto lie_group_size = 7;
+        auto alphaF = alphaF_;
+        auto alphaM = alphaM_;
+        auto beta = beta_;
+        auto gamma = gamma_;
+        auto h = time_step_size;
 
-    auto num_nodes = mesh.GetNumberOfNodes();
-    auto number_of_constraints = lagrange_multipliers;
-    auto dof_size = lie_algebra_size * num_nodes;
-    auto residual_size = dof_size + number_of_constraints;
+        auto num_nodes = mesh.GetNumberOfNodes();
+        auto number_of_constraints = lagrange_multipliers;
+        auto dof_size = lie_algebra_size * num_nodes;
+        auto residual_size = dof_size + number_of_constraints;
 
-    auto lagrange_mults = Kokkos::View<double*>("lagrange_mults", lagrange_multipliers);
-    auto residuals = Kokkos::View<double*>("residual", residual_size);
-    auto iteration_matrix = Kokkos::View<double**>("iteration matrix", residual_size, residual_size);
-    auto left_pre = Kokkos::View<double**>("left preconditioner", residual_size, residual_size);
-    auto right_pre = Kokkos::View<double**>("left preconditioner", residual_size, residual_size);
-    
-    auto dof_residuals = Kokkos::subview(residuals, Kokkos::pair<int,int>(0, dof_size));
-    auto lagrange_residuals = Kokkos::subview(residuals, Kokkos::pair<int,int>(dof_size, residual_size));
+        auto lagrange_mults = Kokkos::View<double*>("lagrange_mults", lagrange_multipliers);
+        auto residuals = Kokkos::View<double*>("residual", residual_size);
+        auto iteration_matrix =
+            Kokkos::View<double**>("iteration matrix", residual_size, residual_size);
+        auto left_pre = Kokkos::View<double**>("left preconditioner", residual_size, residual_size);
+        auto right_pre = Kokkos::View<double**>("left preconditioner", residual_size, residual_size);
 
-    Kokkos::parallel_for(mesh.GetNumberOfNodes(), KOKKOS_LAMBDA(std::size_t node) {
-      auto acceleration = field_data.GetNodalData<Field::Acceleration>(node);
-      auto algo_acceleration_next = field_data.GetNodalData<Field::AlgorithmicAccelerationNext>(node);
-      auto delta_coordinates = field_data.GetNodalData<Field::DeltaCoordinates>(node);
-      auto velocity = field_data.GetNodalData<Field::Velocity>(node);
-      auto algo_acceleration = field_data.GetNodalData<Field::AlgorithmicAcceleration>(node);
+        auto dof_residuals = Kokkos::subview(residuals, Kokkos::pair<int, int>(0, dof_size));
+        auto lagrange_residuals =
+            Kokkos::subview(residuals, Kokkos::pair<int, int>(dof_size, residual_size));
 
-      for(int i = 0; i < lie_algebra_size; ++i) {
-        algo_acceleration_next(i) = (alphaF * acceleration(i) - alphaM * algo_acceleration(i)) / (1. - alphaM);
-        delta_coordinates(i) = velocity(i) + h * (.5 - beta) * algo_acceleration(i) + h * beta * algo_acceleration_next(i);
-        velocity(i) += h * (1. - gamma) * algo_acceleration(i) + h * gamma * algo_acceleration_next(i);
-        algo_acceleration(i) = algo_acceleration_next(i);
-        acceleration(i) = 0.;
-      }
-    });
-    Kokkos::deep_copy(lagrange_mults, 0.);
+        Kokkos::parallel_for(
+            mesh.GetNumberOfNodes(),
+            KOKKOS_LAMBDA(std::size_t node) {
+                auto acceleration = field_data.GetNodalData<Field::Acceleration>(node);
+                auto algo_acceleration_next =
+                    field_data.GetNodalData<Field::AlgorithmicAccelerationNext>(node);
+                auto delta_coordinates = field_data.GetNodalData<Field::DeltaCoordinates>(node);
+                auto velocity = field_data.GetNodalData<Field::Velocity>(node);
+                auto algo_acceleration =
+                    field_data.GetNodalData<Field::AlgorithmicAcceleration>(node);
 
-    auto betaPrime = (1. - alphaM) / (h * h * beta *(1 - alphaF));
-    auto gammaPrime = gamma / (h * beta);
-    auto scalar_pre = (is_preconditioned_) ? beta * h * h : 1.;
+                for (int i = 0; i < lie_algebra_size; ++i) {
+                    algo_acceleration_next(i) =
+                        (alphaF * acceleration(i) - alphaM * algo_acceleration(i)) / (1. - alphaM);
+                    delta_coordinates(i) = velocity(i) + h * (.5 - beta) * algo_acceleration(i) +
+                                           h * beta * algo_acceleration_next(i);
+                    velocity(i) += h * (1. - gamma) * algo_acceleration(i) +
+                                   h * gamma * algo_acceleration_next(i);
+                    algo_acceleration(i) = algo_acceleration_next(i);
+                    acceleration(i) = 0.;
+                }
+            }
+        );
+        Kokkos::deep_copy(lagrange_mults, 0.);
 
-    Kokkos::deep_copy(left_pre, 0.);
-    Kokkos::deep_copy(right_pre, 0.);
-    Kokkos::parallel_for(residual_size, KOKKOS_LAMBDA(int i) {
-      left_pre(i, i) = (i < dof_size) ? scalar_pre : 1.;
-      right_pre(i, i) = (i < dof_size) ? 1. : 1. / scalar_pre;
-    });
+        auto betaPrime = (1. - alphaM) / (h * h * beta * (1 - alphaF));
+        auto gammaPrime = gamma / (h * beta);
+        auto scalar_pre = (is_preconditioned_) ? beta * h * h : 1.;
 
-    std::size_t nonlinear_iteration;
-    bool is_converged = false;
-    for(nonlinear_iteration = 0; nonlinear_iteration < max_iterations; ++nonlinear_iteration) {
-      Kokkos::parallel_for(mesh.GetNumberOfNodes(), KOKKOS_LAMBDA(std::size_t node) {
-        auto coordinates_next = field_data.GetNodalData<Field::CoordinatesNext>(node);
-        auto coordinates = field_data.GetNodalData<Field::Coordinates>(node);
-        auto delta_coordinates = field_data.GetNodalData<Field::DeltaCoordinates>(node);
-        for(int i = 0; i < 3; ++i) {
-          coordinates_next(i) = coordinates(i) + delta_coordinates(i) * h;
-        } 
-  
-        auto orientation_vector = Kokkos::subview(delta_coordinates, Kokkos::pair<int,int>(3,6));
-        auto updated_orientation = Kokkos::View<double[4]>("updated_orientation");
-        exponential_mapping_with_scale(updated_orientation, orientation_vector, h); //must use orientation_vector * h
-        auto current_orientation = Kokkos::subview(coordinates, Kokkos::pair<int,int>(3,7));
-        auto next_orientation = Kokkos::subview(coordinates_next, Kokkos::pair<int,int>(3,7));
-        quaternion_mult(next_orientation, current_orientation, updated_orientation);
-      });
+        Kokkos::deep_copy(left_pre, 0.);
+        Kokkos::deep_copy(right_pre, 0.);
+        Kokkos::parallel_for(
+            residual_size,
+            KOKKOS_LAMBDA(int i) {
+                left_pre(i, i) = (i < dof_size) ? scalar_pre : 1.;
+                right_pre(i, i) = (i < dof_size) ? 1. : 1. / scalar_pre;
+            }
+        );
 
-      assembler_->ComputeResidualVector(residuals, mesh, field_data, lagrange_mults);
-      
-      if((is_converged = CheckConvergence(residuals))) {
-        return is_converged;
-      }
+        std::size_t nonlinear_iteration;
+        bool is_converged = false;
+        for (nonlinear_iteration = 0; nonlinear_iteration < max_iterations; ++nonlinear_iteration) {
+            Kokkos::parallel_for(
+                mesh.GetNumberOfNodes(),
+                KOKKOS_LAMBDA(std::size_t node) {
+                    auto coordinates_next = field_data.GetNodalData<Field::CoordinatesNext>(node);
+                    auto coordinates = field_data.GetNodalData<Field::Coordinates>(node);
+                    auto delta_coordinates = field_data.GetNodalData<Field::DeltaCoordinates>(node);
+                    for (int i = 0; i < 3; ++i) {
+                        coordinates_next(i) = coordinates(i) + delta_coordinates(i) * h;
+                    }
 
-      assembler_->ComputeIterationMatrix(iteration_matrix, h, betaPrime, gammaPrime, mesh, field_data, lagrange_mults);
+                    auto orientation_vector =
+                        Kokkos::subview(delta_coordinates, Kokkos::pair<int, int>(3, 6));
+                    auto updated_orientation = Kokkos::View<double[4]>("updated_orientation");
+                    exponential_mapping_with_scale(
+                        updated_orientation, orientation_vector, h
+                    );  // must use orientation_vector * h
+                    auto current_orientation =
+                        Kokkos::subview(coordinates, Kokkos::pair<int, int>(3, 7));
+                    auto next_orientation =
+                        Kokkos::subview(coordinates_next, Kokkos::pair<int, int>(3, 7));
+                    quaternion_mult(next_orientation, current_orientation, updated_orientation);
+                }
+            );
 
-      KokkosBlas::gemm("N", "N", 1., iteration_matrix, right_pre, 0., iteration_matrix);
-      KokkosBlas::gemm("N", "N", 1., left_pre, iteration_matrix, 0., iteration_matrix);
-      KokkosBlas::scal(dof_residuals, scalar_pre, dof_residuals);
- 
-      openturbine::gen_alpha_solver::solve_linear_system(iteration_matrix, residuals);
+            assembler_->ComputeResidualVector(residuals, mesh, field_data, lagrange_mults);
 
-      KokkosBlas::scal(residuals, -1., residuals);
+            if ((is_converged = CheckConvergence(residuals))) {
+                return is_converged;
+            }
 
-      KokkosBlas::axpby(-1. / scalar_pre, lagrange_residuals, 1., lagrange_mults);
+            assembler_->ComputeIterationMatrix(
+                iteration_matrix, h, betaPrime, gammaPrime, mesh, field_data, lagrange_mults
+            );
 
-      Kokkos::parallel_for(mesh.GetNumberOfNodes(), KOKKOS_LAMBDA(std::size_t node) {
-        auto delta_coordinates = field_data.GetNodalData<Field::DeltaCoordinates>(node);
-        auto velocity = field_data.GetNodalData<Field::Velocity>(node);
-        auto acceleration = field_data.GetNodalData<Field::Acceleration>(node);
+            KokkosBlas::gemm("N", "N", 1., iteration_matrix, right_pre, 0., iteration_matrix);
+            KokkosBlas::gemm("N", "N", 1., left_pre, iteration_matrix, 0., iteration_matrix);
+            KokkosBlas::scal(dof_residuals, scalar_pre, dof_residuals);
 
-        int start_index = node * lie_algebra_size;
-        int end_index = start_index + lie_algebra_size;
-        auto update = Kokkos::subview(dof_residuals, Kokkos::pair<int,int>(start_index, end_index));
-        for(int i = 0; i < lie_algebra_size; ++i) {
-          delta_coordinates(i) += update(i) / h;
-          velocity(i) += gammaPrime * update(i);
-          acceleration(i) += betaPrime * update(i);
+            openturbine::gen_alpha_solver::solve_linear_system(iteration_matrix, residuals);
+
+            KokkosBlas::scal(residuals, -1., residuals);
+
+            KokkosBlas::axpby(-1. / scalar_pre, lagrange_residuals, 1., lagrange_mults);
+
+            Kokkos::parallel_for(
+                mesh.GetNumberOfNodes(),
+                KOKKOS_LAMBDA(std::size_t node) {
+                    auto delta_coordinates = field_data.GetNodalData<Field::DeltaCoordinates>(node);
+                    auto velocity = field_data.GetNodalData<Field::Velocity>(node);
+                    auto acceleration = field_data.GetNodalData<Field::Acceleration>(node);
+
+                    int start_index = node * lie_algebra_size;
+                    int end_index = start_index + lie_algebra_size;
+                    auto update = Kokkos::subview(
+                        dof_residuals, Kokkos::pair<int, int>(start_index, end_index)
+                    );
+                    for (int i = 0; i < lie_algebra_size; ++i) {
+                        delta_coordinates(i) += update(i) / h;
+                        velocity(i) += gammaPrime * update(i);
+                        acceleration(i) += betaPrime * update(i);
+                    }
+                }
+            );
         }
-      });
+
+        Kokkos::parallel_for(
+            mesh.GetNumberOfNodes(),
+            KOKKOS_LAMBDA(std::size_t node) {
+                auto algo_acceleration_next =
+                    field_data.GetNodalData<Field::AlgorithmicAccelerationNext>(node);
+                auto acceleration = field_data.GetNodalData<Field::Acceleration>(node);
+                for (std::size_t i = 0; i < lie_algebra_size; ++i) {
+                    algo_acceleration_next(i) += (1. - alphaF) / (1. - alphaM) * acceleration(i);
+                }
+
+                auto algo_acceleration =
+                    field_data.GetNodalData<Field::AlgorithmicAcceleration>(node);
+                for (std::size_t i = 0; i < lie_algebra_size; ++i) {
+                    algo_acceleration(i) = algo_acceleration_next(i);
+                }
+
+                auto coordinates = field_data.GetNodalData<Field::Coordinates>(node);
+                auto coordinates_next = field_data.GetNodalData<Field::CoordinatesNext>(node);
+                for (std::size_t i = 0; i < lie_group_size; ++i) {
+                    coordinates(i) = coordinates_next(i);
+                }
+            }
+        );
+        return is_converged;
     }
 
-    Kokkos::parallel_for(mesh.GetNumberOfNodes(), KOKKOS_LAMBDA(std::size_t node) {
-      auto algo_acceleration_next = field_data.GetNodalData<Field::AlgorithmicAccelerationNext>(node);
-      auto acceleration = field_data.GetNodalData<Field::Acceleration>(node);
-      for(std::size_t i = 0; i < lie_algebra_size; ++i) {
-        algo_acceleration_next(i) += (1. - alphaF) / (1. - alphaM) * acceleration(i);
-      }
-
-      auto algo_acceleration = field_data.GetNodalData<Field::AlgorithmicAcceleration>(node);
-      for(std::size_t i = 0; i < lie_algebra_size; ++i) {
-        algo_acceleration(i) = algo_acceleration_next(i);
-      }
-
-      auto coordinates = field_data.GetNodalData<Field::Coordinates>(node);
-      auto coordinates_next = field_data.GetNodalData<Field::CoordinatesNext>(node);
-      for(std::size_t i = 0; i < lie_group_size; ++i) {
-        coordinates(i) = coordinates_next(i);
-      }
-    });
-    return is_converged;
-  }
-
-
-  friend GeneralizedAlphaStepper CreateBasicStepper();
+    friend GeneralizedAlphaStepper CreateBasicStepper();
 
 protected:
-  GeneralizedAlphaStepper() = default;
+    GeneralizedAlphaStepper() = default;
 
-  void SetParameters(double alpha_f, double alpha_m, double beta, double gamma) {
-   alphaF_ = alpha_f;
-   alphaM_ = alpha_m;
-   beta_ = beta;
-   gamma_ = gamma;
-  }
+    void SetParameters(double alpha_f, double alpha_m, double beta, double gamma) {
+        alphaF_ = alpha_f;
+        alphaM_ = alpha_m;
+        beta_ = beta;
+        gamma_ = gamma;
+    }
 
-  void SetPreconditioner(bool is_preconditioned) {
-    is_preconditioned_ = is_preconditioned;
-  }
+    void SetPreconditioner(bool is_preconditioned) { is_preconditioned_ = is_preconditioned; }
 
-  void SetSystemAssembler(std::shared_ptr<LinearizationParameters> assembler) {
-    assembler_ = assembler;
-  }
+    void SetSystemAssembler(std::shared_ptr<LinearizationParameters> assembler) {
+        assembler_ = assembler;
+    }
 
-  bool CheckConvergence(Kokkos::View<double*> residuals) {
-    return KokkosBlas::nrm2(residuals) < 1.e-10;
-  }
+    bool CheckConvergence(Kokkos::View<double*> residuals) {
+        return KokkosBlas::nrm2(residuals) < 1.e-10;
+    }
 
-  std::shared_ptr<LinearizationParameters> assembler_;
+    std::shared_ptr<LinearizationParameters> assembler_;
 
-  double alphaF_;
-  double alphaM_;
-  double beta_;
-  double gamma_;
-  bool is_preconditioned_;
+    double alphaF_;
+    double alphaM_;
+    double beta_;
+    double gamma_;
+    bool is_preconditioned_;
 };
 
 GeneralizedAlphaStepper CreateBasicStepper() {
-  GeneralizedAlphaStepper stepper;
-  stepper.SetParameters(0., 0., .5, 1.);
-  stepper.SetPreconditioner(false);
+    GeneralizedAlphaStepper stepper;
+    stepper.SetParameters(0., 0., .5, 1.);
+    stepper.SetPreconditioner(false);
 
-  stepper.SetSystemAssembler(std::make_shared<UnityLinearizationParameters>());
+    stepper.SetSystemAssembler(std::make_shared<UnityLinearizationParameters>());
 
-  return stepper;
+    return stepper;
 }
 
-}
+}  // namespace openturbine::gebt_poc

--- a/src/gebt_poc/gebt_generalized_alpha_time_integrator.h
+++ b/src/gebt_poc/gebt_generalized_alpha_time_integrator.h
@@ -8,7 +8,9 @@
 
 #include "src/gebt_poc/field_data.h"
 #include "src/gebt_poc/mesh.h"
+#include "src/gen_alpha_poc/quaternion.h"
 #include "src/gen_alpha_poc/solver.h"
+#include "src/gen_alpha_poc/vector.h"
 
 namespace openturbine::gebt_poc {
 
@@ -27,17 +29,13 @@ public:
 
 class UnityLinearizationParameters : public LinearizationParameters {
 public:
-    void ComputeResidualVector(
-        Kokkos::View<double*> residuals, Mesh& mesh, FieldData& field_data,
-        Kokkos::View<double*> lagrange_mults
-    ) {
+    void
+    ComputeResidualVector(Kokkos::View<double*> residuals, Mesh&, FieldData&, Kokkos::View<double*>) {
         KokkosBlas::fill(residuals, 1.);
     }
 
-    void ComputeIterationMatrix(
-        Kokkos::View<double**> iteration_matrix, double h, double betaPrime, double gammaPrime,
-        Mesh& mesh, FieldData& field_data, Kokkos::View<double*> lagrange_mults
-    ) {
+    void
+    ComputeIterationMatrix(Kokkos::View<double**> iteration_matrix, double, double, double, Mesh&, FieldData&, Kokkos::View<double*>) {
         Kokkos::parallel_for(
             iteration_matrix.extent(0),
             KOKKOS_LAMBDA(std::size_t i) {

--- a/src/gebt_poc/gebt_generalized_alpha_time_integrator.h
+++ b/src/gebt_poc/gebt_generalized_alpha_time_integrator.h
@@ -1,0 +1,231 @@
+#pragma once
+
+#include <KokkosBlas1_scal.hpp>
+#include <KokkosBlas1_axpby.hpp>
+#include <KokkosBlas1_nrm2.hpp>
+#include <KokkosBlas1_fill.hpp>
+#include <KokkosBlas3_gemm.hpp>
+ 
+#include "src/gen_alpha_poc/solver.h"
+ 
+#include "src/gebt_poc/mesh.h"
+#include "src/gebt_poc/field_data.h"
+
+namespace openturbine::gebt_poc {
+
+class LinearizationParameters {
+public:
+virtual void ComputeResidualVector(Kokkos::View<double*> residuals, Mesh& mesh, FieldData& field_data, Kokkos::View<double*> lagrange_mults) = 0;
+
+virtual void ComputeIterationMatrix(Kokkos::View<double**> iteration_matrix, double h, double betaPrime, double gammaPrime, Mesh& mesh, FieldData& field_data, Kokkos::View<double*> lagrange_mults) = 0;
+};
+
+class UnityLinearizationParameters : public LinearizationParameters{
+public:
+void ComputeResidualVector(Kokkos::View<double*> residuals, Mesh& mesh, FieldData& field_data, Kokkos::View<double*> lagrange_mults) {
+  KokkosBlas::fill(residuals, 1.);
+}
+
+void ComputeIterationMatrix(Kokkos::View<double**> iteration_matrix, double h, double betaPrime, double gammaPrime, Mesh& mesh, FieldData& field_data, Kokkos::View<double*> lagrange_mults) {
+  Kokkos::parallel_for(iteration_matrix.extent(0), KOKKOS_LAMBDA(std::size_t i) {
+    for(std::size_t j = 0; j < iteration_matrix.extent(1); ++j) {
+      iteration_matrix(i, j) = (i == j);
+    }
+  });
+}
+
+};
+
+KOKKOS_FUNCTION
+void exponential_mapping_with_scale(Kokkos::View<double*> quaternion, Kokkos::View<double*> vector, double scale) {
+  auto a = openturbine::gen_alpha_solver::Vector(vector(0) * scale, vector(1) * scale, vector(2) * scale);
+  auto b = openturbine::gen_alpha_solver::quaternion_from_rotation_vector(a);
+  quaternion(0) = b.GetScalarComponent();
+  quaternion(1) = b.GetXComponent();
+  quaternion(2) = b.GetYComponent();
+  quaternion(3) = b.GetZComponent();
+}
+
+KOKKOS_FUNCTION
+void quaternion_mult(Kokkos::View<double*> out, Kokkos::View<double*> q1, Kokkos::View<double*> q2) {
+  auto a = openturbine::gen_alpha_solver::Quaternion(q1(0), q1(1), q1(2), q1(3));
+  auto b = openturbine::gen_alpha_solver::Quaternion(q2(0), q2(1), q2(2), q2(3));
+  auto c = a * b;
+  out(0) = c.GetScalarComponent();
+  out(1) = c.GetXComponent();
+  out(2) = c.GetYComponent();
+  out(3) = c.GetZComponent();
+}
+
+class GeneralizedAlphaStepper {
+public:
+  bool Step(Mesh& mesh, FieldData& field_data, std::size_t lagrange_multipliers, double time_step_size, std::size_t max_iterations) {
+    constexpr auto lie_algebra_size = 6;
+    constexpr auto lie_group_size = 7;
+    auto alphaF = alphaF_;
+    auto alphaM = alphaM_;
+    auto beta = beta_;
+    auto gamma = gamma_;
+    auto h = time_step_size;
+
+    auto num_nodes = mesh.GetNumberOfNodes();
+    auto number_of_constraints = lagrange_multipliers;
+    auto dof_size = lie_algebra_size * num_nodes;
+    auto residual_size = dof_size + number_of_constraints;
+
+    auto lagrange_mults = Kokkos::View<double*>("lagrange_mults", lagrange_multipliers);
+    auto residuals = Kokkos::View<double*>("residual", residual_size);
+    auto iteration_matrix = Kokkos::View<double**>("iteration matrix", residual_size, residual_size);
+    auto left_pre = Kokkos::View<double**>("left preconditioner", residual_size, residual_size);
+    auto right_pre = Kokkos::View<double**>("left preconditioner", residual_size, residual_size);
+    
+    auto dof_residuals = Kokkos::subview(residuals, Kokkos::pair<int,int>(0, dof_size));
+    auto lagrange_residuals = Kokkos::subview(residuals, Kokkos::pair<int,int>(dof_size, residual_size));
+
+    Kokkos::parallel_for(mesh.GetNumberOfNodes(), KOKKOS_LAMBDA(std::size_t node) {
+      auto acceleration = field_data.GetNodalData<Field::Acceleration>(node);
+      auto algo_acceleration_next = field_data.GetNodalData<Field::AlgorithmicAccelerationNext>(node);
+      auto delta_coordinates = field_data.GetNodalData<Field::DeltaCoordinates>(node);
+      auto velocity = field_data.GetNodalData<Field::Velocity>(node);
+      auto algo_acceleration = field_data.GetNodalData<Field::AlgorithmicAcceleration>(node);
+
+      for(int i = 0; i < lie_algebra_size; ++i) {
+        algo_acceleration_next(i) = (alphaF * acceleration(i) - alphaM * algo_acceleration(i)) / (1. - alphaM);
+        delta_coordinates(i) = velocity(i) + h * (.5 - beta) * algo_acceleration(i) + h * beta * algo_acceleration_next(i);
+        velocity(i) += h * (1. - gamma) * algo_acceleration(i) + h * gamma * algo_acceleration_next(i);
+        algo_acceleration(i) = algo_acceleration_next(i);
+        acceleration(i) = 0.;
+      }
+    });
+    Kokkos::deep_copy(lagrange_mults, 0.);
+
+    auto betaPrime = (1. - alphaM) / (h * h * beta *(1 - alphaF));
+    auto gammaPrime = gamma / (h * beta);
+    auto scalar_pre = (is_preconditioned_) ? beta * h * h : 1.;
+
+    Kokkos::deep_copy(left_pre, 0.);
+    Kokkos::deep_copy(right_pre, 0.);
+    Kokkos::parallel_for(residual_size, KOKKOS_LAMBDA(int i) {
+      left_pre(i, i) = (i < dof_size) ? scalar_pre : 1.;
+      right_pre(i, i) = (i < dof_size) ? 1. : 1. / scalar_pre;
+    });
+
+    std::size_t nonlinear_iteration;
+    bool is_converged = false;
+    for(nonlinear_iteration = 0; nonlinear_iteration < max_iterations; ++nonlinear_iteration) {
+      Kokkos::parallel_for(mesh.GetNumberOfNodes(), KOKKOS_LAMBDA(std::size_t node) {
+        auto coordinates_next = field_data.GetNodalData<Field::CoordinatesNext>(node);
+        auto coordinates = field_data.GetNodalData<Field::Coordinates>(node);
+        auto delta_coordinates = field_data.GetNodalData<Field::DeltaCoordinates>(node);
+        for(int i = 0; i < 3; ++i) {
+          coordinates_next(i) = coordinates(i) + delta_coordinates(i) * h;
+        } 
+  
+        auto orientation_vector = Kokkos::subview(delta_coordinates, Kokkos::pair<int,int>(3,6));
+        auto updated_orientation = Kokkos::View<double[4]>("updated_orientation");
+        exponential_mapping_with_scale(updated_orientation, orientation_vector, h); //must use orientation_vector * h
+        auto current_orientation = Kokkos::subview(coordinates, Kokkos::pair<int,int>(3,7));
+        auto next_orientation = Kokkos::subview(coordinates_next, Kokkos::pair<int,int>(3,7));
+        quaternion_mult(next_orientation, current_orientation, updated_orientation);
+      });
+
+      assembler_->ComputeResidualVector(residuals, mesh, field_data, lagrange_mults);
+      
+      if((is_converged = CheckConvergence(residuals))) {
+        return is_converged;
+      }
+
+      assembler_->ComputeIterationMatrix(iteration_matrix, h, betaPrime, gammaPrime, mesh, field_data, lagrange_mults);
+
+      KokkosBlas::gemm("N", "N", 1., iteration_matrix, right_pre, 0., iteration_matrix);
+      KokkosBlas::gemm("N", "N", 1., left_pre, iteration_matrix, 0., iteration_matrix);
+      KokkosBlas::scal(dof_residuals, scalar_pre, dof_residuals);
+ 
+      openturbine::gen_alpha_solver::solve_linear_system(iteration_matrix, residuals);
+
+      KokkosBlas::scal(residuals, -1., residuals);
+
+      KokkosBlas::axpby(-1. / scalar_pre, lagrange_residuals, 1., lagrange_mults);
+
+      Kokkos::parallel_for(mesh.GetNumberOfNodes(), KOKKOS_LAMBDA(std::size_t node) {
+        auto delta_coordinates = field_data.GetNodalData<Field::DeltaCoordinates>(node);
+        auto velocity = field_data.GetNodalData<Field::Velocity>(node);
+        auto acceleration = field_data.GetNodalData<Field::Acceleration>(node);
+
+        int start_index = node * lie_algebra_size;
+        int end_index = start_index + lie_algebra_size;
+        auto update = Kokkos::subview(dof_residuals, Kokkos::pair<int,int>(start_index, end_index));
+        for(int i = 0; i < lie_algebra_size; ++i) {
+          delta_coordinates(i) += update(i) / h;
+          velocity(i) += gammaPrime * update(i);
+          acceleration(i) += betaPrime * update(i);
+        }
+      });
+    }
+
+    Kokkos::parallel_for(mesh.GetNumberOfNodes(), KOKKOS_LAMBDA(std::size_t node) {
+      auto algo_acceleration_next = field_data.GetNodalData<Field::AlgorithmicAccelerationNext>(node);
+      auto acceleration = field_data.GetNodalData<Field::Acceleration>(node);
+      for(std::size_t i = 0; i < lie_algebra_size; ++i) {
+        algo_acceleration_next(i) += (1. - alphaF) / (1. - alphaM) * acceleration(i);
+      }
+
+      auto algo_acceleration = field_data.GetNodalData<Field::AlgorithmicAcceleration>(node);
+      for(std::size_t i = 0; i < lie_algebra_size; ++i) {
+        algo_acceleration(i) = algo_acceleration_next(i);
+      }
+
+      auto coordinates = field_data.GetNodalData<Field::Coordinates>(node);
+      auto coordinates_next = field_data.GetNodalData<Field::CoordinatesNext>(node);
+      for(std::size_t i = 0; i < lie_group_size; ++i) {
+        coordinates(i) = coordinates_next(i);
+      }
+    });
+    return is_converged;
+  }
+
+
+  friend GeneralizedAlphaStepper CreateBasicStepper();
+
+protected:
+  GeneralizedAlphaStepper() = default;
+
+  void SetParameters(double alpha_f, double alpha_m, double beta, double gamma) {
+   alphaF_ = alpha_f;
+   alphaM_ = alpha_m;
+   beta_ = beta;
+   gamma_ = gamma;
+  }
+
+  void SetPreconditioner(bool is_preconditioned) {
+    is_preconditioned_ = is_preconditioned;
+  }
+
+  void SetSystemAssembler(std::shared_ptr<LinearizationParameters> assembler) {
+    assembler_ = assembler;
+  }
+
+  bool CheckConvergence(Kokkos::View<double*> residuals) {
+    return KokkosBlas::nrm2(residuals) < 1.e-10;
+  }
+
+  std::shared_ptr<LinearizationParameters> assembler_;
+
+  double alphaF_;
+  double alphaM_;
+  double beta_;
+  double gamma_;
+  bool is_preconditioned_;
+};
+
+GeneralizedAlphaStepper CreateBasicStepper() {
+  GeneralizedAlphaStepper stepper;
+  stepper.SetParameters(0., 0., .5, 1.);
+  stepper.SetPreconditioner(false);
+
+  stepper.SetSystemAssembler(std::make_shared<UnityLinearizationParameters>());
+
+  return stepper;
+}
+
+}

--- a/tests/unit_tests/gebt_poc/CMakeLists.txt
+++ b/tests/unit_tests/gebt_poc/CMakeLists.txt
@@ -9,4 +9,5 @@ target_sources(
     test_section.cpp
     test_mesh.cpp
     test_field_data.cpp
+    test_gebt_generalized_alpha_solver.cpp
 )

--- a/tests/unit_tests/gebt_poc/test_gebt_generalized_alpha_solver.cpp
+++ b/tests/unit_tests/gebt_poc/test_gebt_generalized_alpha_solver.cpp
@@ -176,7 +176,7 @@ TEST(GEBT_TimeIntegratorTest, AlphaStepSolutionOfHeavyTopAfterOneInc) {
     auto gamma = 0.5 + alpha_f - alpha_m;
     auto beta = 0.25 * std::pow(gamma + 0.5, 2);
 
-    auto stepper = CreateUnityStepper(alpha_f, alpha_m, beta, gamma, true);
+    auto stepper = CreateStepper(alpha_f, alpha_m, beta, gamma, true);
 
     [[maybe_unused]] bool step_converged =
         stepper.Step(mesh, field_data, n_lagrange_mults, time_step, max_nonlinear_iterations);

--- a/tests/unit_tests/gebt_poc/test_gebt_generalized_alpha_solver.cpp
+++ b/tests/unit_tests/gebt_poc/test_gebt_generalized_alpha_solver.cpp
@@ -1,0 +1,124 @@
+#include <gtest/gtest.h>
+
+#include "src/gebt_poc/mesh.h"
+#include "src/gebt_poc/field_data.h"
+
+#include "tests/unit_tests/gen_alpha_poc/test_utilities.h"
+
+namespace openturbine::gebt_poc {
+
+class LinearizationParameters {
+public:
+};
+
+class UnityLinearizationParameters : public LinearizationParameters{
+
+};
+
+class GeneralizedAlphaStepper {
+public:
+  bool Step(Mesh& mesh, FieldData& field_data, std::size_t lagrange_multipliers) {
+    return true;
+  }
+
+
+  friend GeneralizedAlphaStepper CreateBasicStepper();
+
+protected:
+  GeneralizedAlphaStepper() = default;
+
+  void SetParameters(double alpha_f, double alpha_m, double beta, double gamma) {
+   alphaF_ = alpha_f;
+   alphaM_ = alpha_m;
+   beta_ = beta;
+   gamma_ = gamma;
+  }
+
+  void SetPreconditioner(bool is_preconditioned) {
+    is_preconditioned_ = is_preconditioned;
+  }
+
+  void SetSystemAssembler(std::shared_ptr<LinearizationParameters> assembler) {
+    assembler_ = assembler;
+  }
+
+  std::shared_ptr<LinearizationParameters> assembler_;
+
+  double alphaF_;
+  double alphaM_;
+  double beta_;
+  double gamma_;
+  bool is_preconditioned_;
+};
+
+GeneralizedAlphaStepper CreateBasicStepper() {
+  GeneralizedAlphaStepper stepper;
+  stepper.SetParameters(0., 0., .5, 1.);
+  stepper.SetPreconditioner(true);
+
+  stepper.SetSystemAssembler(std::make_shared<UnityLinearizationParameters>());
+
+  return stepper;
+}
+
+}
+
+
+TEST(GEBT_TimeIntegratorTest, AlphaStepSolutionAfterOneIncWithNonZeroInitialState) {
+    using namespace openturbine::gebt_poc;
+    auto stepper = CreateBasicStepper();
+
+    auto mesh = Create1DMesh(1, 1);
+    auto field_data = FieldData(mesh, 1);
+    constexpr auto lie_group_size = 7;
+    constexpr auto lie_algebra_size = 6;
+
+std::cout << 1 << std::endl;
+    Kokkos::parallel_for(mesh.GetNumberOfNodes(), KOKKOS_LAMBDA(int node) {
+      auto coordinates = field_data.GetNodalData<Field::Coordinates>(node);
+      for(int i = 0; i < lie_group_size; ++i) {
+        coordinates(i) = 0.;
+      }
+
+      auto velocity = field_data.GetNodalData<Field::Velocity>(node);
+      auto acceleration = field_data.GetNodalData<Field::Acceleration>(node);
+      auto algo_acceleration = field_data.GetNodalData<Field::AlgorithmicAcceleration>(node);
+      for(int i = 0; i < lie_algebra_size; ++i)
+      {
+        velocity(i) = i + 1.;
+        acceleration(i) = i + 1.;
+        algo_acceleration(i) = i + 1.;
+      }
+    });
+
+std::cout << 2 << std::endl;
+    size_t n_lagrange_mults{0};
+
+std::cout << 3 << std::endl;
+    bool step_converged = stepper.Step(mesh, field_data, n_lagrange_mults);
+
+std::cout << 4 << std::endl;
+    EXPECT_TRUE(step_converged);
+std::cout << 5 << std::endl;
+    using openturbine::gen_alpha_solver::tests::expect_kokkos_view_1D_equal;
+    auto coordinates = Kokkos::View<double*>("coordinates", lie_group_size);
+std::cout << 5.1 << std::endl;
+    auto c = field_data.GetNodalData<Field::Coordinates>(0);
+std::cout << 5.2 << std::endl;
+std::cout << c.extent(0) << std::endl;
+    Kokkos::deep_copy(coordinates, c);
+std::cout << 5.5 << std::endl;
+    expect_kokkos_view_1D_equal(coordinates, {1., 2., 3., 0., 0., 0., 0.});
+std::cout << 6 << std::endl;
+    auto velocity = Kokkos::View<double*>("velocity", lie_algebra_size);
+    Kokkos::deep_copy(velocity, field_data.GetNodalData<Field::Velocity>(0));
+    expect_kokkos_view_1D_equal(velocity, {-1., 0., 1., 2., 3., 4.});
+std::cout << 7 << std::endl;
+    auto acceleration = Kokkos::View<double*>("acceleration", lie_algebra_size);
+    Kokkos::deep_copy(acceleration, field_data.GetNodalData<Field::Acceleration>(0));
+    expect_kokkos_view_1D_equal(acceleration, {-2., -2., -2., -2., -2., -2.});
+std::cout << 8 << std::endl;
+    auto algo_acceleration = Kokkos::View<double*>("algo acceleration", lie_algebra_size);
+    Kokkos::deep_copy(algo_acceleration, field_data.GetNodalData<Field::AlgorithmicAcceleration>(0));
+    expect_kokkos_view_1D_equal(algo_acceleration, {-2., -2., -2., -2., -2., -2.});
+}

--- a/tests/unit_tests/gebt_poc/test_gebt_generalized_alpha_solver.cpp
+++ b/tests/unit_tests/gebt_poc/test_gebt_generalized_alpha_solver.cpp
@@ -3,6 +3,83 @@
 #include "src/gebt_poc/gebt_generalized_alpha_time_integrator.h"
 #include "tests/unit_tests/gen_alpha_poc/test_utilities.h"
 
+TEST(GEBT_TimeIntegratorTest, AlphaStepSolutionAfterOneAndTwoIncsWithZeroAcceleration) {
+    using namespace openturbine::gebt_poc;
+    auto stepper = CreateBasicStepper();
+
+    auto mesh = Create1DMesh(1, 1);
+    auto field_data = FieldData(mesh, 1);
+    constexpr auto lie_group_size = 7;
+    constexpr auto lie_algebra_size = 6;
+
+    Kokkos::parallel_for(
+        mesh.GetNumberOfNodes(),
+        KOKKOS_LAMBDA(int node) {
+            auto coordinates = field_data.GetNodalData<Field::Coordinates>(node);
+            for (int i = 0; i < lie_group_size; ++i) {
+                coordinates(i) = 0.;
+            }
+
+            auto velocity = field_data.GetNodalData<Field::Velocity>(node);
+            auto acceleration = field_data.GetNodalData<Field::Acceleration>(node);
+            auto algo_acceleration = field_data.GetNodalData<Field::AlgorithmicAcceleration>(node);
+            for (int i = 0; i < lie_algebra_size; ++i) {
+                velocity(i) = 0.;
+                acceleration(i) = 0.;
+                algo_acceleration(i) = 0.;
+            }
+        }
+    );
+
+    std::size_t n_lagrange_mults = 0;
+
+    auto time_step = 1.;
+    auto max_nonlinear_iterations = 1;
+
+    {
+      [[maybe_unused]] bool step_converged =
+          stepper.Step(mesh, field_data, n_lagrange_mults, time_step, max_nonlinear_iterations);
+
+      using openturbine::gen_alpha_solver::tests::expect_kokkos_view_1D_equal;
+      auto coordinates = Kokkos::View<double*>("coordinates", lie_group_size);
+      Kokkos::deep_copy(coordinates, field_data.GetNodalData<Field::Coordinates>(0));
+      expect_kokkos_view_1D_equal(coordinates, {0., 0., 0., 0., 0., 0., 0.});
+
+      auto velocity = Kokkos::View<double*>("velocity", lie_algebra_size);
+      Kokkos::deep_copy(velocity, field_data.GetNodalData<Field::Velocity>(0));
+      expect_kokkos_view_1D_equal(velocity, {-2., -2., -2., -2., -2., -2.});
+
+      auto acceleration = Kokkos::View<double*>("acceleration", lie_algebra_size);
+      Kokkos::deep_copy(acceleration, field_data.GetNodalData<Field::Acceleration>(0));
+      expect_kokkos_view_1D_equal(acceleration, {-2., -2., -2., -2., -2., -2.});
+
+      auto algo_acceleration = Kokkos::View<double*>("algo acceleration", lie_algebra_size);
+      Kokkos::deep_copy(algo_acceleration, field_data.GetNodalData<Field::AlgorithmicAcceleration>(0));
+      expect_kokkos_view_1D_equal(algo_acceleration, {-2., -2., -2., -2., -2., -2.});
+    }
+    {
+      [[maybe_unused]] bool step_converged =
+          stepper.Step(mesh, field_data, n_lagrange_mults, time_step, max_nonlinear_iterations);
+
+      using openturbine::gen_alpha_solver::tests::expect_kokkos_view_1D_equal;
+      auto coordinates = Kokkos::View<double*>("coordinates", lie_group_size);
+      Kokkos::deep_copy(coordinates, field_data.GetNodalData<Field::Coordinates>(0));
+      expect_kokkos_view_1D_equal(coordinates, {-2., -2., -2., 0., 0., 0., 0.});
+
+      auto velocity = Kokkos::View<double*>("velocity", lie_algebra_size);
+      Kokkos::deep_copy(velocity, field_data.GetNodalData<Field::Velocity>(0));
+      expect_kokkos_view_1D_equal(velocity, {-4., -4., -4., -4., -4., -4.});
+
+      auto acceleration = Kokkos::View<double*>("acceleration", lie_algebra_size);
+      Kokkos::deep_copy(acceleration, field_data.GetNodalData<Field::Acceleration>(0));
+      expect_kokkos_view_1D_equal(acceleration, {-2., -2., -2., -2., -2., -2.});
+
+      auto algo_acceleration = Kokkos::View<double*>("algo acceleration", lie_algebra_size);
+      Kokkos::deep_copy(algo_acceleration, field_data.GetNodalData<Field::AlgorithmicAcceleration>(0));
+      expect_kokkos_view_1D_equal(algo_acceleration, {-2., -2., -2., -2., -2., -2.});
+    }
+}
+
 TEST(GEBT_TimeIntegratorTest, AlphaStepSolutionAfterOneIncWithNonZeroInitialState) {
     using namespace openturbine::gebt_poc;
     auto stepper = CreateBasicStepper();
@@ -54,4 +131,66 @@ TEST(GEBT_TimeIntegratorTest, AlphaStepSolutionAfterOneIncWithNonZeroInitialStat
     auto algo_acceleration = Kokkos::View<double*>("algo acceleration", lie_algebra_size);
     Kokkos::deep_copy(algo_acceleration, field_data.GetNodalData<Field::AlgorithmicAcceleration>(0));
     expect_kokkos_view_1D_equal(algo_acceleration, {-2., -2., -2., -2., -2., -2.});
+}
+
+TEST(GEBT_TimeIntegratorTest, AlphaStepSolutionOfHeavyTopAfterOneInc) {
+    using namespace openturbine::gebt_poc;
+
+    auto mesh = Create1DMesh(1, 1);
+    auto field_data = FieldData(mesh, 1);
+    constexpr auto lie_group_size = 7;
+    constexpr auto lie_algebra_size = 6;
+
+    Kokkos::parallel_for(
+        mesh.GetNumberOfNodes(),
+        KOKKOS_LAMBDA(int node) {
+            auto coordinates = field_data.GetNodalData<Field::Coordinates>(node);
+            for (int i = 0; i < lie_group_size; ++i) {
+                coordinates(i) = 1.;
+            }
+
+            auto velocity = field_data.GetNodalData<Field::Velocity>(node);
+            auto acceleration = field_data.GetNodalData<Field::Acceleration>(node);
+            auto algo_acceleration = field_data.GetNodalData<Field::AlgorithmicAcceleration>(node);
+            for (int i = 0; i < lie_algebra_size; ++i) {
+                velocity(i) = 2.;
+                acceleration(i) = 3.;
+                algo_acceleration(i) = 5.;
+            }
+        }
+    );
+    
+    // Calculate properties for the time integrator
+    double time_step = 0.1;
+    std::size_t max_nonlinear_iterations = 1;
+    std::size_t n_lagrange_mults = 3;
+
+    // Calculate the generalized alpha parameters
+    auto rho_inf = 0.5;
+    auto alpha_m = (2. * rho_inf - 1.) / (rho_inf + 1.);
+    auto alpha_f = rho_inf / (rho_inf + 1.);
+    auto gamma = 0.5 + alpha_f - alpha_m;
+    auto beta = 0.25 * std::pow(gamma + 0.5, 2);
+
+    auto stepper = CreateUnityStepper(alpha_f, alpha_m, beta, gamma, true);
+
+    [[maybe_unused]] bool step_converged =
+        stepper.Step(mesh, field_data, n_lagrange_mults, time_step, max_nonlinear_iterations);
+
+    using openturbine::gen_alpha_solver::tests::expect_kokkos_view_1D_equal;
+    auto coordinates = Kokkos::View<double*>("coordinates", lie_group_size);
+    Kokkos::deep_copy(coordinates, field_data.GetNodalData<Field::Coordinates>(0));
+    expect_kokkos_view_1D_equal(coordinates, {1.207222, 1.207222, 1.207222, 0.674773, 1.086996, 1.086996, 1.086996});
+
+    auto velocity = Kokkos::View<double*>("velocity", lie_algebra_size);
+    Kokkos::deep_copy(velocity, field_data.GetNodalData<Field::Velocity>(0));
+    expect_kokkos_view_1D_equal(velocity, {-16.583333, -16.583333, -16.583333, -16.583333, -16.583333, -16.583333});
+
+    auto acceleration = Kokkos::View<double*>("acceleration", lie_algebra_size);
+    Kokkos::deep_copy(acceleration, field_data.GetNodalData<Field::Acceleration>(0));
+    expect_kokkos_view_1D_equal(acceleration, {-337.5, -337.5, -337.5, -337.5, -337.5, -337.5});
+
+    auto algo_acceleration = Kokkos::View<double*>("algo acceleration", lie_algebra_size);
+    Kokkos::deep_copy(algo_acceleration, field_data.GetNodalData<Field::AlgorithmicAcceleration>(0));
+    expect_kokkos_view_1D_equal(algo_acceleration, {-224., -224., -224., -224., -224., -224.});
 }

--- a/tests/unit_tests/gebt_poc/test_gebt_generalized_alpha_solver.cpp
+++ b/tests/unit_tests/gebt_poc/test_gebt_generalized_alpha_solver.cpp
@@ -1,68 +1,8 @@
 #include <gtest/gtest.h>
 
-#include "src/gebt_poc/mesh.h"
-#include "src/gebt_poc/field_data.h"
-
 #include "tests/unit_tests/gen_alpha_poc/test_utilities.h"
 
-namespace openturbine::gebt_poc {
-
-class LinearizationParameters {
-public:
-};
-
-class UnityLinearizationParameters : public LinearizationParameters{
-
-};
-
-class GeneralizedAlphaStepper {
-public:
-  bool Step(Mesh& mesh, FieldData& field_data, std::size_t lagrange_multipliers) {
-    return true;
-  }
-
-
-  friend GeneralizedAlphaStepper CreateBasicStepper();
-
-protected:
-  GeneralizedAlphaStepper() = default;
-
-  void SetParameters(double alpha_f, double alpha_m, double beta, double gamma) {
-   alphaF_ = alpha_f;
-   alphaM_ = alpha_m;
-   beta_ = beta;
-   gamma_ = gamma;
-  }
-
-  void SetPreconditioner(bool is_preconditioned) {
-    is_preconditioned_ = is_preconditioned;
-  }
-
-  void SetSystemAssembler(std::shared_ptr<LinearizationParameters> assembler) {
-    assembler_ = assembler;
-  }
-
-  std::shared_ptr<LinearizationParameters> assembler_;
-
-  double alphaF_;
-  double alphaM_;
-  double beta_;
-  double gamma_;
-  bool is_preconditioned_;
-};
-
-GeneralizedAlphaStepper CreateBasicStepper() {
-  GeneralizedAlphaStepper stepper;
-  stepper.SetParameters(0., 0., .5, 1.);
-  stepper.SetPreconditioner(true);
-
-  stepper.SetSystemAssembler(std::make_shared<UnityLinearizationParameters>());
-
-  return stepper;
-}
-
-}
-
+#include "src/gebt_poc/gebt_generalized_alpha_time_integrator.h"
 
 TEST(GEBT_TimeIntegratorTest, AlphaStepSolutionAfterOneIncWithNonZeroInitialState) {
     using namespace openturbine::gebt_poc;
@@ -73,7 +13,6 @@ TEST(GEBT_TimeIntegratorTest, AlphaStepSolutionAfterOneIncWithNonZeroInitialStat
     constexpr auto lie_group_size = 7;
     constexpr auto lie_algebra_size = 6;
 
-std::cout << 1 << std::endl;
     Kokkos::parallel_for(mesh.GetNumberOfNodes(), KOKKOS_LAMBDA(int node) {
       auto coordinates = field_data.GetNodalData<Field::Coordinates>(node);
       for(int i = 0; i < lie_group_size; ++i) {
@@ -91,33 +30,25 @@ std::cout << 1 << std::endl;
       }
     });
 
-std::cout << 2 << std::endl;
-    size_t n_lagrange_mults{0};
+    std::size_t n_lagrange_mults = 0;
 
-std::cout << 3 << std::endl;
-    bool step_converged = stepper.Step(mesh, field_data, n_lagrange_mults);
+    auto time_step = 1.;
+    auto max_nonlinear_iterations = 1;
+    bool step_converged = stepper.Step(mesh, field_data, n_lagrange_mults, time_step, max_nonlinear_iterations);
 
-std::cout << 4 << std::endl;
-    EXPECT_TRUE(step_converged);
-std::cout << 5 << std::endl;
     using openturbine::gen_alpha_solver::tests::expect_kokkos_view_1D_equal;
     auto coordinates = Kokkos::View<double*>("coordinates", lie_group_size);
-std::cout << 5.1 << std::endl;
-    auto c = field_data.GetNodalData<Field::Coordinates>(0);
-std::cout << 5.2 << std::endl;
-std::cout << c.extent(0) << std::endl;
-    Kokkos::deep_copy(coordinates, c);
-std::cout << 5.5 << std::endl;
+    Kokkos::deep_copy(coordinates, field_data.GetNodalData<Field::Coordinates>(0));
     expect_kokkos_view_1D_equal(coordinates, {1., 2., 3., 0., 0., 0., 0.});
-std::cout << 6 << std::endl;
+
     auto velocity = Kokkos::View<double*>("velocity", lie_algebra_size);
     Kokkos::deep_copy(velocity, field_data.GetNodalData<Field::Velocity>(0));
     expect_kokkos_view_1D_equal(velocity, {-1., 0., 1., 2., 3., 4.});
-std::cout << 7 << std::endl;
+
     auto acceleration = Kokkos::View<double*>("acceleration", lie_algebra_size);
     Kokkos::deep_copy(acceleration, field_data.GetNodalData<Field::Acceleration>(0));
     expect_kokkos_view_1D_equal(acceleration, {-2., -2., -2., -2., -2., -2.});
-std::cout << 8 << std::endl;
+
     auto algo_acceleration = Kokkos::View<double*>("algo acceleration", lie_algebra_size);
     Kokkos::deep_copy(algo_acceleration, field_data.GetNodalData<Field::AlgorithmicAcceleration>(0));
     expect_kokkos_view_1D_equal(algo_acceleration, {-2., -2., -2., -2., -2., -2.});

--- a/tests/unit_tests/gebt_poc/test_gebt_generalized_alpha_solver.cpp
+++ b/tests/unit_tests/gebt_poc/test_gebt_generalized_alpha_solver.cpp
@@ -1,8 +1,7 @@
 #include <gtest/gtest.h>
 
-#include "tests/unit_tests/gen_alpha_poc/test_utilities.h"
-
 #include "src/gebt_poc/gebt_generalized_alpha_time_integrator.h"
+#include "tests/unit_tests/gen_alpha_poc/test_utilities.h"
 
 TEST(GEBT_TimeIntegratorTest, AlphaStepSolutionAfterOneIncWithNonZeroInitialState) {
     using namespace openturbine::gebt_poc;
@@ -13,28 +12,31 @@ TEST(GEBT_TimeIntegratorTest, AlphaStepSolutionAfterOneIncWithNonZeroInitialStat
     constexpr auto lie_group_size = 7;
     constexpr auto lie_algebra_size = 6;
 
-    Kokkos::parallel_for(mesh.GetNumberOfNodes(), KOKKOS_LAMBDA(int node) {
-      auto coordinates = field_data.GetNodalData<Field::Coordinates>(node);
-      for(int i = 0; i < lie_group_size; ++i) {
-        coordinates(i) = 0.;
-      }
+    Kokkos::parallel_for(
+        mesh.GetNumberOfNodes(),
+        KOKKOS_LAMBDA(int node) {
+            auto coordinates = field_data.GetNodalData<Field::Coordinates>(node);
+            for (int i = 0; i < lie_group_size; ++i) {
+                coordinates(i) = 0.;
+            }
 
-      auto velocity = field_data.GetNodalData<Field::Velocity>(node);
-      auto acceleration = field_data.GetNodalData<Field::Acceleration>(node);
-      auto algo_acceleration = field_data.GetNodalData<Field::AlgorithmicAcceleration>(node);
-      for(int i = 0; i < lie_algebra_size; ++i)
-      {
-        velocity(i) = i + 1.;
-        acceleration(i) = i + 1.;
-        algo_acceleration(i) = i + 1.;
-      }
-    });
+            auto velocity = field_data.GetNodalData<Field::Velocity>(node);
+            auto acceleration = field_data.GetNodalData<Field::Acceleration>(node);
+            auto algo_acceleration = field_data.GetNodalData<Field::AlgorithmicAcceleration>(node);
+            for (int i = 0; i < lie_algebra_size; ++i) {
+                velocity(i) = i + 1.;
+                acceleration(i) = i + 1.;
+                algo_acceleration(i) = i + 1.;
+            }
+        }
+    );
 
     std::size_t n_lagrange_mults = 0;
 
     auto time_step = 1.;
     auto max_nonlinear_iterations = 1;
-    bool step_converged = stepper.Step(mesh, field_data, n_lagrange_mults, time_step, max_nonlinear_iterations);
+    bool step_converged =
+        stepper.Step(mesh, field_data, n_lagrange_mults, time_step, max_nonlinear_iterations);
 
     using openturbine::gen_alpha_solver::tests::expect_kokkos_view_1D_equal;
     auto coordinates = Kokkos::View<double*>("coordinates", lie_group_size);

--- a/tests/unit_tests/gebt_poc/test_gebt_generalized_alpha_solver.cpp
+++ b/tests/unit_tests/gebt_poc/test_gebt_generalized_alpha_solver.cpp
@@ -35,7 +35,7 @@ TEST(GEBT_TimeIntegratorTest, AlphaStepSolutionAfterOneIncWithNonZeroInitialStat
 
     auto time_step = 1.;
     auto max_nonlinear_iterations = 1;
-    bool step_converged =
+    [[maybe_unused]] bool step_converged =
         stepper.Step(mesh, field_data, n_lagrange_mults, time_step, max_nonlinear_iterations);
 
     using openturbine::gen_alpha_solver::tests::expect_kokkos_view_1D_equal;

--- a/tests/unit_tests/gebt_poc/test_gebt_generalized_alpha_solver.cpp
+++ b/tests/unit_tests/gebt_poc/test_gebt_generalized_alpha_solver.cpp
@@ -37,46 +37,50 @@ TEST(GEBT_TimeIntegratorTest, AlphaStepSolutionAfterOneAndTwoIncsWithZeroAcceler
     auto max_nonlinear_iterations = 1;
 
     {
-      [[maybe_unused]] bool step_converged =
-          stepper.Step(mesh, field_data, n_lagrange_mults, time_step, max_nonlinear_iterations);
+        [[maybe_unused]] bool step_converged =
+            stepper.Step(mesh, field_data, n_lagrange_mults, time_step, max_nonlinear_iterations);
 
-      using openturbine::gen_alpha_solver::tests::expect_kokkos_view_1D_equal;
-      auto coordinates = Kokkos::View<double*>("coordinates", lie_group_size);
-      Kokkos::deep_copy(coordinates, field_data.GetNodalData<Field::Coordinates>(0));
-      expect_kokkos_view_1D_equal(coordinates, {0., 0., 0., 0., 0., 0., 0.});
+        using openturbine::gen_alpha_solver::tests::expect_kokkos_view_1D_equal;
+        auto coordinates = Kokkos::View<double*>("coordinates", lie_group_size);
+        Kokkos::deep_copy(coordinates, field_data.GetNodalData<Field::Coordinates>(0));
+        expect_kokkos_view_1D_equal(coordinates, {0., 0., 0., 0., 0., 0., 0.});
 
-      auto velocity = Kokkos::View<double*>("velocity", lie_algebra_size);
-      Kokkos::deep_copy(velocity, field_data.GetNodalData<Field::Velocity>(0));
-      expect_kokkos_view_1D_equal(velocity, {-2., -2., -2., -2., -2., -2.});
+        auto velocity = Kokkos::View<double*>("velocity", lie_algebra_size);
+        Kokkos::deep_copy(velocity, field_data.GetNodalData<Field::Velocity>(0));
+        expect_kokkos_view_1D_equal(velocity, {-2., -2., -2., -2., -2., -2.});
 
-      auto acceleration = Kokkos::View<double*>("acceleration", lie_algebra_size);
-      Kokkos::deep_copy(acceleration, field_data.GetNodalData<Field::Acceleration>(0));
-      expect_kokkos_view_1D_equal(acceleration, {-2., -2., -2., -2., -2., -2.});
+        auto acceleration = Kokkos::View<double*>("acceleration", lie_algebra_size);
+        Kokkos::deep_copy(acceleration, field_data.GetNodalData<Field::Acceleration>(0));
+        expect_kokkos_view_1D_equal(acceleration, {-2., -2., -2., -2., -2., -2.});
 
-      auto algo_acceleration = Kokkos::View<double*>("algo acceleration", lie_algebra_size);
-      Kokkos::deep_copy(algo_acceleration, field_data.GetNodalData<Field::AlgorithmicAcceleration>(0));
-      expect_kokkos_view_1D_equal(algo_acceleration, {-2., -2., -2., -2., -2., -2.});
+        auto algo_acceleration = Kokkos::View<double*>("algo acceleration", lie_algebra_size);
+        Kokkos::deep_copy(
+            algo_acceleration, field_data.GetNodalData<Field::AlgorithmicAcceleration>(0)
+        );
+        expect_kokkos_view_1D_equal(algo_acceleration, {-2., -2., -2., -2., -2., -2.});
     }
     {
-      [[maybe_unused]] bool step_converged =
-          stepper.Step(mesh, field_data, n_lagrange_mults, time_step, max_nonlinear_iterations);
+        [[maybe_unused]] bool step_converged =
+            stepper.Step(mesh, field_data, n_lagrange_mults, time_step, max_nonlinear_iterations);
 
-      using openturbine::gen_alpha_solver::tests::expect_kokkos_view_1D_equal;
-      auto coordinates = Kokkos::View<double*>("coordinates", lie_group_size);
-      Kokkos::deep_copy(coordinates, field_data.GetNodalData<Field::Coordinates>(0));
-      expect_kokkos_view_1D_equal(coordinates, {-2., -2., -2., 0., 0., 0., 0.});
+        using openturbine::gen_alpha_solver::tests::expect_kokkos_view_1D_equal;
+        auto coordinates = Kokkos::View<double*>("coordinates", lie_group_size);
+        Kokkos::deep_copy(coordinates, field_data.GetNodalData<Field::Coordinates>(0));
+        expect_kokkos_view_1D_equal(coordinates, {-2., -2., -2., 0., 0., 0., 0.});
 
-      auto velocity = Kokkos::View<double*>("velocity", lie_algebra_size);
-      Kokkos::deep_copy(velocity, field_data.GetNodalData<Field::Velocity>(0));
-      expect_kokkos_view_1D_equal(velocity, {-4., -4., -4., -4., -4., -4.});
+        auto velocity = Kokkos::View<double*>("velocity", lie_algebra_size);
+        Kokkos::deep_copy(velocity, field_data.GetNodalData<Field::Velocity>(0));
+        expect_kokkos_view_1D_equal(velocity, {-4., -4., -4., -4., -4., -4.});
 
-      auto acceleration = Kokkos::View<double*>("acceleration", lie_algebra_size);
-      Kokkos::deep_copy(acceleration, field_data.GetNodalData<Field::Acceleration>(0));
-      expect_kokkos_view_1D_equal(acceleration, {-2., -2., -2., -2., -2., -2.});
+        auto acceleration = Kokkos::View<double*>("acceleration", lie_algebra_size);
+        Kokkos::deep_copy(acceleration, field_data.GetNodalData<Field::Acceleration>(0));
+        expect_kokkos_view_1D_equal(acceleration, {-2., -2., -2., -2., -2., -2.});
 
-      auto algo_acceleration = Kokkos::View<double*>("algo acceleration", lie_algebra_size);
-      Kokkos::deep_copy(algo_acceleration, field_data.GetNodalData<Field::AlgorithmicAcceleration>(0));
-      expect_kokkos_view_1D_equal(algo_acceleration, {-2., -2., -2., -2., -2., -2.});
+        auto algo_acceleration = Kokkos::View<double*>("algo acceleration", lie_algebra_size);
+        Kokkos::deep_copy(
+            algo_acceleration, field_data.GetNodalData<Field::AlgorithmicAcceleration>(0)
+        );
+        expect_kokkos_view_1D_equal(algo_acceleration, {-2., -2., -2., -2., -2., -2.});
     }
 }
 
@@ -159,7 +163,7 @@ TEST(GEBT_TimeIntegratorTest, AlphaStepSolutionOfHeavyTopAfterOneInc) {
             }
         }
     );
-    
+
     // Calculate properties for the time integrator
     double time_step = 0.1;
     std::size_t max_nonlinear_iterations = 1;
@@ -180,11 +184,15 @@ TEST(GEBT_TimeIntegratorTest, AlphaStepSolutionOfHeavyTopAfterOneInc) {
     using openturbine::gen_alpha_solver::tests::expect_kokkos_view_1D_equal;
     auto coordinates = Kokkos::View<double*>("coordinates", lie_group_size);
     Kokkos::deep_copy(coordinates, field_data.GetNodalData<Field::Coordinates>(0));
-    expect_kokkos_view_1D_equal(coordinates, {1.207222, 1.207222, 1.207222, 0.674773, 1.086996, 1.086996, 1.086996});
+    expect_kokkos_view_1D_equal(
+        coordinates, {1.207222, 1.207222, 1.207222, 0.674773, 1.086996, 1.086996, 1.086996}
+    );
 
     auto velocity = Kokkos::View<double*>("velocity", lie_algebra_size);
     Kokkos::deep_copy(velocity, field_data.GetNodalData<Field::Velocity>(0));
-    expect_kokkos_view_1D_equal(velocity, {-16.583333, -16.583333, -16.583333, -16.583333, -16.583333, -16.583333});
+    expect_kokkos_view_1D_equal(
+        velocity, {-16.583333, -16.583333, -16.583333, -16.583333, -16.583333, -16.583333}
+    );
 
     auto acceleration = Kokkos::View<double*>("acceleration", lie_algebra_size);
     Kokkos::deep_copy(acceleration, field_data.GetNodalData<Field::Acceleration>(0));


### PR DESCRIPTION
Outer loops are now over the nodes.  Several places where BLAS calls could be used now use them for clarity.

One major change is that a new "state" is not created every iteration.
Instead, the existing data is modified in place, which reduces the number
of allocations needed.  To save state data, the user will need to do so
in between iterations manually.

This request has only ported over one unit test to use the new structure.
Further testing using the heavy top problem is underway.