### PR TITLE
Update Constraint Residual Vector for new theory

### DIFF
--- a/src/gebt_poc/solver.cpp
+++ b/src/gebt_poc/solver.cpp
@@ -469,8 +469,9 @@ void ConstraintsResidualVector(
     auto translation_0 = Kokkos::subview(gen_coords, Kokkos::make_pair(0, 3));
     auto rotation_0 = Kokkos::subview(gen_coords, Kokkos::make_pair(3, 7));
 
-    // For the GEBT, proof of concept problem, the target translation and rotation is zero,
-    // so the residual vector is based on the generalized coordinates at the first node
+    // For the GEBT proof of concept problem (i.e. the clamped beam), the dofs are enforced to be
+    // zero at the left end of the beam, so the constraint residual is simply based on the
+    // generalized coordinates at the first node
     Kokkos::parallel_for(
         1,
         KOKKOS_LAMBDA(std::size_t) {

--- a/src/gebt_poc/solver.cpp
+++ b/src/gebt_poc/solver.cpp
@@ -468,28 +468,28 @@ void ConstraintsResidualVector(
 ) {
     auto translation_0 = Kokkos::subview(gen_coords, Kokkos::make_pair(0, 3));
     auto rotation_0 = Kokkos::subview(gen_coords, Kokkos::make_pair(3, 7));
-    auto rotation_matrix_0 = gen_alpha_solver::EulerParameterToRotationMatrix(rotation_0);
-    auto position_0 = Kokkos::subview(position_vector, Kokkos::make_pair(0, 3));
 
-    // position = position_0 + translation_0
-    auto position = Kokkos::View<double[kNumberOfVectorComponents]>("position");
-    Kokkos::deep_copy(position, position_0);
-    KokkosBlas::axpy(1., translation_0, position);
-
-    // rotated_position = rotation_matrix_0 * position
-    auto rotated_position = Kokkos::View<double[kNumberOfVectorComponents]>("rotated_position");
-    KokkosBlas::gemv("N", 1., rotation_matrix_0, position, 0., rotated_position);
-
-    // Assemble the constraint residual vector
-    // {constraints_residual}_6x1 = {
-    //    {translation_0}_3x1
-    //    {rotated_position - position_0}_3x1
-    // }
-    auto constraints_residual_1 = Kokkos::subview(constraints_residual, Kokkos::make_pair(0, 3));
-    Kokkos::deep_copy(constraints_residual_1, translation_0);
-    auto constraints_residual_2 = Kokkos::subview(constraints_residual, Kokkos::make_pair(3, 6));
-    Kokkos::deep_copy(constraints_residual_2, rotated_position);
-    KokkosBlas::axpy(-1., position_0, constraints_residual_2);
+    // For the GEBT, proof of concept problem, the target translation and rotation is zero,
+    // so the residual vector is based on the generalized coordinates at the first node
+    Kokkos::parallel_for(
+        1,
+        KOKKOS_LAMBDA(std::size_t) {
+            // Construct rotation vector from root node rotation quaternion
+            auto rotation_vector = openturbine::gen_alpha_solver::rotation_vector_from_quaternion(
+                openturbine::gen_alpha_solver::Quaternion(
+                    gen_coords(3), gen_coords(4), gen_coords(5), gen_coords(6)
+                )
+            );
+            // Set residual as translation and rotation of root node
+            // TODO: update when position & rotation are prescribed
+            constraints_residual(0) = gen_coords(0);
+            constraints_residual(1) = gen_coords(1);
+            constraints_residual(2) = gen_coords(2);
+            constraints_residual(3) = rotation_vector.GetXComponent();
+            constraints_residual(4) = rotation_vector.GetYComponent();
+            constraints_residual(5) = rotation_vector.GetZComponent();
+        }
+    );
 }
 
 void ConstraintsGradientMatrix(

--- a/src/gebt_poc/solver.cpp
+++ b/src/gebt_poc/solver.cpp
@@ -466,9 +466,6 @@ void ConstraintsResidualVector(
     const Kokkos::View<double*> gen_coords, const Kokkos::View<double*> position_vector,
     Kokkos::View<double*> constraints_residual
 ) {
-    auto translation_0 = Kokkos::subview(gen_coords, Kokkos::make_pair(0, 3));
-    auto rotation_0 = Kokkos::subview(gen_coords, Kokkos::make_pair(3, 7));
-
     // For the GEBT proof of concept problem (i.e. the clamped beam), the dofs are enforced to be
     // zero at the left end of the beam, so the constraint residual is simply based on the
     // generalized coordinates at the first node

--- a/src/gen_alpha_poc/quaternion.h
+++ b/src/gen_alpha_poc/quaternion.h
@@ -163,8 +163,8 @@ Vector rotation_vector_from_quaternion(const Quaternion& quaternion) {
 
     return (
         n_length < kEpsilon
-            ? (2. / q0 - 2. / 3. * n_length_squared / (q0 * q0 * q0))
-            : 4. * std::atan(n_length / (q0 + std::sqrt(q0 * q0 + n_length_squared))) / n_length
+            ? n * (2. / q0 - 2. / 3. * n_length_squared / (q0 * q0 * q0))
+            : n * 4. * std::atan(n_length / (q0 + std::sqrt(q0 * q0 + n_length_squared))) / n_length
     );
 }
 

--- a/src/gen_alpha_poc/quaternion.h
+++ b/src/gen_alpha_poc/quaternion.h
@@ -157,17 +157,18 @@ Vector rotation_vector_from_quaternion(const Quaternion& quaternion) {
     auto q2 = quaternion.GetYComponent();
     auto q3 = quaternion.GetZComponent();
 
-    auto sin_angle_squared = q1 * q1 + q2 * q2 + q3 * q3;
+    Vector n(q1, q2, q3);                           // Vector part of quaternion
+    double n_length = n.Length();                   // magnitude of vector
+    double n_length_squared = n_length * n_length;  // magnitude squared
 
-    // Return the rotation vector {0, 0, 0} if provided quaternion is null
-    if (close_to(sin_angle_squared, 0.)) {
-        return Vector{0.0, 0.0, 0.0};
+    // If the length of the vector is less than machine precision,
+    // calculate and return rotation vector using method stable for small angles
+    if (n_length < kEpsilon) {
+        return n * (2. / q0 - 2. / 3. * n_length_squared / (q0 * q0 * q0));
     }
 
-    double sin_angle = std::sqrt(sin_angle_squared);
-    double k = 2. * std::atan2(sin_angle, q0) / sin_angle;
-
-    return {q1 * k, q2 * k, q3 * k};
+    // Otherwise, calculate and return rotation vector using this method
+    return n * 4. * std::atan(n_length / (q0 + std::sqrt(q0 * q0 + n_length_squared))) / n_length;
 }
 
 /// Returns a quaternion from provided Euler parameters/angle-axis representation of rotation

--- a/src/gen_alpha_poc/quaternion.h
+++ b/src/gen_alpha_poc/quaternion.h
@@ -161,14 +161,11 @@ Vector rotation_vector_from_quaternion(const Quaternion& quaternion) {
     double n_length = n.Length();                   // magnitude of vector
     double n_length_squared = n_length * n_length;  // magnitude squared
 
-    // If the length of the vector is less than machine precision,
-    // calculate and return rotation vector using method stable for small angles
-    if (n_length < kEpsilon) {
-        return n * (2. / q0 - 2. / 3. * n_length_squared / (q0 * q0 * q0));
-    }
-
-    // Otherwise, calculate and return rotation vector using this method
-    return n * 4. * std::atan(n_length / (q0 + std::sqrt(q0 * q0 + n_length_squared))) / n_length;
+    return (
+        n_length < kEpsilon
+            ? (2. / q0 - 2. / 3. * n_length_squared / (q0 * q0 * q0))
+            : 4. * std::atan(n_length / (q0 + std::sqrt(q0 * q0 + n_length_squared))) / n_length
+    );
 }
 
 /// Returns a quaternion from provided Euler parameters/angle-axis representation of rotation

--- a/src/gen_alpha_poc/utilities.h
+++ b/src/gen_alpha_poc/utilities.h
@@ -6,6 +6,7 @@
 
 namespace openturbine::gen_alpha_solver {
 
+static constexpr double kEpsilon{std::numeric_limits<double>::epsilon()};
 static constexpr double kTolerance = 1e-6;
 static constexpr double kPi = 3.14159265358979323846;
 

--- a/tests/unit_tests/gebt_poc/test_solver.cpp
+++ b/tests/unit_tests/gebt_poc/test_solver.cpp
@@ -625,6 +625,8 @@ TEST(SolverTest, ConstraintsResidualVector) {
     ConstraintsResidualVector(generalized_coords, position_vectors, constraints_residual);
 
     openturbine::gen_alpha_solver::tests::expect_kokkos_view_1D_equal(
+        // constraints_residual should be same as the generalized_coords where
+        // q{0.9987502603949662, 0.049979169270678324, 0., 0.} -> v{0.1, 0., 0.}
         constraints_residual, {0.1, 0., 0.12, 0.1, 0., 0.0}
     );
 }

--- a/tests/unit_tests/gebt_poc/test_solver.cpp
+++ b/tests/unit_tests/gebt_poc/test_solver.cpp
@@ -625,7 +625,7 @@ TEST(SolverTest, ConstraintsResidualVector) {
     ConstraintsResidualVector(generalized_coords, position_vectors, constraints_residual);
 
     openturbine::gen_alpha_solver::tests::expect_kokkos_view_1D_equal(
-        constraints_residual, {0.1, 0., 0.12, 0.1, -0.01198, 0.1194}
+        constraints_residual, {0.1, 0., 0.12, 0.1, 0., 0.0}
     );
 }
 

--- a/tests/unit_tests/gen_alpha_poc/test_quaternions.cpp
+++ b/tests/unit_tests/gen_alpha_poc/test_quaternions.cpp
@@ -211,6 +211,18 @@ TEST(QuaternionTest, GetRotationVectorFromNullQuaternion) {
     ASSERT_NEAR(v.GetZComponent(), expected.GetZComponent(), 1e-6);
 }
 
+TEST(QuaternionTest, QuaternionToRotationVectorToQuaternion) {
+    Quaternion q(0.707107, 0., 0., 0.707107);
+    auto v = rotation_vector_from_quaternion(q);
+    auto q2 = quaternion_from_rotation_vector(v);
+    Quaternion expected(0.707107, 0., 0., 0.707107);
+
+    ASSERT_NEAR(q2.GetScalarComponent(), expected.GetScalarComponent(), 1e-6);
+    ASSERT_NEAR(q2.GetXComponent(), expected.GetXComponent(), 1e-6);
+    ASSERT_NEAR(q2.GetYComponent(), expected.GetYComponent(), 1e-6);
+    ASSERT_NEAR(q2.GetZComponent(), expected.GetZComponent(), 1e-6);
+}
+
 TEST(QuaternionTest, QuaternionFromAngleAxis_ZeroAngle) {
     double angle = 0.;
     Vector axis{1., 0., 0.};

--- a/tests/unit_tests/gen_alpha_poc/test_quaternions.cpp
+++ b/tests/unit_tests/gen_alpha_poc/test_quaternions.cpp
@@ -211,16 +211,14 @@ TEST(QuaternionTest, GetRotationVectorFromNullQuaternion) {
     ASSERT_NEAR(v.GetZComponent(), expected.GetZComponent(), 1e-6);
 }
 
-TEST(QuaternionTest, QuaternionToRotationVectorToQuaternion) {
-    Quaternion q(0.707107, 0., 0., 0.707107);
+TEST(QuaternionTest, GetRotationVectorQuaternionWithVerySmallRotation) {
+    Quaternion q(1.0, -1.0e-18, 0.0, 0.0);
     auto v = rotation_vector_from_quaternion(q);
-    auto q2 = quaternion_from_rotation_vector(v);
-    Quaternion expected(0.707107, 0., 0., 0.707107);
+    Vector expected{-2.0e-18, 0.0, 0.0};
 
-    ASSERT_NEAR(q2.GetScalarComponent(), expected.GetScalarComponent(), 1e-6);
-    ASSERT_NEAR(q2.GetXComponent(), expected.GetXComponent(), 1e-6);
-    ASSERT_NEAR(q2.GetYComponent(), expected.GetYComponent(), 1e-6);
-    ASSERT_NEAR(q2.GetZComponent(), expected.GetZComponent(), 1e-6);
+    ASSERT_NEAR(v.GetXComponent(), expected.GetXComponent(), 1e-20);
+    ASSERT_NEAR(v.GetYComponent(), expected.GetYComponent(), 1e-20);
+    ASSERT_NEAR(v.GetZComponent(), expected.GetZComponent(), 1e-20);
 }
 
 TEST(QuaternionTest, QuaternionFromAngleAxis_ZeroAngle) {


### PR DESCRIPTION
This PR updates the calculation of the constraint residual vector based on the latest revisions to the theory document. The constraint residual vector is specific to the geometrically exact beam theory proof of concept in that the prescribed displacement and rotation of the root node is zero, so the residual is simply the displacement and rotation of the first node. The rotation is represented by the rotation vector (logarithmic map) of the quaternion. The implementation for calculating a rotation vector from a quaternion (`rotation_vector_from_quaternion`) was updated to avoid loss of data due to floating point number precision. A new unit test was added to verify that the rotation vector is calculated correctly for extremely small rotation angles.