### PR TITLE
Fix issues with View indices in 2-D generalized alpha time integrator

### DIFF
--- a/src/gebt_poc/gen_alpha_2D.cpp
+++ b/src/gebt_poc/gen_alpha_2D.cpp
@@ -66,9 +66,12 @@ std::tuple<State, Kokkos::View<double*>> GeneralizedAlphaTimeIntegrator::AlphaSt
     auto algo_acceleration = state.GetAlgorithmicAcceleration();
 
     // Define some constants that will be used in the algorithm
+    const auto size_dofs = velocity.extent(0) * velocity.extent(1);
+    const auto size_constraints = n_constraints;
+    const auto size_problem = size_dofs + size_constraints;
+
     const auto h = this->time_stepper_.GetTimeStep();
     const auto n_nodes = state.GetNumberOfNodes();
-    const auto size = velocity.size();
 
     const auto kAlphaFLocal = kAlphaF_;
     const auto kAlphaMLocal = kAlphaM_;
@@ -100,7 +103,7 @@ std::tuple<State, Kokkos::View<double*>> GeneralizedAlphaTimeIntegrator::AlphaSt
         // Perform the linear update part of the generalized alpha algorithm
         // Algorithm from Table 1, Brüls, Cardona, and Arnold 2012
         Kokkos::parallel_for(
-            size,
+            kNumberOfLieAlgebraComponents,
             KOKKOS_LAMBDA(const size_t i) {
                 algo_acceleration_next(node, i) = (kAlphaFLocal * acceleration(node, i) -
                                                    kAlphaMLocal * algo_acceleration(node, i)) /
@@ -130,14 +133,14 @@ std::tuple<State, Kokkos::View<double*>> GeneralizedAlphaTimeIntegrator::AlphaSt
     const auto kGammaPrime = kGamma_ / (h * kBeta_);
 
     // Precondition the linear solve (Bottasso et al 2008)
-    const auto dl = Kokkos::View<double**>("dl", size + n_constraints, size + n_constraints);
-    const auto dr = Kokkos::View<double**>("dr", size + n_constraints, size + n_constraints);
+    const auto dl = Kokkos::View<double**>("dl", size_problem, size_problem);
+    const auto dr = Kokkos::View<double**>("dr", size_problem, size_problem);
     Kokkos::deep_copy(dl, 0.);
     Kokkos::deep_copy(dr, 0.);
 
     if (this->is_preconditioned_) {
         Kokkos::parallel_for(
-            size + n_constraints,
+            size_problem,
             KOKKOS_LAMBDA(const size_t i) {
                 dl(i, i) = 1.;
                 dr(i, i) = 1.;
@@ -145,9 +148,9 @@ std::tuple<State, Kokkos::View<double*>> GeneralizedAlphaTimeIntegrator::AlphaSt
         );
 
         Kokkos::parallel_for(
-            size + n_constraints,
+            size_problem,
             KOKKOS_LAMBDA(const size_t i) {
-                if (i >= size) {
+                if (i >= size_dofs) {
                     dr(i, i) = 1. / (kBetaLocal * h * h);
                 } else {
                     dl(i, i) = kBetaLocal * h * h;
@@ -160,10 +163,15 @@ std::tuple<State, Kokkos::View<double*>> GeneralizedAlphaTimeIntegrator::AlphaSt
     for (time_stepper_.SetNumberOfIterations(0);
          time_stepper_.GetNumberOfIterations() < max_iterations;
          time_stepper_.IncrementNumberOfIterations()) {
+        log->Debug(
+            "Performing Newton-Raphson iteration number " +
+            std::to_string(time_stepper_.GetNumberOfIterations() + 1) + "\n"
+        );
+
         UpdateGeneralizedCoordinates(gen_coords, delta_gen_coords, gen_coords_next);
 
         // Compute the residuals and check for convergence
-        const auto residuals = Kokkos::View<double*>("residuals", size + n_constraints);
+        const auto residuals = Kokkos::View<double*>("residuals", size_problem);
         linearization_parameters->ResidualVector(
             gen_coords_next, velocity_next, acceleration_next, lagrange_mults_next, residuals
         );
@@ -174,7 +182,7 @@ std::tuple<State, Kokkos::View<double*>> GeneralizedAlphaTimeIntegrator::AlphaSt
         }
 
         auto iteration_matrix =
-            Kokkos::View<double**>("iteration_matrix", size + n_constraints, size + n_constraints);
+            Kokkos::View<double**>("iteration_matrix", size_problem, size_problem);
         linearization_parameters->IterationMatrix(
             h, kBetaPrime, kGammaPrime, gen_coords_next, delta_gen_coords, velocity_next,
             acceleration_next, lagrange_mults_next, iteration_matrix
@@ -185,7 +193,7 @@ std::tuple<State, Kokkos::View<double*>> GeneralizedAlphaTimeIntegrator::AlphaSt
             iteration_matrix = gen_alpha_solver::multiply_matrix_with_matrix(dl, iteration_matrix);
 
             Kokkos::parallel_for(
-                size,
+                size_dofs,
                 KOKKOS_LAMBDA(const size_t i) { residuals(i) = residuals(i) * kBetaLocal * h * h; }
             );
         }
@@ -231,23 +239,25 @@ std::tuple<State, Kokkos::View<double*>> GeneralizedAlphaTimeIntegrator::AlphaSt
         for (size_t node = 0; node < n_nodes; node++) {
             // Update the velocity, acceleration, and constraints based on the increments
             Kokkos::parallel_for(
-                size,
+                kNumberOfLieAlgebraComponents,
                 KOKKOS_LAMBDA(const size_t i) {
                     delta_gen_coords(node, i) += delta_x(i) / h;
                     velocity_next(node, i) += kGammaPrime * delta_x(i);
                     acceleration_next(node, i) += kBetaPrime * delta_x(i);
                 }
             );
-
-            // Update algorithmic acceleration once Newton-Raphson iterations have ended
-            Kokkos::parallel_for(
-                size,
-                KOKKOS_LAMBDA(const size_t i) {
-                    algo_acceleration_next(node, i) +=
-                        (1. - kAlphaFLocal) / (1. - kAlphaMLocal) * acceleration_next(node, i);
-                }
-            );
         }
+    }
+
+    // Update algorithmic acceleration once Newton-Raphson iterations have ended
+    for (size_t node = 0; node < n_nodes; node++) {
+        Kokkos::parallel_for(
+            kNumberOfLieAlgebraComponents,
+            KOKKOS_LAMBDA(const size_t i) {
+                algo_acceleration_next(node, i) +=
+                    (1. - kAlphaFLocal) / (1. - kAlphaMLocal) * acceleration_next(node, i);
+            }
+        );
     }
 
     const auto n_iterations = time_stepper_.GetNumberOfIterations();
@@ -260,7 +270,7 @@ std::tuple<State, Kokkos::View<double*>> GeneralizedAlphaTimeIntegrator::AlphaSt
 
     if (this->is_converged_) {
         log->Info(
-            "Newton-Raphson iterations converged in " + std::to_string(n_iterations + 1) +
+            "Newton-Raphson iterations converged in " + std::to_string(n_iterations) +
             " iterations\n"
         );
         return results;
@@ -268,7 +278,7 @@ std::tuple<State, Kokkos::View<double*>> GeneralizedAlphaTimeIntegrator::AlphaSt
 
     log->Warning(
         "Newton-Raphson iterations failed to converge on a solution after " +
-        std::to_string(n_iterations + 1) + " iterations!\n"
+        std::to_string(n_iterations) + " iterations!\n"
     );
 
     return results;


### PR DESCRIPTION
This is a quick patch to fix invalid indexing issues with `Kokkos::View`s in gen_alpha_2D.cpp.