### PR TITLE
Fixed runtime errors when running unit tests in a CUDA build

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -2,15 +2,21 @@
 set(Kokkos_DIR "$ENV{Kokkos_ROOT}" CACHE STRING "Kokkos root directory")
 find_package(KokkosKernels REQUIRED)
 
+if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS "9.0")
+  set(FS_LIB stdc++fs)
+endif()
+
 target_sources(${oturb_exe_name} PRIVATE main.cpp)
 set_target_properties(${oturb_exe_name} PROPERTIES LINKER_LANGUAGE CXX)
 target_link_libraries(${oturb_exe_name} PRIVATE
     Kokkos::kokkoskernels
+    ${FS_LIB}
 )
 
 set_target_properties(${oturb_lib_name} PROPERTIES LINKER_LANGUAGE CXX)
 target_link_libraries(${oturb_lib_name} PRIVATE
     Kokkos::kokkoskernels
+    ${FS_LIB}
 )
 
 target_include_directories(${oturb_exe_name} PRIVATE ${PROJECT_BINARY_DIR})

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -2,8 +2,10 @@
 set(Kokkos_DIR "$ENV{Kokkos_ROOT}" CACHE STRING "Kokkos root directory")
 find_package(KokkosKernels REQUIRED)
 
-if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS "9.0")
-  set(FS_LIB stdc++fs)
+if(CMAKE_CXX_COMPILER_ID MATCHES GNU)
+  if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS "9.0")
+    set(FS_LIB stdc++fs)
+  endif()
 endif()
 
 target_sources(${oturb_exe_name} PRIVATE main.cpp)

--- a/src/gebt_poc/element.cpp
+++ b/src/gebt_poc/element.cpp
@@ -1,6 +1,6 @@
-#include <KokkosBlas.hpp>
-
 #include "src/gebt_poc/element.h"
+
+#include <KokkosBlas.hpp>
 
 #include "src/utilities/log.h"
 
@@ -40,12 +40,14 @@ double CalculateJacobian(
     return jacobian;
 }
 
-double CalculateJacobian(Kokkos::View<const double*[3]> nodes, Kokkos::View<const double*> shape_derivatives) {
+double CalculateJacobian(
+    Kokkos::View<const double* [3]> nodes, Kokkos::View<const double*> shape_derivatives
+) {
     auto v0 = KokkosBlas::dot(shape_derivatives, Kokkos::subview(nodes, Kokkos::ALL, 0));
     auto v1 = KokkosBlas::dot(shape_derivatives, Kokkos::subview(nodes, Kokkos::ALL, 1));
     auto v2 = KokkosBlas::dot(shape_derivatives, Kokkos::subview(nodes, Kokkos::ALL, 2));
 
-    return std::sqrt(v0*v0 + v1*v1 + v2*v2);
+    return std::sqrt(v0 * v0 + v1 * v1 + v2 * v2);
 }
 
 }  // namespace openturbine::gebt_poc

--- a/src/gebt_poc/element.cpp
+++ b/src/gebt_poc/element.cpp
@@ -1,3 +1,5 @@
+#include <KokkosBlas.hpp>
+
 #include "src/gebt_poc/element.h"
 
 #include "src/utilities/log.h"
@@ -36,6 +38,14 @@ double CalculateJacobian(
         jacobian = v.Length();
     }
     return jacobian;
+}
+
+double CalculateJacobian(Kokkos::View<const double*[3]> nodes, Kokkos::View<const double*> shape_derivatives) {
+    auto v0 = KokkosBlas::dot(shape_derivatives, Kokkos::subview(nodes, Kokkos::ALL, 0));
+    auto v1 = KokkosBlas::dot(shape_derivatives, Kokkos::subview(nodes, Kokkos::ALL, 1));
+    auto v2 = KokkosBlas::dot(shape_derivatives, Kokkos::subview(nodes, Kokkos::ALL, 2));
+
+    return std::sqrt(v0*v0 + v1*v1 + v2*v2);
 }
 
 }  // namespace openturbine::gebt_poc

--- a/src/gebt_poc/element.h
+++ b/src/gebt_poc/element.h
@@ -8,8 +8,6 @@ namespace openturbine::gebt_poc {
 // and the nodal coordinates of the element in the global csys
 // Physically, the Jacobian represents the following (In 1-D):
 // Length of element in the global csys / Length of element in the natural csys
-double CalculateJacobian(
-    const std::vector<Point>& nodes, const std::vector<double>& shape_derivatives
-);
+double CalculateJacobian(Kokkos::View<const double*[3]> nodes, Kokkos::View<const double*> shape_derivatives);
 
 }  // namespace openturbine::gebt_poc

--- a/src/gebt_poc/element.h
+++ b/src/gebt_poc/element.h
@@ -8,6 +8,8 @@ namespace openturbine::gebt_poc {
 // and the nodal coordinates of the element in the global csys
 // Physically, the Jacobian represents the following (In 1-D):
 // Length of element in the global csys / Length of element in the natural csys
-double CalculateJacobian(Kokkos::View<const double*[3]> nodes, Kokkos::View<const double*> shape_derivatives);
+double CalculateJacobian(
+    Kokkos::View<const double* [3]> nodes, Kokkos::View<const double*> shape_derivatives
+);
 
 }  // namespace openturbine::gebt_poc

--- a/src/gebt_poc/mesh.h
+++ b/src/gebt_poc/mesh.h
@@ -10,7 +10,7 @@ public:
     int GetNumberOfNodes() const { return number_of_nodes_; }
 
     KOKKOS_FUNCTION
-    Kokkos::View<const int*> GetNodesForElement(int element_id) const {
+    auto GetNodesForElement(int element_id) const {
         return Kokkos::subview(connectivity_, element_id, Kokkos::ALL);
     }
 
@@ -55,8 +55,10 @@ protected:
     void CheckNodeUniquenessConsistency() {
         for (std::size_t element = 0; element < connectivity_.extent(0); ++element) {
             auto node_list = GetNodesForElement(element);
-            auto host_node_list = Kokkos::create_mirror(node_list);
-            Kokkos::deep_copy(host_node_list, node_list);
+            auto tmp_node_list = Kokkos::View<double*>("tmp", node_list.extent(0));
+            auto host_node_list = Kokkos::create_mirror(tmp_node_list);
+            Kokkos::deep_copy(tmp_node_list, node_list);
+            Kokkos::deep_copy(host_node_list, tmp_node_list);
             auto node_list_vector = std::vector<int>(host_node_list.extent(0));
             for (std::size_t node = 0; node < node_list_vector.size(); ++node) {
                 node_list_vector[node] = host_node_list(node);

--- a/src/gebt_poc/solver.cpp
+++ b/src/gebt_poc/solver.cpp
@@ -40,7 +40,9 @@ void CalculateCurvature(
 ) {
     // curvature = B * q_prime
     auto b_matrix = Kokkos::View<double[3][4]>("b_matrix");
-    gen_alpha_solver::BMatrixForQuaternions(b_matrix, Kokkos::subview(gen_coords, Kokkos::make_pair(3, 7)));
+    gen_alpha_solver::BMatrixForQuaternions(
+        b_matrix, Kokkos::subview(gen_coords, Kokkos::make_pair(3, 7))
+    );
     auto q_prime = Kokkos::subview(gen_coords_derivative, Kokkos::make_pair(3, 7));
     KokkosBlas::gemv("N", 2., b_matrix, q_prime, 0., curvature);
 }
@@ -149,10 +151,13 @@ void CalculateStaticResidual(
     const auto order = n_nodes - 1;
     const auto n_quad_pts = quadrature.GetNumberOfQuadraturePoints();
 
-    auto nodes = Kokkos::View<double*[3]>("nodes", n_nodes);
-    for(std::size_t i = 0; i < n_nodes; ++i) {
-        auto index = i*kNumberOfLieAlgebraComponents;
-        Kokkos::deep_copy(Kokkos::subview(nodes, i, Kokkos::ALL), Kokkos::subview(position_vectors, Kokkos::make_pair(index, index+3)));
+    auto nodes = Kokkos::View<double* [3]>("nodes", n_nodes);
+    for (std::size_t i = 0; i < n_nodes; ++i) {
+        auto index = i * kNumberOfLieAlgebraComponents;
+        Kokkos::deep_copy(
+            Kokkos::subview(nodes, i, Kokkos::ALL),
+            Kokkos::subview(position_vectors, Kokkos::make_pair(index, index + 3))
+        );
     }
 
     // Allocate Views for some required intermediate variables
@@ -360,10 +365,13 @@ void CalculateStaticIterationMatrix(
     const auto order = n_nodes - 1;
     const auto n_quad_pts = quadrature.GetNumberOfQuadraturePoints();
 
-    auto nodes = Kokkos::View<double*[3]>("nodes", n_nodes);
-    for(std::size_t i = 0; i < n_nodes; ++i) {
-        auto index = i*kNumberOfLieAlgebraComponents;
-        Kokkos::deep_copy(Kokkos::subview(nodes, i, Kokkos::ALL), Kokkos::subview(position_vectors, Kokkos::make_pair(index, index+3)));
+    auto nodes = Kokkos::View<double* [3]>("nodes", n_nodes);
+    for (std::size_t i = 0; i < n_nodes; ++i) {
+        auto index = i * kNumberOfLieAlgebraComponents;
+        Kokkos::deep_copy(
+            Kokkos::subview(nodes, i, Kokkos::ALL),
+            Kokkos::subview(position_vectors, Kokkos::make_pair(index, index + 3))
+        );
     }
 
     // Allocate Views for some required intermediate variables
@@ -532,11 +540,14 @@ void ConstraintsGradientMatrix(
         constraints_gradient_matrix, Kokkos::make_pair(3, 6), Kokkos::make_pair(3, 6)
     );
 
-    Kokkos::parallel_for(1, KOKKOS_LAMBDA(std::size_t) {
-      B11(0, 0) = 1.;
-      B11(1, 1) = 1.;
-      B11(2, 2) = 1.;
-    });
+    Kokkos::parallel_for(
+        1,
+        KOKKOS_LAMBDA(std::size_t) {
+            B11(0, 0) = 1.;
+            B11(1, 1) = 1.;
+            B11(2, 2) = 1.;
+        }
+    );
 
     KokkosBlas::scal(B21, -1., rotation_matrix_0);
     KokkosBlas::gemm("N", "N", -1., rotation_matrix_0, position_cross_prod_matrix, 0., B22);

--- a/src/gen_alpha_poc/quaternion.h
+++ b/src/gen_alpha_poc/quaternion.h
@@ -258,14 +258,18 @@ inline Kokkos::View<double**> EulerParameterToRotationMatrix(const Kokkos::View<
     auto tilde_c_tilde_c = gen_alpha_solver::multiply_matrix_with_matrix(tilde_c, tilde_c);
 
     auto rotation_matrix = Kokkos::View<double[3][3]>("rotation_matrix");
-    Kokkos::parallel_for(1, KOKKOS_LAMBDA(std::size_t) {
-      for(std::size_t i = 0; i < 3; ++i) {
-        for(std::size_t j = 0; j < 3; ++j) {
-            rotation_matrix(i, j) =
-                identity_matrix(i, j) + 2 * euler_param(0) * tilde_c(i, j) + 2 * tilde_c_tilde_c(i, j);
+    Kokkos::parallel_for(
+        1,
+        KOKKOS_LAMBDA(std::size_t) {
+            for (std::size_t i = 0; i < 3; ++i) {
+                for (std::size_t j = 0; j < 3; ++j) {
+                    rotation_matrix(i, j) = identity_matrix(i, j) +
+                                            2 * euler_param(0) * tilde_c(i, j) +
+                                            2 * tilde_c_tilde_c(i, j);
+                }
+            }
         }
-      }
-    });
+    );
     return rotation_matrix;
 }
 
@@ -308,7 +312,9 @@ Quaternion rotation_matrix_to_quaternion(const RotationMatrix& rotation_matrix) 
 }
 
 /// Returns the B derivative matrix given for Euler parameters, i.e. unit quaternions
-inline void BMatrixForQuaternions(Kokkos::View<double[3][4]> bmatrix, Kokkos::View<const double[4]> quaternion) {
+inline void BMatrixForQuaternions(
+    Kokkos::View<double[3][4]> bmatrix, Kokkos::View<const double[4]> quaternion
+) {
     auto populate_bmatrix = KOKKOS_LAMBDA(size_t) {
         bmatrix(0, 0) = -quaternion(1);
         bmatrix(0, 1) = quaternion(0);

--- a/src/gen_alpha_poc/quaternion.h
+++ b/src/gen_alpha_poc/quaternion.h
@@ -249,8 +249,7 @@ RotationMatrix quaternion_to_rotation_matrix(const Quaternion& quaternion) {
 /// Converts a 4x1 unit quaternion to a 3x3 rotation matrix and returns the result
 inline Kokkos::View<double**> EulerParameterToRotationMatrix(const Kokkos::View<double*> euler_param
 ) {
-    auto c0 = euler_param(0);
-    auto c = Kokkos::View<double*>("c", 3);
+    auto c = Kokkos::View<double[3]>("c");
     Kokkos::parallel_for(
         3, KOKKOS_LAMBDA(const size_t i) { c(i) = euler_param(i + 1); }
     );
@@ -258,14 +257,15 @@ inline Kokkos::View<double**> EulerParameterToRotationMatrix(const Kokkos::View<
     auto tilde_c = gen_alpha_solver::create_cross_product_matrix(c);
     auto tilde_c_tilde_c = gen_alpha_solver::multiply_matrix_with_matrix(tilde_c, tilde_c);
 
-    auto rotation_matrix = Kokkos::View<double**>("rotation_matrix", 3, 3);
-    Kokkos::parallel_for(
-        Kokkos::MDRangePolicy<Kokkos::DefaultExecutionSpace, Kokkos::Rank<2>>({0, 0}, {3, 3}),
-        KOKKOS_LAMBDA(const size_t i, const size_t j) {
+    auto rotation_matrix = Kokkos::View<double[3][3]>("rotation_matrix");
+    Kokkos::parallel_for(1, KOKKOS_LAMBDA(std::size_t) {
+      for(std::size_t i = 0; i < 3; ++i) {
+        for(std::size_t j = 0; j < 3; ++j) {
             rotation_matrix(i, j) =
-                identity_matrix(i, j) + 2 * c0 * tilde_c(i, j) + 2 * tilde_c_tilde_c(i, j);
+                identity_matrix(i, j) + 2 * euler_param(0) * tilde_c(i, j) + 2 * tilde_c_tilde_c(i, j);
         }
-    );
+      }
+    });
     return rotation_matrix;
 }
 
@@ -308,32 +308,24 @@ Quaternion rotation_matrix_to_quaternion(const RotationMatrix& rotation_matrix) 
 }
 
 /// Returns the B derivative matrix given for Euler parameters, i.e. unit quaternions
-inline Kokkos::View<double**> BMatrixForQuaternions(const Quaternion& quaternion) {
-    auto q0 = quaternion.GetScalarComponent();
-    auto q1 = quaternion.GetXComponent();
-    auto q2 = quaternion.GetYComponent();
-    auto q3 = quaternion.GetZComponent();
-
-    Kokkos::View<double**> bmatrix("bmatrix", 3, 4);
+inline void BMatrixForQuaternions(Kokkos::View<double[3][4]> bmatrix, Kokkos::View<const double[4]> quaternion) {
     auto populate_bmatrix = KOKKOS_LAMBDA(size_t) {
-        bmatrix(0, 0) = -q1;
-        bmatrix(0, 1) = q0;
-        bmatrix(0, 2) = -q3;
-        bmatrix(0, 3) = q2;
+        bmatrix(0, 0) = -quaternion(1);
+        bmatrix(0, 1) = quaternion(0);
+        bmatrix(0, 2) = -quaternion(3);
+        bmatrix(0, 3) = quaternion(2);
 
-        bmatrix(1, 0) = -q2;
-        bmatrix(1, 1) = q3;
-        bmatrix(1, 2) = q0;
-        bmatrix(1, 3) = -q1;
+        bmatrix(1, 0) = -quaternion(2);
+        bmatrix(1, 1) = quaternion(3);
+        bmatrix(1, 2) = quaternion(0);
+        bmatrix(1, 3) = -quaternion(1);
 
-        bmatrix(2, 0) = -q3;
-        bmatrix(2, 1) = -q2;
-        bmatrix(2, 2) = q1;
-        bmatrix(2, 3) = q0;
+        bmatrix(2, 0) = -quaternion(3);
+        bmatrix(2, 1) = -quaternion(2);
+        bmatrix(2, 2) = quaternion(1);
+        bmatrix(2, 3) = quaternion(0);
     };
     Kokkos::parallel_for(1, populate_bmatrix);
-
-    return bmatrix;
 }
 
 }  // namespace openturbine::gen_alpha_solver

--- a/src/gen_alpha_poc/utilities.cpp
+++ b/src/gen_alpha_poc/utilities.cpp
@@ -257,21 +257,4 @@ Kokkos::View<double**> add_matrix_with_matrix(
     return add_matrix_with_matrix(matrix_a_copy, matrix_b_copy);
 }
 
-Kokkos::View<double[1]> dot_product(
-    const Kokkos::View<double*> vector_a, const Kokkos::View<double*> vector_b
-) {
-    if (vector_a.extent(0) != vector_b.extent(0)) {
-        throw std::invalid_argument("The dimensions of the vectors must be equal to each other");
-    }
-
-    auto result = Kokkos::View<double[1]>("result", 1);
-    auto entries = Kokkos::RangePolicy<Kokkos::DefaultExecutionSpace>(0, vector_a.extent(0));
-    auto dot_product = KOKKOS_LAMBDA(size_t index) {
-        result(0) += vector_a(index) * vector_b(index);
-    };
-    Kokkos::parallel_for(entries, dot_product);
-
-    return result;
-}
-
 }  // namespace openturbine::gen_alpha_solver

--- a/src/gen_alpha_poc/utilities.h
+++ b/src/gen_alpha_poc/utilities.h
@@ -82,7 +82,4 @@ add_matrix_with_matrix(const Kokkos::View<double**>, const Kokkos::View<double**
 Kokkos::View<double**>
 add_matrix_with_matrix(const Kokkos::View<const double**>, const Kokkos::View<const double**>);
 
-/// Multiplies an 1 x n vector with an n x 1 vector and returns a double
-Kokkos::View<double[1]> dot_product(const Kokkos::View<double*>, const Kokkos::View<double*>);
-
 }  // namespace openturbine::gen_alpha_solver

--- a/tests/unit_tests/CMakeLists.txt
+++ b/tests/unit_tests/CMakeLists.txt
@@ -18,8 +18,10 @@ target_compile_options(
 target_include_directories(${oturb_unit_test_exe_name} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
 target_include_directories(${oturb_unit_test_exe_name} PRIVATE ${PROJECT_BINARY_DIR})
 
-if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS "9.0")
-  set(FS_LIB stdc++fs)
+if(CMAKE_CXX_COMPILER_ID MATCHES GNU)
+  if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS "9.0")
+    set(FS_LIB stdc++fs)
+  endif()
 endif()
 
 # Link our unit test executable with GoogleTest

--- a/tests/unit_tests/CMakeLists.txt
+++ b/tests/unit_tests/CMakeLists.txt
@@ -18,9 +18,13 @@ target_compile_options(
 target_include_directories(${oturb_unit_test_exe_name} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
 target_include_directories(${oturb_unit_test_exe_name} PRIVATE ${PROJECT_BINARY_DIR})
 
+if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS "9.0")
+  set(FS_LIB stdc++fs)
+endif()
+
 # Link our unit test executable with GoogleTest
 find_package(GTest REQUIRED)
-target_link_libraries(${oturb_unit_test_exe_name} PRIVATE GTest::gtest GTest::gtest_main)
+target_link_libraries(${oturb_unit_test_exe_name} PRIVATE ${FS_LIB} GTest::gtest GTest::gtest_main)
 
 # Link to OpenTurbine test targets
 target_link_libraries(${oturb_unit_test_exe_name} PRIVATE ${oturb_lib_name})

--- a/tests/unit_tests/gebt_poc/test_element.cpp
+++ b/tests/unit_tests/gebt_poc/test_element.cpp
@@ -1,17 +1,32 @@
 #include <gtest/gtest.h>
+#include <initializer_list>
 
 #include "src/gebt_poc/element.h"
 #include "tests/unit_tests/gen_alpha_poc/test_utilities.h"
 
 namespace openturbine::gebt_poc::tests {
 
+auto MakePointVector(std::initializer_list<Point> point_list ) {
+  auto points = Kokkos::View<double*[3]>("points", point_list.size());
+  auto host_points = Kokkos::create_mirror(points);
+  std::size_t i = 0;
+  for(auto& point : point_list) {
+    host_points(i, 0) = point.GetXComponent();
+    host_points(i, 1) = point.GetYComponent();
+    host_points(i, 2) = point.GetZComponent();
+    ++i;
+  }
+  Kokkos::deep_copy(points, host_points);
+  return points;
+}
+
 TEST(ElementTest, JacobianFor1DLinearElement) {
-    auto shape_derivatives = LagrangePolynomialDerivative(1, -1.);
+    auto shape_derivatives = gen_alpha_solver::create_vector(LagrangePolynomialDerivative(1, -1.));
 
     // Nodes are located at GLL points i.e. (-1, 0., 0.) and (1., 0., 0.)
     auto node_1 = Point(-1., 0., 0.);
     auto node_2 = Point(1., 0., 0.);
-    auto nodes_1 = std::vector<Point>{node_1, node_2};
+    auto nodes_1 = MakePointVector({node_1, node_2});
     auto jacobian_1 = CalculateJacobian(nodes_1, shape_derivatives);
 
     // ** For 1-D elements, the Jacobian is always length of the element / 2 **
@@ -20,7 +35,7 @@ TEST(ElementTest, JacobianFor1DLinearElement) {
 
     auto node_3 = Point(-2., 0., 0.);
     auto node_4 = Point(2., 0., 0.);
-    auto nodes_2 = std::vector<Point>{node_3, node_4};
+    auto nodes_2 = MakePointVector({node_3, node_4});
     auto jacobian_2 = CalculateJacobian(nodes_2, shape_derivatives);
 
     // Length of the element is 4, so Jacobian is 2
@@ -28,7 +43,7 @@ TEST(ElementTest, JacobianFor1DLinearElement) {
 
     auto node_5 = Point(0., 0., 0.);
     auto node_6 = Point(1., 0., 0.);
-    auto nodes_3 = std::vector<Point>{node_5, node_6};
+    auto nodes_3 = MakePointVector({node_5, node_6});
     auto jacobian_3 = CalculateJacobian(nodes_3, shape_derivatives);
 
     // Length of the element is 1, so Jacobian is 0.5
@@ -36,18 +51,18 @@ TEST(ElementTest, JacobianFor1DLinearElement) {
 }
 
 TEST(ElementTest, JacobianFor1DFourthOrderElement) {
-    auto shape_derivatives_1 = LagrangePolynomialDerivative(4, -0.9061798459386640);
-    auto shape_derivatives_2 = LagrangePolynomialDerivative(4, -0.5384693101056831);
-    auto shape_derivatives_3 = LagrangePolynomialDerivative(4, 0.);
-    auto shape_derivatives_4 = LagrangePolynomialDerivative(4, 0.5384693101056831);
-    auto shape_derivatives_5 = LagrangePolynomialDerivative(4, 0.9061798459386640);
+    auto shape_derivatives_1 = gen_alpha_solver::create_vector(LagrangePolynomialDerivative(4, -0.9061798459386640));
+    auto shape_derivatives_2 = gen_alpha_solver::create_vector(LagrangePolynomialDerivative(4, -0.5384693101056831));
+    auto shape_derivatives_3 = gen_alpha_solver::create_vector(LagrangePolynomialDerivative(4, 0.));
+    auto shape_derivatives_4 = gen_alpha_solver::create_vector(LagrangePolynomialDerivative(4, 0.5384693101056831));
+    auto shape_derivatives_5 = gen_alpha_solver::create_vector(LagrangePolynomialDerivative(4, 0.9061798459386640));
 
     auto node_1 = Point(0.0, 0.0, 0.0);
     auto node_2 = Point(0.16237631096713473, 0.17578464768961147, 0.1481911137890286);
     auto node_3 = Point(0.25, 1., 1.1875);
     auto node_4 = Point(-0.30523345382427747, 2.4670724951675314, 2.953849702537502);
     auto node_5 = Point(-1., 3.5, 4.);
-    auto nodes = std::vector<Point>{node_1, node_2, node_3, node_4, node_5};
+    auto nodes = MakePointVector({node_1, node_2, node_3, node_4, node_5});
 
     auto jacobian_1 = CalculateJacobian(nodes, shape_derivatives_1);
     auto jacobian_2 = CalculateJacobian(nodes, shape_derivatives_2);

--- a/tests/unit_tests/gebt_poc/test_element.cpp
+++ b/tests/unit_tests/gebt_poc/test_element.cpp
@@ -1,23 +1,24 @@
-#include <gtest/gtest.h>
 #include <initializer_list>
+
+#include <gtest/gtest.h>
 
 #include "src/gebt_poc/element.h"
 #include "tests/unit_tests/gen_alpha_poc/test_utilities.h"
 
 namespace openturbine::gebt_poc::tests {
 
-auto MakePointVector(std::initializer_list<Point> point_list ) {
-  auto points = Kokkos::View<double*[3]>("points", point_list.size());
-  auto host_points = Kokkos::create_mirror(points);
-  std::size_t i = 0;
-  for(auto& point : point_list) {
-    host_points(i, 0) = point.GetXComponent();
-    host_points(i, 1) = point.GetYComponent();
-    host_points(i, 2) = point.GetZComponent();
-    ++i;
-  }
-  Kokkos::deep_copy(points, host_points);
-  return points;
+auto MakePointVector(std::initializer_list<Point> point_list) {
+    auto points = Kokkos::View<double* [3]>("points", point_list.size());
+    auto host_points = Kokkos::create_mirror(points);
+    std::size_t i = 0;
+    for (auto& point : point_list) {
+        host_points(i, 0) = point.GetXComponent();
+        host_points(i, 1) = point.GetYComponent();
+        host_points(i, 2) = point.GetZComponent();
+        ++i;
+    }
+    Kokkos::deep_copy(points, host_points);
+    return points;
 }
 
 TEST(ElementTest, JacobianFor1DLinearElement) {
@@ -51,11 +52,15 @@ TEST(ElementTest, JacobianFor1DLinearElement) {
 }
 
 TEST(ElementTest, JacobianFor1DFourthOrderElement) {
-    auto shape_derivatives_1 = gen_alpha_solver::create_vector(LagrangePolynomialDerivative(4, -0.9061798459386640));
-    auto shape_derivatives_2 = gen_alpha_solver::create_vector(LagrangePolynomialDerivative(4, -0.5384693101056831));
+    auto shape_derivatives_1 =
+        gen_alpha_solver::create_vector(LagrangePolynomialDerivative(4, -0.9061798459386640));
+    auto shape_derivatives_2 =
+        gen_alpha_solver::create_vector(LagrangePolynomialDerivative(4, -0.5384693101056831));
     auto shape_derivatives_3 = gen_alpha_solver::create_vector(LagrangePolynomialDerivative(4, 0.));
-    auto shape_derivatives_4 = gen_alpha_solver::create_vector(LagrangePolynomialDerivative(4, 0.5384693101056831));
-    auto shape_derivatives_5 = gen_alpha_solver::create_vector(LagrangePolynomialDerivative(4, 0.9061798459386640));
+    auto shape_derivatives_4 =
+        gen_alpha_solver::create_vector(LagrangePolynomialDerivative(4, 0.5384693101056831));
+    auto shape_derivatives_5 =
+        gen_alpha_solver::create_vector(LagrangePolynomialDerivative(4, 0.9061798459386640));
 
     auto node_1 = Point(0.0, 0.0, 0.0);
     auto node_2 = Point(0.16237631096713473, 0.17578464768961147, 0.1481911137890286);

--- a/tests/unit_tests/gebt_poc/test_field_data.cpp
+++ b/tests/unit_tests/gebt_poc/test_field_data.cpp
@@ -26,8 +26,10 @@ void readNodalData(
 ) {
     for (int node = 0; node < mesh.GetNumberOfNodes(); ++node) {
         auto nodal_values = field_data.ReadNodalData<field>(node);
-        auto host_values = Kokkos::create_mirror(nodal_values);
-        Kokkos::deep_copy(host_values, nodal_values);
+        auto tmp_values = Kokkos::View<double*>("tmp", nodal_values.extent(0));
+        auto host_values = Kokkos::create_mirror(tmp_values);
+        Kokkos::deep_copy(tmp_values, nodal_values);
+        Kokkos::deep_copy(host_values, tmp_values);
         for (std::size_t component = 0; component < host_values.extent(0); ++component) {
             EXPECT_EQ(
                 host_values(component), multiplier * (node * host_values.extent(0) + component)
@@ -103,8 +105,10 @@ TEST(FieldDataTest, CreateElementDataAndAccess) {
     for (int element = 0; element < number_of_elements; ++element) {
         auto weights = field_data.ReadElementData<Field::Weight>(element);
         EXPECT_EQ(weights.extent(0), 4);
-        auto host_weights = Kokkos::create_mirror(weights);
-        Kokkos::deep_copy(host_weights, weights);
+        auto tmp_weights = Kokkos::View<double[4]>("tmp");
+        auto host_weights = Kokkos::create_mirror(tmp_weights);
+        Kokkos::deep_copy(tmp_weights, weights);
+        Kokkos::deep_copy(host_weights, tmp_weights);
         EXPECT_EQ(host_weights(0), element * 4.);
         EXPECT_EQ(host_weights(1), element * 4. + 1.);
         EXPECT_EQ(host_weights(2), element * 4. + 2.);
@@ -118,8 +122,10 @@ TEST(FieldDataTest, CreateElementDataAndAccess) {
         EXPECT_EQ(stiffness.extent(0), 4);
         EXPECT_EQ(stiffness.extent(1), 6);
         EXPECT_EQ(stiffness.extent(2), 6);
-        auto host_stiffness = Kokkos::create_mirror(stiffness);
-        Kokkos::deep_copy(host_stiffness, stiffness);
+        auto tmp_stiffness = Kokkos::View<double[4][6][6]>("tmp");
+        auto host_stiffness = Kokkos::create_mirror(tmp_stiffness);
+        Kokkos::deep_copy(tmp_stiffness, stiffness);
+        Kokkos::deep_copy(host_stiffness, tmp_stiffness);
         for (int point = 0; point < quadrature_points_per_element; ++point) {
             for (int row = 0; row < 6; ++row) {
                 for (int column = 0; column < 6; ++column) {

--- a/tests/unit_tests/gebt_poc/test_mesh.cpp
+++ b/tests/unit_tests/gebt_poc/test_mesh.cpp
@@ -56,10 +56,10 @@ TEST(MeshTest, Create1DMesh_2Element_5Node) {
         auto nodeList = mesh.GetNodesForElement(0);
         EXPECT_EQ(nodeList.extent(0), nodesPerElement);
 
-            auto tmpNodeList = Kokkos::View<double[5]>("tmp");
-    auto hostNodeList = Kokkos::create_mirror(tmpNodeList);
-    Kokkos::deep_copy(tmpNodeList, nodeList);
-    Kokkos::deep_copy(hostNodeList, tmpNodeList);
+        auto tmpNodeList = Kokkos::View<double[5]>("tmp");
+        auto hostNodeList = Kokkos::create_mirror(tmpNodeList);
+        Kokkos::deep_copy(tmpNodeList, nodeList);
+        Kokkos::deep_copy(hostNodeList, tmpNodeList);
         EXPECT_EQ(hostNodeList(0), 0);
         EXPECT_EQ(hostNodeList(1), 1);
         EXPECT_EQ(hostNodeList(2), 2);
@@ -71,10 +71,10 @@ TEST(MeshTest, Create1DMesh_2Element_5Node) {
         auto nodeList = mesh.GetNodesForElement(1);
         EXPECT_EQ(nodeList.extent(0), nodesPerElement);
 
-    auto tmpNodeList = Kokkos::View<double[5]>("tmp");
-    auto hostNodeList = Kokkos::create_mirror(tmpNodeList);
-    Kokkos::deep_copy(tmpNodeList, nodeList);
-    Kokkos::deep_copy(hostNodeList, tmpNodeList);
+        auto tmpNodeList = Kokkos::View<double[5]>("tmp");
+        auto hostNodeList = Kokkos::create_mirror(tmpNodeList);
+        Kokkos::deep_copy(tmpNodeList, nodeList);
+        Kokkos::deep_copy(hostNodeList, tmpNodeList);
         EXPECT_EQ(hostNodeList(0), 4);
         EXPECT_EQ(hostNodeList(1), 5);
         EXPECT_EQ(hostNodeList(2), 6);
@@ -95,10 +95,10 @@ TEST(MeshTest, Create1DMesh_3Element_3Node) {
         auto nodeList = mesh.GetNodesForElement(0);
         EXPECT_EQ(nodeList.extent(0), nodesPerElement);
 
-    auto tmpNodeList = Kokkos::View<double[3]>("tmp");
-    auto hostNodeList = Kokkos::create_mirror(tmpNodeList);
-    Kokkos::deep_copy(tmpNodeList, nodeList);
-    Kokkos::deep_copy(hostNodeList, tmpNodeList);
+        auto tmpNodeList = Kokkos::View<double[3]>("tmp");
+        auto hostNodeList = Kokkos::create_mirror(tmpNodeList);
+        Kokkos::deep_copy(tmpNodeList, nodeList);
+        Kokkos::deep_copy(hostNodeList, tmpNodeList);
         EXPECT_EQ(hostNodeList(0), 0);
         EXPECT_EQ(hostNodeList(1), 1);
         EXPECT_EQ(hostNodeList(2), 2);
@@ -108,10 +108,10 @@ TEST(MeshTest, Create1DMesh_3Element_3Node) {
         auto nodeList = mesh.GetNodesForElement(1);
         EXPECT_EQ(nodeList.extent(0), nodesPerElement);
 
-    auto tmpNodeList = Kokkos::View<double[3]>("tmp");
-    auto hostNodeList = Kokkos::create_mirror(tmpNodeList);
-    Kokkos::deep_copy(tmpNodeList, nodeList);
-    Kokkos::deep_copy(hostNodeList, tmpNodeList);
+        auto tmpNodeList = Kokkos::View<double[3]>("tmp");
+        auto hostNodeList = Kokkos::create_mirror(tmpNodeList);
+        Kokkos::deep_copy(tmpNodeList, nodeList);
+        Kokkos::deep_copy(hostNodeList, tmpNodeList);
         EXPECT_EQ(hostNodeList(0), 2);
         EXPECT_EQ(hostNodeList(1), 3);
         EXPECT_EQ(hostNodeList(2), 4);
@@ -121,10 +121,10 @@ TEST(MeshTest, Create1DMesh_3Element_3Node) {
         auto nodeList = mesh.GetNodesForElement(2);
         EXPECT_EQ(nodeList.extent(0), nodesPerElement);
 
-    auto tmpNodeList = Kokkos::View<double[3]>("tmp");
-    auto hostNodeList = Kokkos::create_mirror(tmpNodeList);
-    Kokkos::deep_copy(tmpNodeList, nodeList);
-    Kokkos::deep_copy(hostNodeList, tmpNodeList);
+        auto tmpNodeList = Kokkos::View<double[3]>("tmp");
+        auto hostNodeList = Kokkos::create_mirror(tmpNodeList);
+        Kokkos::deep_copy(tmpNodeList, nodeList);
+        Kokkos::deep_copy(hostNodeList, tmpNodeList);
         EXPECT_EQ(hostNodeList(0), 4);
         EXPECT_EQ(hostNodeList(1), 5);
         EXPECT_EQ(hostNodeList(2), 6);

--- a/tests/unit_tests/gebt_poc/test_mesh.cpp
+++ b/tests/unit_tests/gebt_poc/test_mesh.cpp
@@ -14,8 +14,10 @@ TEST(MeshTest, Create1DMesh_1Element_2Node) {
     auto nodeList = mesh.GetNodesForElement(0);
     EXPECT_EQ(nodeList.extent(0), nodesPerElement);
 
-    auto hostNodeList = Kokkos::create_mirror(nodeList);
-    Kokkos::deep_copy(hostNodeList, nodeList);
+    auto tmpNodeList = Kokkos::View<double[2]>("tmp");
+    auto hostNodeList = Kokkos::create_mirror(tmpNodeList);
+    Kokkos::deep_copy(tmpNodeList, nodeList);
+    Kokkos::deep_copy(hostNodeList, tmpNodeList);
     EXPECT_EQ(hostNodeList(0), 0);
     EXPECT_EQ(hostNodeList(1), 1);
 }
@@ -31,8 +33,10 @@ TEST(MeshTest, Create1DMesh_1Element_5Node) {
     auto nodeList = mesh.GetNodesForElement(0);
     EXPECT_EQ(nodeList.extent(0), nodesPerElement);
 
-    auto hostNodeList = Kokkos::create_mirror(nodeList);
-    Kokkos::deep_copy(hostNodeList, nodeList);
+    auto tmpNodeList = Kokkos::View<double[5]>("tmp");
+    auto hostNodeList = Kokkos::create_mirror(tmpNodeList);
+    Kokkos::deep_copy(tmpNodeList, nodeList);
+    Kokkos::deep_copy(hostNodeList, tmpNodeList);
     EXPECT_EQ(hostNodeList(0), 0);
     EXPECT_EQ(hostNodeList(1), 1);
     EXPECT_EQ(hostNodeList(2), 2);
@@ -52,8 +56,10 @@ TEST(MeshTest, Create1DMesh_2Element_5Node) {
         auto nodeList = mesh.GetNodesForElement(0);
         EXPECT_EQ(nodeList.extent(0), nodesPerElement);
 
-        auto hostNodeList = Kokkos::create_mirror(nodeList);
-        Kokkos::deep_copy(hostNodeList, nodeList);
+            auto tmpNodeList = Kokkos::View<double[5]>("tmp");
+    auto hostNodeList = Kokkos::create_mirror(tmpNodeList);
+    Kokkos::deep_copy(tmpNodeList, nodeList);
+    Kokkos::deep_copy(hostNodeList, tmpNodeList);
         EXPECT_EQ(hostNodeList(0), 0);
         EXPECT_EQ(hostNodeList(1), 1);
         EXPECT_EQ(hostNodeList(2), 2);
@@ -65,8 +71,10 @@ TEST(MeshTest, Create1DMesh_2Element_5Node) {
         auto nodeList = mesh.GetNodesForElement(1);
         EXPECT_EQ(nodeList.extent(0), nodesPerElement);
 
-        auto hostNodeList = Kokkos::create_mirror(nodeList);
-        Kokkos::deep_copy(hostNodeList, nodeList);
+    auto tmpNodeList = Kokkos::View<double[5]>("tmp");
+    auto hostNodeList = Kokkos::create_mirror(tmpNodeList);
+    Kokkos::deep_copy(tmpNodeList, nodeList);
+    Kokkos::deep_copy(hostNodeList, tmpNodeList);
         EXPECT_EQ(hostNodeList(0), 4);
         EXPECT_EQ(hostNodeList(1), 5);
         EXPECT_EQ(hostNodeList(2), 6);
@@ -87,8 +95,10 @@ TEST(MeshTest, Create1DMesh_3Element_3Node) {
         auto nodeList = mesh.GetNodesForElement(0);
         EXPECT_EQ(nodeList.extent(0), nodesPerElement);
 
-        auto hostNodeList = Kokkos::create_mirror(nodeList);
-        Kokkos::deep_copy(hostNodeList, nodeList);
+    auto tmpNodeList = Kokkos::View<double[3]>("tmp");
+    auto hostNodeList = Kokkos::create_mirror(tmpNodeList);
+    Kokkos::deep_copy(tmpNodeList, nodeList);
+    Kokkos::deep_copy(hostNodeList, tmpNodeList);
         EXPECT_EQ(hostNodeList(0), 0);
         EXPECT_EQ(hostNodeList(1), 1);
         EXPECT_EQ(hostNodeList(2), 2);
@@ -98,8 +108,10 @@ TEST(MeshTest, Create1DMesh_3Element_3Node) {
         auto nodeList = mesh.GetNodesForElement(1);
         EXPECT_EQ(nodeList.extent(0), nodesPerElement);
 
-        auto hostNodeList = Kokkos::create_mirror(nodeList);
-        Kokkos::deep_copy(hostNodeList, nodeList);
+    auto tmpNodeList = Kokkos::View<double[3]>("tmp");
+    auto hostNodeList = Kokkos::create_mirror(tmpNodeList);
+    Kokkos::deep_copy(tmpNodeList, nodeList);
+    Kokkos::deep_copy(hostNodeList, tmpNodeList);
         EXPECT_EQ(hostNodeList(0), 2);
         EXPECT_EQ(hostNodeList(1), 3);
         EXPECT_EQ(hostNodeList(2), 4);
@@ -109,8 +121,10 @@ TEST(MeshTest, Create1DMesh_3Element_3Node) {
         auto nodeList = mesh.GetNodesForElement(2);
         EXPECT_EQ(nodeList.extent(0), nodesPerElement);
 
-        auto hostNodeList = Kokkos::create_mirror(nodeList);
-        Kokkos::deep_copy(hostNodeList, nodeList);
+    auto tmpNodeList = Kokkos::View<double[3]>("tmp");
+    auto hostNodeList = Kokkos::create_mirror(tmpNodeList);
+    Kokkos::deep_copy(tmpNodeList, nodeList);
+    Kokkos::deep_copy(hostNodeList, tmpNodeList);
         EXPECT_EQ(hostNodeList(0), 4);
         EXPECT_EQ(hostNodeList(1), 5);
         EXPECT_EQ(hostNodeList(2), 6);

--- a/tests/unit_tests/gebt_poc/test_solver.cpp
+++ b/tests/unit_tests/gebt_poc/test_solver.cpp
@@ -119,9 +119,9 @@ TEST(SolverTest, CalculateCurvature) {
     auto curvature = Kokkos::View<double[3]>("curvature");
     CalculateCurvature(gen_coords, gen_coords_derivative, curvature);
 
-    EXPECT_NEAR(curvature(0), -0.03676700256944363, 1e-6);
-    EXPECT_NEAR(curvature(1), 0.062023963818612256, 1e-6);
-    EXPECT_NEAR(curvature(2), 0.15023478838786522, 1e-6);
+    openturbine::gen_alpha_solver::tests::expect_kokkos_view_1D_equal(
+        curvature, {-0.03676700256944363, 0.062023963818612256, 0.15023478838786522}
+    );
 }
 
 TEST(SolverTest, CalculateSectionalStiffness) {

--- a/tests/unit_tests/gen_alpha_poc/test_math_utilities.cpp
+++ b/tests/unit_tests/gen_alpha_poc/test_math_utilities.cpp
@@ -332,12 +332,4 @@ TEST(MathUtilitiesTest, Add3x3MatrixTo3x3Matrix) {
     expect_kokkos_view_2D_equal(result, {{2., 4., 6.}, {8., 10., 12.}, {14., 16., 18.}});
 }
 
-TEST(MathUtilitiesTest, CalculateDotProduct) {
-    auto vector_a = create_vector({1., 2., 3.});
-    auto vector_b = create_vector({4., 5., 6.});
-    auto result = dot_product(vector_a, vector_b);
-
-    expect_kokkos_view_1D_equal(result, {32.});
-}
-
 }  // namespace openturbine::gen_alpha_solver::tests

--- a/tests/unit_tests/gen_alpha_poc/test_quaternions.cpp
+++ b/tests/unit_tests/gen_alpha_poc/test_quaternions.cpp
@@ -490,8 +490,9 @@ INSTANTIATE_TEST_SUITE_P(
 
 TEST(QuaternionTest, CreateBMatrixForUnitQuaternions) {
     {
-        Quaternion q(1., 0., 0., 0.);
-        auto bmatrix = BMatrixForQuaternions(q);
+        auto bmatrix = Kokkos::View<double[3][4]>("bmatrix");
+        auto q = create_vector({1., 0., 0., 0.});
+        BMatrixForQuaternions(bmatrix, q);
 
         expect_kokkos_view_2D_equal(
             bmatrix, {{0., 1., 0., 0.}, {0., 0., 1., -0.}, {0., 0., 0., 1.}}
@@ -503,8 +504,9 @@ TEST(QuaternionTest, CreateBMatrixForUnitQuaternions) {
         auto q1 = 2. / l;
         auto q2 = 3. / l;
         auto q3 = 4. / l;
-        Quaternion q(q0, q1, q2, q3);
-        auto bmatrix = BMatrixForQuaternions(q);
+        auto q = create_vector({q0, q1, q2, q3});
+        auto bmatrix = Kokkos::View<double[3][4]>("bmatrix");
+        BMatrixForQuaternions(bmatrix, q);
 
         expect_kokkos_view_2D_equal(
             bmatrix, {{-q1, q0, -q3, q2}, {-q2, q3, q0, -q1}, {-q3, -q2, q1, q0}}

--- a/tests/unit_tests/gen_alpha_poc/test_rotation_matrix.cpp
+++ b/tests/unit_tests/gen_alpha_poc/test_rotation_matrix.cpp
@@ -55,5 +55,4 @@ TEST(RotationMatrixTest, GetComponents) {
         }
     );
 }
-
 }  // namespace openturbine::gen_alpha_solver::tests


### PR DESCRIPTION
Most of these errors are associated with memory space access errors,
while some are more nuanced aspects of Kokkos usage.  For example,
`Kokkos::deep_copy` requires views in different memory spaces to
have contiguous storage, complicating some places where we use
subviews.

This commit also removes some usages of `std::vector` in favor of
`Kokkos::View`s in support of running efficiently on device.  

The CMake script now supports the GCC 8 compiler, which needs
some extra linker flags compared to more modern versions.  

All unit tests now run on a CUDA build of OpenTurbine.