### PR TITLE
Refactor static beam solver functions

### DIFF
--- a/src/gebt_poc/solver.h
+++ b/src/gebt_poc/solver.h
@@ -64,9 +64,9 @@ Kokkos::View<double*> CalculateCurvature(
 
 /// Calculates the given sectional stiffness matrix in inertial basis based on the given
 /// rotation matrices
-Kokkos::View<double**> CalculateSectionalStiffness(
+void CalculateSectionalStiffness(
     const StiffnessMatrix& stiffness, Kokkos::View<double**> rotation_0,
-    Kokkos::View<double**> rotation
+    Kokkos::View<double**> rotation, Kokkos::View<double**> sectional_stiffness
 );
 
 /// Calculates the elastic forces based on the sectional strain, derivative of the position
@@ -91,9 +91,10 @@ void CalculateIterationMatrixComponents(
 );
 
 /// Calculates the static iteration matrix for a beam element
-Kokkos::View<double**> CalculateStaticIterationMatrix(
+void CalculateStaticIterationMatrix(
     const Kokkos::View<double*> position_vectors, const Kokkos::View<double*> gen_coords,
-    const StiffnessMatrix& stiffness, const Quadrature& quadrature
+    const StiffnessMatrix& stiffness, const Quadrature& quadrature,
+    Kokkos::View<double**> iteration_matrix
 );
 
 /// Calculates the constraint residual vector for a beam element

--- a/src/gebt_poc/solver.h
+++ b/src/gebt_poc/solver.h
@@ -95,7 +95,9 @@ void CalculateIterationMatrixComponents(
     const Kokkos::View<double*> gen_coords_derivatives,
     const Kokkos::View<double[kNumberOfLieGroupComponents][kNumberOfLieGroupComponents]>
         sectional_stiffness,
-    Kokkos::View<double**> O_P_Q_matrices
+    Kokkos::View<double[kNumberOfLieGroupComponents][kNumberOfLieGroupComponents]> O_matrix,
+    Kokkos::View<double[kNumberOfLieGroupComponents][kNumberOfLieGroupComponents]> P_matrix,
+    Kokkos::View<double[kNumberOfLieGroupComponents][kNumberOfLieGroupComponents]> Q_matrix
 );
 
 /// Calculates the static iteration matrix for a beam element

--- a/src/gebt_poc/solver.h
+++ b/src/gebt_poc/solver.h
@@ -52,9 +52,9 @@ private:
 
 /// Calculates the interpolated values for a nodal quantity (e.g. displacement or position vector)
 /// at a given quadrature point
-Kokkos::View<double*> Interpolate(
+void Interpolate(
     Kokkos::View<double*> nodal_values, Kokkos::View<double*> interpolation_function,
-    double jacobian = 1.
+    const double jacobian, Kokkos::View<double*> interpolated_values
 );
 
 /// Calculates the curvature from generalized coordinates and their derivatives

--- a/src/gebt_poc/solver.h
+++ b/src/gebt_poc/solver.h
@@ -67,7 +67,9 @@ void CalculateCurvature(
 /// rotation matrices
 void CalculateSectionalStiffness(
     const StiffnessMatrix& stiffness, Kokkos::View<double**> rotation_0,
-    Kokkos::View<double**> rotation, Kokkos::View<double**> sectional_stiffness
+    Kokkos::View<double[kNumberOfVectorComponents][kNumberOfVectorComponents]> rotation,
+    Kokkos::View<double[kNumberOfLieGroupComponents][kNumberOfLieGroupComponents]>
+        sectional_stiffness
 );
 
 /// Calculates the elastic forces based on the sectional strain, derivative of the position
@@ -76,7 +78,9 @@ void CalculateElasticForces(
     const Kokkos::View<double*> strain, Kokkos::View<double**> rotation,
     const Kokkos::View<double*> pos_vector_derivatives,
     const Kokkos::View<double*> gen_coords_derivatives,
-    const Kokkos::View<double**> sectional_stiffness, Kokkos::View<double*> elastic_forces
+    const Kokkos::View<double[kNumberOfLieGroupComponents][kNumberOfLieGroupComponents]>
+        sectional_stiffness,
+    Kokkos::View<double*> elastic_forces
 );
 
 /// Calculates the static residual vector for a beam element
@@ -88,7 +92,9 @@ void CalculateStaticResidual(
 void CalculateIterationMatrixComponents(
     const Kokkos::View<double*> elastic_force_fc, const Kokkos::View<double*> pos_vector_derivatives,
     const Kokkos::View<double*> gen_coords_derivatives,
-    const Kokkos::View<double**> sectional_stiffness, Kokkos::View<double**> O_P_Q_matrices
+    const Kokkos::View<double[kNumberOfLieGroupComponents][kNumberOfLieGroupComponents]>
+        sectional_stiffness,
+    Kokkos::View<double**> O_P_Q_matrices
 );
 
 /// Calculates the static iteration matrix for a beam element
@@ -101,13 +107,13 @@ void CalculateStaticIterationMatrix(
 /// Calculates the constraint residual vector for a beam element
 void ConstraintsResidualVector(
     const Kokkos::View<double*> gen_coords, const Kokkos::View<double*> position_vector,
-    const Kokkos::View<double*> constraint_residual
+    const Kokkos::View<double*> constraints_residual
 );
 
 /// Calculates the constraint gradient matrix for a beam element
 void ConstraintsGradientMatrix(
     const Kokkos::View<double*> gen_coords, const Kokkos::View<double*> position_vector,
-    Kokkos::View<double**> constraint_gradient_matrix
+    Kokkos::View<double**> constraints_gradient_matrix
 );
 
 }  // namespace openturbine::gebt_poc

--- a/src/gebt_poc/solver.h
+++ b/src/gebt_poc/solver.h
@@ -80,9 +80,9 @@ void CalculateElasticForces(
 );
 
 /// Calculates the static residual vector for a beam element
-Kokkos::View<double*> CalculateStaticResidual(
+void CalculateStaticResidual(
     const Kokkos::View<double*> position_vectors, const Kokkos::View<double*> gen_coords,
-    const StiffnessMatrix& stiffness, const Quadrature& quadrature
+    const StiffnessMatrix& stiffness, const Quadrature& quadrature, Kokkos::View<double*> residual
 );
 
 void CalculateIterationMatrixComponents(

--- a/src/gebt_poc/solver.h
+++ b/src/gebt_poc/solver.h
@@ -58,8 +58,9 @@ Kokkos::View<double*> Interpolate(
 );
 
 /// Calculates the curvature from generalized coordinates and their derivatives
-Kokkos::View<double*> CalculateCurvature(
-    const Kokkos::View<double*> gen_coords, const Kokkos::View<double*> gen_coords_derivative
+void CalculateCurvature(
+    const Kokkos::View<double*> gen_coords, const Kokkos::View<double*> gen_coords_derivative,
+    const Kokkos::View<double*> curvature
 );
 
 /// Calculates the given sectional stiffness matrix in inertial basis based on the given

--- a/src/gebt_poc/solver.h
+++ b/src/gebt_poc/solver.h
@@ -84,10 +84,10 @@ Kokkos::View<double*> CalculateStaticResidual(
     const StiffnessMatrix& stiffness, const Quadrature& quadrature
 );
 
-Kokkos::View<double**> CalculateIterationMatrixComponents(
+void CalculateIterationMatrixComponents(
     const Kokkos::View<double*> elastic_force_fc, const Kokkos::View<double*> pos_vector_derivatives,
     const Kokkos::View<double*> gen_coords_derivatives,
-    const Kokkos::View<double**> sectional_stiffness
+    const Kokkos::View<double**> sectional_stiffness, Kokkos::View<double**> O_P_Q_matrices
 );
 
 /// Calculates the static iteration matrix for a beam element

--- a/src/gebt_poc/solver.h
+++ b/src/gebt_poc/solver.h
@@ -80,7 +80,8 @@ void CalculateElasticForces(
     const Kokkos::View<double*> gen_coords_derivatives,
     const Kokkos::View<double[kNumberOfLieGroupComponents][kNumberOfLieGroupComponents]>
         sectional_stiffness,
-    Kokkos::View<double*> elastic_forces
+    Kokkos::View<double[kNumberOfLieGroupComponents]> elastic_forces_fc,
+    Kokkos::View<double[kNumberOfLieGroupComponents]> elastic_forces_fd
 );
 
 /// Calculates the static residual vector for a beam element

--- a/src/gebt_poc/solver.h
+++ b/src/gebt_poc/solver.h
@@ -72,11 +72,11 @@ void CalculateSectionalStiffness(
 
 /// Calculates the elastic forces based on the sectional strain, derivative of the position
 /// vector and the generalized coordinates, and the sectional stiffness matrix
-Kokkos::View<double*> CalculateElasticForces(
+void CalculateElasticForces(
     const Kokkos::View<double*> strain, Kokkos::View<double**> rotation,
     const Kokkos::View<double*> pos_vector_derivatives,
     const Kokkos::View<double*> gen_coords_derivatives,
-    const Kokkos::View<double**> sectional_stiffness
+    const Kokkos::View<double**> sectional_stiffness, Kokkos::View<double*> elastic_forces
 );
 
 /// Calculates the static residual vector for a beam element

--- a/tests/unit_tests/gebt_poc/test_solver.cpp
+++ b/tests/unit_tests/gebt_poc/test_solver.cpp
@@ -94,7 +94,8 @@ TEST(SolverTest, CalculateCurvature) {
     };
     Kokkos::parallel_for(1, populate_gen_coords_derivative);
 
-    auto curvature = CalculateCurvature(gen_coords, gen_coords_derivative);
+    auto curvature = Kokkos::View<double*>("curvature", 3);
+    CalculateCurvature(gen_coords, gen_coords_derivative, curvature);
 
     EXPECT_NEAR(curvature(0), -0.03676700256944363, 1e-6);
     EXPECT_NEAR(curvature(1), 0.062023963818612256, 1e-6);

--- a/tests/unit_tests/gebt_poc/test_solver.cpp
+++ b/tests/unit_tests/gebt_poc/test_solver.cpp
@@ -239,8 +239,8 @@ TEST(SolverTest, CalculateStaticResidualWithZeroValues) {
          0.3818300505051189, 0.2797053914892766, 0.1294849661688697}
     );
 
-    auto residual =
-        CalculateStaticResidual(position_vectors, generalized_coords, stiffness, quadrature);
+    auto residual = Kokkos::View<double*>("residual", 30);
+    CalculateStaticResidual(position_vectors, generalized_coords, stiffness, quadrature, residual);
 
     openturbine::gen_alpha_solver::tests::expect_kokkos_view_1D_equal(
         residual,
@@ -358,8 +358,8 @@ TEST(SolverTest, CalculateStaticResidualWithNonZeroValues) {
         0.3818300505051189, 0.2797053914892766, 0.1294849661688697};
     auto quadrature = UserDefinedQuadrature(quadrature_points, quadrature_weights);
 
-    auto residual =
-        CalculateStaticResidual(position_vectors, generalized_coords, stiffness, quadrature);
+    auto residual = Kokkos::View<double*>("residual", 30);
+    CalculateStaticResidual(position_vectors, generalized_coords, stiffness, quadrature, residual);
 
     openturbine::gen_alpha_solver::tests::expect_kokkos_view_1D_equal(residual, expected_residual);
 }

--- a/tests/unit_tests/gebt_poc/test_solver.cpp
+++ b/tests/unit_tests/gebt_poc/test_solver.cpp
@@ -407,8 +407,10 @@ TEST(SolverTest, CalculateIterationMatrixComponents) {
           24.054825962838, 43.50305858028866}}
     );
 
-    auto O_P_Q_matrices = CalculateIterationMatrixComponents(
-        elastic_force_fc, position_vector_derivatives, gen_coords_derivatives, stiffness
+    auto O_P_Q_matrices = Kokkos::View<double**>("O_P_Q_matrices", 18, 6);
+    CalculateIterationMatrixComponents(
+        elastic_force_fc, position_vector_derivatives, gen_coords_derivatives, stiffness,
+        O_P_Q_matrices
     );
     auto o_matrix = Kokkos::View<double**>("o_matrix", 6, 6);
     auto populate_o_matrix = KOKKOS_LAMBDA(size_t i) {

--- a/tests/unit_tests/gebt_poc/test_solver.cpp
+++ b/tests/unit_tests/gebt_poc/test_solver.cpp
@@ -191,8 +191,10 @@ TEST(SolverTest, CalculateElasticForces) {
         {5., 10., 15., 20., 25., 30.},  // row 5
         {6., 12., 18., 24., 30., 36.}   // row 6
     });
-    auto elastic_forces = CalculateElasticForces(
-        sectional_strain, rotation, position_vector_derivatives, gen_coords_derivatives, stiffness
+    auto elastic_forces = Kokkos::View<double*>("elastic_forces", 12);
+    CalculateElasticForces(
+        sectional_strain, rotation, position_vector_derivatives, gen_coords_derivatives, stiffness,
+        elastic_forces
     );
 
     openturbine::gen_alpha_solver::tests::expect_kokkos_view_1D_equal(

--- a/tests/unit_tests/gebt_poc/test_solver.cpp
+++ b/tests/unit_tests/gebt_poc/test_solver.cpp
@@ -418,21 +418,16 @@ TEST(SolverTest, CalculateIterationMatrixComponents) {
           24.054825962838, 43.50305858028866}}
     );
 
-    auto O_P_Q_matrices = Kokkos::View<double**>("O_P_Q_matrices", 18, 6);
+    auto O_matrix = Kokkos::View<double**>("O_matrix", 6, 6);
+    auto P_matrix = Kokkos::View<double**>("P_matrix", 6, 6);
+    auto Q_matrix = Kokkos::View<double**>("Q_matrix", 6, 6);
     CalculateIterationMatrixComponents(
-        elastic_force_fc, position_vector_derivatives, gen_coords_derivatives, stiffness,
-        O_P_Q_matrices
+        elastic_force_fc, position_vector_derivatives, gen_coords_derivatives, stiffness, O_matrix,
+        P_matrix, Q_matrix
     );
-    auto o_matrix = Kokkos::View<double**>("o_matrix", 6, 6);
-    auto populate_o_matrix = KOKKOS_LAMBDA(size_t i) {
-        for (size_t j = 0; j < 6; ++j) {
-            o_matrix(i, j) = O_P_Q_matrices(i, j);
-        }
-    };
-    Kokkos::parallel_for(6, populate_o_matrix);
 
     openturbine::gen_alpha_solver::tests::expect_kokkos_view_2D_equal(
-        o_matrix,
+        O_matrix,
         {
             {0., 0., 0., 1.5581361688659614, 3.3881347643742066, -2.409080935189973},  // row 1
             {0., 0., 0., 2.023343846951859, 4.594085351204066, -3.233749380295583},    // row 2
@@ -442,17 +437,8 @@ TEST(SolverTest, CalculateIterationMatrixComponents) {
             {0., 0., 0., 9.270600163100875, 17.450580610135344, -12.962904649290419}   // row 6
         }
     );
-
-    auto p_matrix = Kokkos::View<double**>("p_matrix", 6, 6);
-    auto populate_p_matrix = KOKKOS_LAMBDA(size_t i) {
-        for (size_t j = 0; j < 6; ++j) {
-            p_matrix(i, j) = O_P_Q_matrices(i + 6, j);
-        }
-    };
-    Kokkos::parallel_for(6, populate_p_matrix);
-
     openturbine::gen_alpha_solver::tests::expect_kokkos_view_2D_equal(
-        p_matrix,
+        P_matrix,
         {
             {0., 0., 0., 0., 0., 0.},  // row 1
             {0., 0., 0., 0., 0., 0.},  // row 2
@@ -465,17 +451,8 @@ TEST(SolverTest, CalculateIterationMatrixComponents) {
              -7.16778142704732, -12.962904649290419}  // row 6
         }
     );
-
-    auto q_matrix = Kokkos::View<double**>("q_matrix", 6, 6);
-    auto populate_q_matrix = KOKKOS_LAMBDA(size_t i) {
-        for (size_t j = 0; j < 6; ++j) {
-            q_matrix(i, j) = O_P_Q_matrices(i + 12, j);
-        }
-    };
-    Kokkos::parallel_for(6, populate_q_matrix);
-
     openturbine::gen_alpha_solver::tests::expect_kokkos_view_2D_equal(
-        q_matrix,
+        Q_matrix,
         {
             {0., 0., 0., 0., 0., 0.},                                                  // row 1
             {0., 0., 0., 0., 0., 0.},                                                  // row 2

--- a/tests/unit_tests/gebt_poc/test_solver.cpp
+++ b/tests/unit_tests/gebt_poc/test_solver.cpp
@@ -57,8 +57,11 @@ TEST(SolverTest, CalculateInterpolatedValues) {
     auto quadrature_pt = 0.;
     auto shape_function = gen_alpha_solver::create_vector(LagrangePolynomial(1, quadrature_pt));
 
+    auto interpolated_values = Kokkos::View<double*>("interpolated_values", 7);
+    Interpolate(generalized_coords, shape_function, 1., interpolated_values);
+
     openturbine::gen_alpha_solver::tests::expect_kokkos_view_1D_equal(
-        Interpolate(generalized_coords, shape_function), {1.5, 2.5, 3.5, 0., 0., 1., 3.}
+        interpolated_values, {1.5, 2.5, 3.5, 0., 0., 1., 3.}
     );
 }
 

--- a/tests/unit_tests/gebt_poc/test_solver.cpp
+++ b/tests/unit_tests/gebt_poc/test_solver.cpp
@@ -191,14 +191,18 @@ TEST(SolverTest, CalculateElasticForces) {
         {5., 10., 15., 20., 25., 30.},  // row 5
         {6., 12., 18., 24., 30., 36.}   // row 6
     });
-    auto elastic_forces = Kokkos::View<double*>("elastic_forces", 12);
+    auto elastic_forces_fc = Kokkos::View<double*>("elastic_forces_fc", 6);
+    auto elastic_forces_fd = Kokkos::View<double*>("elastic_forces_fd", 6);
     CalculateElasticForces(
         sectional_strain, rotation, position_vector_derivatives, gen_coords_derivatives, stiffness,
-        elastic_forces
+        elastic_forces_fc, elastic_forces_fd
     );
 
     openturbine::gen_alpha_solver::tests::expect_kokkos_view_1D_equal(
-        elastic_forces, {-197.6, -395.2, -592.8, -790.4, -988., -1185.6, 0., 0., 0., 0., 0., 0.}
+        elastic_forces_fc, {-197.6, -395.2, -592.8, -790.4, -988., -1185.6}
+    );
+    openturbine::gen_alpha_solver::tests::expect_kokkos_view_1D_equal(
+        elastic_forces_fd, {0., 0., 0., 0., 0., 0.}
     );
 }
 

--- a/tests/unit_tests/gebt_poc/test_solver.cpp
+++ b/tests/unit_tests/gebt_poc/test_solver.cpp
@@ -121,7 +121,8 @@ TEST(SolverTest, CalculateSectionalStiffness) {
         {6., 12., 18., 24., 30., 36.}   // row 6
     }));
 
-    auto sectional_stiffness = CalculateSectionalStiffness(stiffness, rotation_0, rotation);
+    auto sectional_stiffness = Kokkos::View<double**>("sectional_stiffness", 6, 6);
+    CalculateSectionalStiffness(stiffness, rotation_0, rotation, sectional_stiffness);
 
     openturbine::gen_alpha_solver::tests::expect_kokkos_view_2D_equal(
         sectional_stiffness,
@@ -514,8 +515,10 @@ TEST(SolverTest, CalculateStaticIterationMatrixWithZeroValues) {
          0.3818300505051189, 0.2797053914892766, 0.1294849661688697}
     );
 
-    auto iteration_matrix =
-        CalculateStaticIterationMatrix(position_vectors, generalized_coords, stiffness, quadrature);
+    auto iteration_matrix = Kokkos::View<double**>("iteration_matrix", 30, 30);
+    CalculateStaticIterationMatrix(
+        position_vectors, generalized_coords, stiffness, quadrature, iteration_matrix
+    );
 
     openturbine::gen_alpha_solver::tests::expect_kokkos_view_2D_equal(iteration_matrix, zeros_30x30);
 }
@@ -628,8 +631,10 @@ TEST(SolverTest, CalculateStaticIterationMatrixWithNonZeroValues) {
         0.3818300505051189, 0.2797053914892766, 0.1294849661688697};
     auto quadrature = UserDefinedQuadrature(quadrature_points, quadrature_weights);
 
-    auto iteration_matrix =
-        CalculateStaticIterationMatrix(position_vectors, generalized_coords, stiffness, quadrature);
+    auto iteration_matrix = Kokkos::View<double**>("iteration_matrix", 30, 30);
+    CalculateStaticIterationMatrix(
+        position_vectors, generalized_coords, stiffness, quadrature, iteration_matrix
+    );
 
     openturbine::gen_alpha_solver::tests::expect_kokkos_view_2D_equal(
         iteration_matrix, expected_iteration_matrix


### PR DESCRIPTION
This is a refactoring pull request (i.e. no new unit test added) to clean up the static beam solver functions. The goal was to improve usage of `Kokkos` data structures in the code, specifically to

- Remove allocation of unnecessary `View`s
- Use `KokkosBlas` for linear algebra operations (as opposed to using our own definitions)
- Pass `View`s into functions to get return values rather than dynamically creating them etc.

It should be helpful for our next step of solver development where we pull these functions into a linearization parameters class.