### PR TITLE
Revise CI pipeline

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,19 @@
+---
+Checks: "*,
+        -abseil-*,
+        -altera-*,
+        -android-*,
+        -fuchsia-*,
+        -google-*,
+        -llvm*,
+        -modernize-use-trailing-return-type,
+        -zircon-*,
+        -readability-else-after-return,
+        -readability-static-accessed-through-instance,
+        -readability-avoid-const-params-in-decls,
+        -cppcoreguidelines-non-private-member-variables-in-classes,
+        -misc-non-private-member-variables-in-classes,
+"
+WarningsAsErrors: ''
+HeaderFilterRegex: ''
+FormatStyle:     none

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -194,6 +194,65 @@ jobs:
           -DCMAKE_BUILD_TYPE=Debug \
           -DCMAKE_CXX_CLANG_TIDY="clang-tidy"
         cmake --build . 
+  CppCheck:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Install dependencies
+      run: sudo apt-get install libgtest-dev cppcheck 
+    - name: Cache install Kokkos
+      id: cache-kokkos
+      uses: actions/cache@v3
+      with:
+        path: ~/dependencies/kokkos
+        key: ${{runner.os}}-kokkos
+    - name: Install Kokkos
+      if: steps.cache-kokkos.outputs.cache-hit != 'true'
+      run: |
+        sudo mkdir -p ~/dependencies/kokkos
+        git clone --depth 1 --branch 4.2.00 https://github.com/kokkos/kokkos
+        cd kokkos
+        mkdir build
+        cd build
+        cmake .. \
+          -DCMAKE_INSTALL_PREFIX:PATH=~/dependencies/kokkos \
+          -DCMAKE_BUILD_TYPE=Debug \
+          -DKokkos_ENABLE_DEBUG=ON \
+          -DKokkos_ENABLE_DEBUG_BOUNDS_CHECK=ON
+        sudo cmake --build . --target install -j 2
+    - name: Cache install Kokkos-Kernels
+      id: cache-kokkos-kernels
+      uses: actions/cache@v3
+      with:
+        path: ~/dependencies/kokkos_kernels
+        key: ${{runner.os}}-kokkos-kernels
+    - name: Install Kokkos-Kernels
+      if: steps.cache-kokkos-kernels.outputs.cache-hit != 'true'
+      run: |
+        sudo mkdir -p ~/dependencies/kokkos_kernels
+        export Kokkos_DIR=~/dependencies/kokkos
+          git clone https://github.com/kokkos/kokkos-kernels
+        cd kokkos-kernels
+        mkdir build
+        cd build
+        cmake .. \
+          -DCMAKE_INSTALL_PREFIX:PATH=~/dependencies/kokkos_kernels \
+          -DCMAKE_BUILD_TYPE=Debug
+        sudo cmake --build . --target install -j 2
+    - name: Clone
+      uses: actions/checkout@v3
+      with:
+        submodules: true
+    - name: Test OpenTurbine
+      run: |
+        export KokkosKernels_DIR=~/dependencies/kokkos_kernels
+        mkdir build
+        cd build
+        cmake .. \
+          -DOTURB_ENABLE_TESTS:BOOL=ON \
+          -DOTURB_ENABLE_BASIC_SANITIZERS=ON \
+          -DCMAKE_BUILD_TYPE=Debug \
+          -DCMAKE_CXX_CPPCHECK="cppcheck;--enable=all;--force;"
+        cmake --build . 
   Formatting:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,14 +6,28 @@ jobs:
   Release:
     runs-on: ${{matrix.os}}
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
+        compiler: [gcc, llvm]
+        build_type: [Release, Debug]
+        generator: 
+          - "Ninja Multi-Config"
         include:
           - os: ubuntu-latest
             install_deps: sudo apt-get install libgtest-dev
           - os: macos-latest
             install_deps: brew install googletest
     steps:
+    - name: Setup Cpp
+      uses: aminya/setup-cpp@v1
+      with:
+        compiler: ${{ matrix.compiler }}
+        cmake: true
+        ninja: true
+        clangtidy: true
+        cppcheck: true
+        ccache: true
     - name: Install dependencies
       run: |
         ${{matrix.install_deps}}
@@ -32,8 +46,11 @@ jobs:
         mkdir build
         cd build
         cmake .. \
+          -G ${{ matrix.generator }} \
           -DCMAKE_INSTALL_PREFIX:PATH=~/dependencies/kokkos \
-          -DCMAKE_BUILD_TYPE=Release 
+          -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} \
+          -DKokkos_ENABLE_DEBUG=${{ matrix.build_type == 'Debug' }} \
+          -DKokkos_ENABLE_DEBUG_BOUNDS_CHECK=${{ matrix.build_type == 'Debug' }}
         sudo cmake --build . --target install -j 2
     - name: Cache install Kokkos-Kernels
       id: cache-kokkos-kernels
@@ -50,18 +67,18 @@ jobs:
           git clone https://github.com/kokkos/kokkos-kernels
         fi
         if [ ${{matrix.os}} = 'macos-latest' ]; then
-          export FC=$(brew --prefix gcc)/bin/gfortran
           git clone --depth 1 --branch 4.2.00 https://github.com/kokkos/kokkos-kernels
         fi
         cd kokkos-kernels
         mkdir build
         cd build
         cmake .. \
+          -G ${{ matrix.generator }} \
           -DCMAKE_INSTALL_PREFIX:PATH=~/dependencies/kokkos_kernels \
-          -DCMAKE_BUILD_TYPE=Release
+          -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
         sudo cmake --build . --target install -j 2
     - name: Clone
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         submodules: true
     - name: Test OpenTurbine
@@ -70,194 +87,195 @@ jobs:
         mkdir build
         cd build
         cmake .. \
+          -G ${{ matrix.generator }} \
           -DOTURB_ENABLE_TESTS:BOOL=ON \
-          -DCMAKE_BUILD_TYPE=Release
+          -DOTURB_ENABLE_BASIC_SANITIZERS=ON \
+          -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
         cmake --build . -j 2
-        ./openturbine -h
-        ./openturbine_unit_tests
-  Debug:
-    runs-on: ubuntu-latest
-    steps:
-    - name: Install dependencies
-      run: sudo apt-get install libgtest-dev 
-    - name: Cache install Kokkos
-      id: cache-kokkos
-      uses: actions/cache@v3
-      with:
-        path: ~/dependencies/kokkos
-        key: ${{runner.os}}-kokkos
-    - name: Install Kokkos
-      if: steps.cache-kokkos.outputs.cache-hit != 'true'
-      run: |
-        sudo mkdir -p ~/dependencies/kokkos
-        git clone --depth 1 --branch 4.2.00 https://github.com/kokkos/kokkos
-        cd kokkos
-        mkdir build
-        cd build
-        cmake .. \
-          -DCMAKE_INSTALL_PREFIX:PATH=~/dependencies/kokkos \
-          -DCMAKE_BUILD_TYPE=Debug \
-          -DKokkos_ENABLE_DEBUG=ON \
-          -DKokkos_ENABLE_DEBUG_BOUNDS_CHECK=ON
-        sudo cmake --build . --target install -j 2
-    - name: Cache install Kokkos-Kernels
-      id: cache-kokkos-kernels
-      uses: actions/cache@v3
-      with:
-        path: ~/dependencies/kokkos_kernels
-        key: ${{runner.os}}-kokkos-kernels
-    - name: Install Kokkos-Kernels
-      if: steps.cache-kokkos-kernels.outputs.cache-hit != 'true'
-      run: |
-        sudo mkdir -p ~/dependencies/kokkos_kernels
-        export Kokkos_DIR=~/dependencies/kokkos
-          git clone https://github.com/kokkos/kokkos-kernels
-        cd kokkos-kernels
-        mkdir build
-        cd build
-        cmake .. \
-          -DCMAKE_INSTALL_PREFIX:PATH=~/dependencies/kokkos_kernels \
-          -DCMAKE_BUILD_TYPE=Debug
-        sudo cmake --build . --target install -j 2
-    - name: Clone
-      uses: actions/checkout@v3
-      with:
-        submodules: true
-    - name: Test OpenTurbine
-      run: |
-        export KokkosKernels_DIR=~/dependencies/kokkos_kernels
-        mkdir build
-        cd build
-        cmake .. \
-          -DOTURB_ENABLE_TESTS:BOOL=ON \
-          -DOTURB_ENABLE_BASIC_SANITIZERS=ON \
-          -DCMAKE_BUILD_TYPE=Debug 
-        cmake --build . -j 2
-        ./openturbine -h
-        ./openturbine_unit_tests
-  Clang-Tidy:
-    runs-on: ubuntu-latest
-    steps:
-    - name: Install dependencies
-      run: sudo apt-get install libgtest-dev 
-    - name: Cache install Kokkos
-      id: cache-kokkos
-      uses: actions/cache@v3
-      with:
-        path: ~/dependencies/kokkos
-        key: ${{runner.os}}-kokkos
-    - name: Install Kokkos
-      if: steps.cache-kokkos.outputs.cache-hit != 'true'
-      run: |
-        sudo mkdir -p ~/dependencies/kokkos
-        git clone --depth 1 --branch 4.2.00 https://github.com/kokkos/kokkos
-        cd kokkos
-        mkdir build
-        cd build
-        cmake .. \
-          -DCMAKE_INSTALL_PREFIX:PATH=~/dependencies/kokkos \
-          -DCMAKE_BUILD_TYPE=Debug \
-          -DKokkos_ENABLE_DEBUG=ON \
-          -DKokkos_ENABLE_DEBUG_BOUNDS_CHECK=ON
-        sudo cmake --build . --target install -j 2
-    - name: Cache install Kokkos-Kernels
-      id: cache-kokkos-kernels
-      uses: actions/cache@v3
-      with:
-        path: ~/dependencies/kokkos_kernels
-        key: ${{runner.os}}-kokkos-kernels
-    - name: Install Kokkos-Kernels
-      if: steps.cache-kokkos-kernels.outputs.cache-hit != 'true'
-      run: |
-        sudo mkdir -p ~/dependencies/kokkos_kernels
-        export Kokkos_DIR=~/dependencies/kokkos
-          git clone https://github.com/kokkos/kokkos-kernels
-        cd kokkos-kernels
-        mkdir build
-        cd build
-        cmake .. \
-          -DCMAKE_INSTALL_PREFIX:PATH=~/dependencies/kokkos_kernels \
-          -DCMAKE_BUILD_TYPE=Debug
-        sudo cmake --build . --target install -j 2
-    - name: Clone
-      uses: actions/checkout@v3
-      with:
-        submodules: true
-    - name: Test OpenTurbine
-      run: |
-        export KokkosKernels_DIR=~/dependencies/kokkos_kernels
-        mkdir build
-        cd build
-        cmake .. \
-          -DOTURB_ENABLE_TESTS:BOOL=ON \
-          -DOTURB_ENABLE_BASIC_SANITIZERS=ON \
-          -DCMAKE_BUILD_TYPE=Debug \
-          -DCMAKE_CXX_CLANG_TIDY="clang-tidy"
-        cmake --build . 
-  CppCheck:
-    runs-on: ubuntu-latest
-    steps:
-    - name: Install dependencies
-      run: sudo apt-get install libgtest-dev cppcheck 
-    - name: Cache install Kokkos
-      id: cache-kokkos
-      uses: actions/cache@v3
-      with:
-        path: ~/dependencies/kokkos
-        key: ${{runner.os}}-kokkos
-    - name: Install Kokkos
-      if: steps.cache-kokkos.outputs.cache-hit != 'true'
-      run: |
-        sudo mkdir -p ~/dependencies/kokkos
-        git clone --depth 1 --branch 4.2.00 https://github.com/kokkos/kokkos
-        cd kokkos
-        mkdir build
-        cd build
-        cmake .. \
-          -DCMAKE_INSTALL_PREFIX:PATH=~/dependencies/kokkos \
-          -DCMAKE_BUILD_TYPE=Debug \
-          -DKokkos_ENABLE_DEBUG=ON \
-          -DKokkos_ENABLE_DEBUG_BOUNDS_CHECK=ON
-        sudo cmake --build . --target install -j 2
-    - name: Cache install Kokkos-Kernels
-      id: cache-kokkos-kernels
-      uses: actions/cache@v3
-      with:
-        path: ~/dependencies/kokkos_kernels
-        key: ${{runner.os}}-kokkos-kernels
-    - name: Install Kokkos-Kernels
-      if: steps.cache-kokkos-kernels.outputs.cache-hit != 'true'
-      run: |
-        sudo mkdir -p ~/dependencies/kokkos_kernels
-        export Kokkos_DIR=~/dependencies/kokkos
-          git clone https://github.com/kokkos/kokkos-kernels
-        cd kokkos-kernels
-        mkdir build
-        cd build
-        cmake .. \
-          -DCMAKE_INSTALL_PREFIX:PATH=~/dependencies/kokkos_kernels \
-          -DCMAKE_BUILD_TYPE=Debug
-        sudo cmake --build . --target install -j 2
-    - name: Clone
-      uses: actions/checkout@v3
-      with:
-        submodules: true
-    - name: Test OpenTurbine
-      run: |
-        export KokkosKernels_DIR=~/dependencies/kokkos_kernels
-        mkdir build
-        cd build
-        cmake .. \
-          -DOTURB_ENABLE_TESTS:BOOL=ON \
-          -DOTURB_ENABLE_BASIC_SANITIZERS=ON \
-          -DCMAKE_BUILD_TYPE=Debug \
-          -DCMAKE_CXX_CPPCHECK="cppcheck;--enable=all;--force;--suppress=missingIncludeSystem"
-        cmake --build . 
+        ctest -C ${{ matrix.build_type }}
+#  Debug:
+#    runs-on: ubuntu-latest
+#    steps:
+#    - name: Install dependencies
+#      run: sudo apt-get install libgtest-dev 
+#    - name: Cache install Kokkos
+#      id: cache-kokkos
+#      uses: actions/cache@v3
+#      with:
+#        path: ~/dependencies/kokkos
+#        key: ${{runner.os}}-kokkos
+#    - name: Install Kokkos
+#      if: steps.cache-kokkos.outputs.cache-hit != 'true'
+#      run: |
+#        sudo mkdir -p ~/dependencies/kokkos
+#        git clone --depth 1 --branch 4.2.00 https://github.com/kokkos/kokkos
+#        cd kokkos
+#        mkdir build
+#        cd build
+#        cmake .. \
+#          -DCMAKE_INSTALL_PREFIX:PATH=~/dependencies/kokkos \
+#          -DCMAKE_BUILD_TYPE=Debug \
+#          -DKokkos_ENABLE_DEBUG=ON \
+#          -DKokkos_ENABLE_DEBUG_BOUNDS_CHECK=ON
+#        sudo cmake --build . --target install -j 2
+#    - name: Cache install Kokkos-Kernels
+#      id: cache-kokkos-kernels
+#      uses: actions/cache@v3
+#      with:
+#        path: ~/dependencies/kokkos_kernels
+#        key: ${{runner.os}}-kokkos-kernels
+#    - name: Install Kokkos-Kernels
+#      if: steps.cache-kokkos-kernels.outputs.cache-hit != 'true'
+#      run: |
+#        sudo mkdir -p ~/dependencies/kokkos_kernels
+#        export Kokkos_DIR=~/dependencies/kokkos
+#          git clone https://github.com/kokkos/kokkos-kernels
+#        cd kokkos-kernels
+#        mkdir build
+#        cd build
+#        cmake .. \
+#          -DCMAKE_INSTALL_PREFIX:PATH=~/dependencies/kokkos_kernels \
+#          -DCMAKE_BUILD_TYPE=Debug
+#        sudo cmake --build . --target install -j 2
+#    - name: Clone
+#      uses: actions/checkout@v4
+#      with:
+#        submodules: true
+#    - name: Test OpenTurbine
+#      run: |
+#        export KokkosKernels_DIR=~/dependencies/kokkos_kernels
+#        mkdir build
+#        cd build
+#        cmake .. \
+#          -DOTURB_ENABLE_TESTS:BOOL=ON \
+#          -DOTURB_ENABLE_BASIC_SANITIZERS=ON \
+#          -DCMAKE_BUILD_TYPE=Debug 
+#        cmake --build . -j 2
+#        ./openturbine -h
+#        ./openturbine_unit_tests
+#  Clang-Tidy:
+#    runs-on: ubuntu-latest
+#    steps:
+#    - name: Install dependencies
+#      run: sudo apt-get install libgtest-dev 
+#    - name: Cache install Kokkos
+#      id: cache-kokkos
+#      uses: actions/cache@v3
+#      with:
+#        path: ~/dependencies/kokkos
+#        key: ${{runner.os}}-kokkos
+#    - name: Install Kokkos
+#      if: steps.cache-kokkos.outputs.cache-hit != 'true'
+#      run: |
+#        sudo mkdir -p ~/dependencies/kokkos
+#        git clone --depth 1 --branch 4.2.00 https://github.com/kokkos/kokkos
+#        cd kokkos
+#        mkdir build
+#        cd build
+#        cmake .. \
+#          -DCMAKE_INSTALL_PREFIX:PATH=~/dependencies/kokkos \
+#          -DCMAKE_BUILD_TYPE=Debug \
+#          -DKokkos_ENABLE_DEBUG=ON \
+#          -DKokkos_ENABLE_DEBUG_BOUNDS_CHECK=ON
+#        sudo cmake --build . --target install -j 2
+#    - name: Cache install Kokkos-Kernels
+#      id: cache-kokkos-kernels
+#      uses: actions/cache@v3
+#      with:
+#        path: ~/dependencies/kokkos_kernels
+#        key: ${{runner.os}}-kokkos-kernels
+#    - name: Install Kokkos-Kernels
+#      if: steps.cache-kokkos-kernels.outputs.cache-hit != 'true'
+#      run: |
+#        sudo mkdir -p ~/dependencies/kokkos_kernels
+#        export Kokkos_DIR=~/dependencies/kokkos
+#          git clone https://github.com/kokkos/kokkos-kernels
+#        cd kokkos-kernels
+#        mkdir build
+#        cd build
+#        cmake .. \
+#          -DCMAKE_INSTALL_PREFIX:PATH=~/dependencies/kokkos_kernels \
+#          -DCMAKE_BUILD_TYPE=Debug
+#        sudo cmake --build . --target install -j 2
+#    - name: Clone
+#      uses: actions/checkout@v4
+#      with:
+#        submodules: true
+#    - name: Test OpenTurbine
+#      run: |
+#        export KokkosKernels_DIR=~/dependencies/kokkos_kernels
+#        mkdir build
+#        cd build
+#        cmake .. \
+#          -DOTURB_ENABLE_TESTS:BOOL=ON \
+#          -DOTURB_ENABLE_BASIC_SANITIZERS=ON \
+#          -DCMAKE_BUILD_TYPE=Debug \
+#          -DCMAKE_CXX_CLANG_TIDY="clang-tidy"
+#        cmake --build . 
+#  CppCheck:
+#    runs-on: ubuntu-latest
+#    steps:
+#    - name: Install dependencies
+#      run: sudo apt-get install libgtest-dev cppcheck 
+#    - name: Cache install Kokkos
+#      id: cache-kokkos
+#      uses: actions/cache@v3
+#      with:
+#        path: ~/dependencies/kokkos
+#        key: ${{runner.os}}-kokkos
+#    - name: Install Kokkos
+#      if: steps.cache-kokkos.outputs.cache-hit != 'true'
+#      run: |
+#        sudo mkdir -p ~/dependencies/kokkos
+#        git clone --depth 1 --branch 4.2.00 https://github.com/kokkos/kokkos
+#        cd kokkos
+#        mkdir build
+#        cd build
+#        cmake .. \
+#          -DCMAKE_INSTALL_PREFIX:PATH=~/dependencies/kokkos \
+#          -DCMAKE_BUILD_TYPE=Debug \
+#          -DKokkos_ENABLE_DEBUG=ON \
+#          -DKokkos_ENABLE_DEBUG_BOUNDS_CHECK=ON
+#        sudo cmake --build . --target install -j 2
+#    - name: Cache install Kokkos-Kernels
+#      id: cache-kokkos-kernels
+#      uses: actions/cache@v3
+#      with:
+#        path: ~/dependencies/kokkos_kernels
+#        key: ${{runner.os}}-kokkos-kernels
+#    - name: Install Kokkos-Kernels
+#      if: steps.cache-kokkos-kernels.outputs.cache-hit != 'true'
+#      run: |
+#        sudo mkdir -p ~/dependencies/kokkos_kernels
+#        export Kokkos_DIR=~/dependencies/kokkos
+#          git clone https://github.com/kokkos/kokkos-kernels
+#        cd kokkos-kernels
+#        mkdir build
+#        cd build
+#        cmake .. \
+#          -DCMAKE_INSTALL_PREFIX:PATH=~/dependencies/kokkos_kernels \
+#          -DCMAKE_BUILD_TYPE=Debug
+#        sudo cmake --build . --target install -j 2
+#    - name: Clone
+#      uses: actions/checkout@v4
+#      with:
+#        submodules: true
+#    - name: Test OpenTurbine
+#      run: |
+#        export KokkosKernels_DIR=~/dependencies/kokkos_kernels
+#        mkdir build
+#        cd build
+#        cmake .. \
+#          -DOTURB_ENABLE_TESTS:BOOL=ON \
+#          -DOTURB_ENABLE_BASIC_SANITIZERS=ON \
+#          -DCMAKE_BUILD_TYPE=Debug \
+#          -DCMAKE_CXX_CPPCHECK="cppcheck;--enable=all;--force;--suppress=missingIncludeSystem"
+#        cmake --build . 
   Formatting:
     runs-on: ubuntu-latest
     steps:
     - name: Clone
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Check formatting
       uses: DoozyX/clang-format-lint-action@v0.16.2
       with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -131,11 +131,69 @@ jobs:
         cmake .. \
           -DOTURB_ENABLE_TESTS:BOOL=ON \
           -DOTURB_ENABLE_BASIC_SANITIZERS=ON \
-          -DCMAKE_BUILD_TYPE=Debug \
-          -DCMAKE_CXX_CLANG_TIDY="clang-tidy;-header-filter=.;-checks=*;-warnings-as-errors=*;"
+          -DCMAKE_BUILD_TYPE=Debug 
         cmake --build . -j 2
         ./openturbine -h
         ./openturbine_unit_tests
+  Clang-Tidy:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Install dependencies
+      run: sudo apt-get install libgtest-dev 
+    - name: Cache install Kokkos
+      id: cache-kokkos
+      uses: actions/cache@v3
+      with:
+        path: ~/dependencies/kokkos
+        key: ${{runner.os}}-kokkos
+    - name: Install Kokkos
+      if: steps.cache-kokkos.outputs.cache-hit != 'true'
+      run: |
+        sudo mkdir -p ~/dependencies/kokkos
+        git clone --depth 1 --branch 4.2.00 https://github.com/kokkos/kokkos
+        cd kokkos
+        mkdir build
+        cd build
+        cmake .. \
+          -DCMAKE_INSTALL_PREFIX:PATH=~/dependencies/kokkos \
+          -DCMAKE_BUILD_TYPE=Debug \
+          -DKokkos_ENABLE_DEBUG=ON \
+          -DKokkos_ENABLE_DEBUG_BOUNDS_CHECK=ON
+        sudo cmake --build . --target install -j 2
+    - name: Cache install Kokkos-Kernels
+      id: cache-kokkos-kernels
+      uses: actions/cache@v3
+      with:
+        path: ~/dependencies/kokkos_kernels
+        key: ${{runner.os}}-kokkos-kernels
+    - name: Install Kokkos-Kernels
+      if: steps.cache-kokkos-kernels.outputs.cache-hit != 'true'
+      run: |
+        sudo mkdir -p ~/dependencies/kokkos_kernels
+        export Kokkos_DIR=~/dependencies/kokkos
+          git clone https://github.com/kokkos/kokkos-kernels
+        cd kokkos-kernels
+        mkdir build
+        cd build
+        cmake .. \
+          -DCMAKE_INSTALL_PREFIX:PATH=~/dependencies/kokkos_kernels \
+          -DCMAKE_BUILD_TYPE=Debug
+        sudo cmake --build . --target install -j 2
+    - name: Clone
+      uses: actions/checkout@v3
+      with:
+        submodules: true
+    - name: Test OpenTurbine
+      run: |
+        export KokkosKernels_DIR=~/dependencies/kokkos_kernels
+        mkdir build
+        cd build
+        cmake .. \
+          -DOTURB_ENABLE_TESTS:BOOL=ON \
+          -DOTURB_ENABLE_BASIC_SANITIZERS=ON \
+          -DCMAKE_BUILD_TYPE=Debug \
+          -DCMAKE_CXX_CLANG_TIDY="clang-tidy;-header-filter=.;-checks=*;-warnings-as-errors=*;"
+        cmake --build . 
   Formatting:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,7 +3,7 @@ name: OpenTurbine-CI
 on: push
 
 jobs:
-  Release:
+  Correctness:
     runs-on: ${{matrix.os}}
     strategy:
       fail-fast: false

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -101,7 +101,7 @@ jobs:
           -DOTURB_ENABLE_TESTS:BOOL=ON \
           -DOTURB_ENABLE_BASIC_SANITIZERS=ON \
           -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} \
-          -DCMAKE_CXX_CPPCHECK="cppcheck;--enable=all;--force;--suppress=missingIncludeSystem"
+          -DCMAKE_CXX_CPPCHECK="cppcheck;--enable=all;--force;--suppress=missingIncludeSystem;--library=googletest;--clang"
         cmake --build . -j 1
     - name: Run Clang-Tidy
       if: matrix.os == 'ubuntu-latest' && matrix.compiler == 'llvm'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -75,6 +75,65 @@ jobs:
         cmake --build . -j 2
         ./openturbine -h
         ./openturbine_unit_tests
+  Debug-GCC:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Install dependencies
+      run: sudo apt-get install libgtest-dev 
+    - name: Cache install Kokkos
+      id: cache-kokkos
+      uses: actions/cache@v3
+      with:
+        path: ~/dependencies/kokkos
+        key: ${{runner.os}}-kokkos
+    - name: Install Kokkos
+      if: steps.cache-kokkos.outputs.cache-hit != 'true'
+      run: |
+        sudo mkdir -p ~/dependencies/kokkos
+        git clone --depth 1 --branch 4.2.00 https://github.com/kokkos/kokkos
+        cd kokkos
+        mkdir build
+        cd build
+        cmake .. \
+          -DCMAKE_INSTALL_PREFIX:PATH=~/dependencies/kokkos \
+          -DCMAKE_BUILD_TYPE=Debug \
+          -DKokkos_ENABLE_DEBUG=ON \
+          -DKokkos_ENABLE_DEBUG_BOUNDS_CHECK=ON
+        sudo cmake --build . --target install -j 2
+    - name: Cache install Kokkos-Kernels
+      id: cache-kokkos-kernels
+      uses: actions/cache@v3
+      with:
+        path: ~/dependencies/kokkos_kernels
+        key: ${{runner.os}}-kokkos-kernels
+    - name: Install Kokkos-Kernels
+      if: steps.cache-kokkos-kernels.outputs.cache-hit != 'true'
+      run: |
+        sudo mkdir -p ~/dependencies/kokkos_kernels
+        export Kokkos_DIR=~/dependencies/kokkos
+          git clone https://github.com/kokkos/kokkos-kernels
+        cd kokkos-kernels
+        mkdir build
+        cd build
+        cmake .. \
+          -DCMAKE_INSTALL_PREFIX:PATH=~/dependencies/kokkos_kernels \
+          -DCMAKE_BUILD_TYPE=Debug
+        sudo cmake --build . --target install -j 2
+    - name: Clone
+      uses: actions/checkout@v3
+      with:
+        submodules: true
+    - name: Test OpenTurbine
+      run: |
+        export KokkosKernels_DIR=~/dependencies/kokkos_kernels
+        mkdir build
+        cd build
+        cmake .. \
+          -DOTURB_ENABLE_TESTS:BOOL=ON \
+          -DCMAKE_BUILD_TYPE=Debug
+        cmake --build . -j 2
+        ./openturbine -h
+        ./openturbine_unit_tests
   Formatting:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,6 +11,9 @@ jobs:
         os: [ubuntu-latest, macos-latest]
         compiler: [gcc, llvm]
         build_type: [Release, Debug]
+        exclude: 
+          - os: macos-latest
+            compiler: gcc
         include:
           - os: ubuntu-latest
             install_deps: sudo apt-get install libgtest-dev

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -75,7 +75,7 @@ jobs:
         cmake --build . -j 2
         ./openturbine -h
         ./openturbine_unit_tests
-  Debug-GCC:
+  Debug:
     runs-on: ubuntu-latest
     steps:
     - name: Install dependencies
@@ -130,6 +130,7 @@ jobs:
         cd build
         cmake .. \
           -DOTURB_ENABLE_TESTS:BOOL=ON \
+          -DOTURB_ENABLE_BASIC_SANITIZERS=ON \
           -DCMAKE_BUILD_TYPE=Debug
         cmake --build . -j 2
         ./openturbine -h

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,20 +3,7 @@ name: OpenTurbine-CI
 on: push
 
 jobs:
-  Formatting:
-    runs-on: ubuntu-latest
-    steps:
-    - name: Clone
-      uses: actions/checkout@v3
-    - name: Check formatting
-      uses: DoozyX/clang-format-lint-action@v0.16.2
-      with:
-        source: './src ./tests/unit_tests'
-        exclude: '.'
-        extensions: 'H,h,cpp'
-        clangFormatVersion: 16
   CPU:
-    needs: Formatting
     runs-on: ${{matrix.os}}
     strategy:
       matrix:
@@ -90,3 +77,15 @@ jobs:
         cmake --build . -j 2
         ./openturbine -h
         ./openturbine_unit_tests
+  Formatting:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Clone
+      uses: actions/checkout@v3
+    - name: Check formatting
+      uses: DoozyX/clang-format-lint-action@v0.16.2
+      with:
+        source: './src ./tests/unit_tests'
+        exclude: '.'
+        extensions: 'H,h,cpp'
+        clangFormatVersion: 16

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -192,7 +192,7 @@ jobs:
           -DOTURB_ENABLE_TESTS:BOOL=ON \
           -DOTURB_ENABLE_BASIC_SANITIZERS=ON \
           -DCMAKE_BUILD_TYPE=Debug \
-          -DCMAKE_CXX_CLANG_TIDY="clang-tidy;-header-filter=.;-checks=*;-warnings-as-errors=*;"
+          -DCMAKE_CXX_CLANG_TIDY="clang-tidy"
         cmake --build . 
   Formatting:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -251,7 +251,7 @@ jobs:
           -DOTURB_ENABLE_TESTS:BOOL=ON \
           -DOTURB_ENABLE_BASIC_SANITIZERS=ON \
           -DCMAKE_BUILD_TYPE=Debug \
-          -DCMAKE_CXX_CPPCHECK="cppcheck;--enable=all;--force;"
+          -DCMAKE_CXX_CPPCHECK="cppcheck;--enable=all;--force;--suppress=missingIncludeSystem"
         cmake --build . 
   Formatting:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -131,7 +131,8 @@ jobs:
         cmake .. \
           -DOTURB_ENABLE_TESTS:BOOL=ON \
           -DOTURB_ENABLE_BASIC_SANITIZERS=ON \
-          -DCMAKE_BUILD_TYPE=Debug
+          -DCMAKE_BUILD_TYPE=Debug \
+          -DCMAKE_CXX_CLANG_TIDY="clang-tidy;-header-filter=.;-checks=*;-warnings-as-errors=*;"
         cmake --build . -j 2
         ./openturbine -h
         ./openturbine_unit_tests

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,16 +3,16 @@ name: OpenTurbine-CI
 on: push
 
 jobs:
-  CPU:
+  Release:
     runs-on: ${{matrix.os}}
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
         include:
           - os: ubuntu-latest
-            install_deps: sudo apt-get install liblapack-dev liblapacke-dev libgtest-dev
+            install_deps: sudo apt-get install libgtest-dev
           - os: macos-latest
-            install_deps: brew install gfortran lapack googletest
+            install_deps: brew install googletest
     steps:
     - name: Install dependencies
       run: |
@@ -33,10 +33,7 @@ jobs:
         cd build
         cmake .. \
           -DCMAKE_INSTALL_PREFIX:PATH=~/dependencies/kokkos \
-          -DCMAKE_BUILD_TYPE=Debug \
-          -DKokkos_ENABLE_COMPILER_WARNINGS=ON \
-          -DKokkos_ENABLE_DEBUG=ON \
-          -DKokkos_ENABLE_DEBUG_BOUNDS_CHECK=ON 
+          -DCMAKE_BUILD_TYPE=Release 
         sudo cmake --build . --target install -j 2
     - name: Cache install Kokkos-Kernels
       id: cache-kokkos-kernels
@@ -61,19 +58,20 @@ jobs:
         cd build
         cmake .. \
           -DCMAKE_INSTALL_PREFIX:PATH=~/dependencies/kokkos_kernels \
-          -DCMAKE_BUILD_TYPE=Debug \
-          -DKokkosKernels_ENABLE_TPL_BLAS=ON 
+          -DCMAKE_BUILD_TYPE=Release
         sudo cmake --build . --target install -j 2
     - name: Clone
       uses: actions/checkout@v3
       with:
         submodules: true
-    - name: Test
+    - name: Test OpenTurbine
       run: |
         export KokkosKernels_DIR=~/dependencies/kokkos_kernels
         mkdir build
         cd build
-        cmake .. -DOTURB_ENABLE_TESTS:BOOL=ON
+        cmake .. \
+          -DOTURB_ENABLE_TESTS:BOOL=ON \
+          -DCMAKE_BUILD_TYPE=Release
         cmake --build . -j 2
         ./openturbine -h
         ./openturbine_unit_tests

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,8 +11,6 @@ jobs:
         os: [ubuntu-latest, macos-latest]
         compiler: [gcc, llvm]
         build_type: [Release, Debug]
-        generator: 
-          - "Ninja Multi-Config"
         include:
           - os: ubuntu-latest
             install_deps: sudo apt-get install libgtest-dev
@@ -46,7 +44,6 @@ jobs:
         mkdir build
         cd build
         cmake .. \
-          -G ${{ matrix.generator }} \
           -DCMAKE_INSTALL_PREFIX:PATH=~/dependencies/kokkos \
           -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} \
           -DKokkos_ENABLE_DEBUG=${{ matrix.build_type == 'Debug' }} \
@@ -73,7 +70,6 @@ jobs:
         mkdir build
         cd build
         cmake .. \
-          -G ${{ matrix.generator }} \
           -DCMAKE_INSTALL_PREFIX:PATH=~/dependencies/kokkos_kernels \
           -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
         sudo cmake --build . --target install -j 2
@@ -87,190 +83,35 @@ jobs:
         mkdir build
         cd build
         cmake .. \
-          -G ${{ matrix.generator }} \
           -DOTURB_ENABLE_TESTS:BOOL=ON \
           -DOTURB_ENABLE_BASIC_SANITIZERS=ON \
-          -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
+          -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} 
         cmake --build . -j 2
         ctest -C ${{ matrix.build_type }}
-#  Debug:
-#    runs-on: ubuntu-latest
-#    steps:
-#    - name: Install dependencies
-#      run: sudo apt-get install libgtest-dev 
-#    - name: Cache install Kokkos
-#      id: cache-kokkos
-#      uses: actions/cache@v3
-#      with:
-#        path: ~/dependencies/kokkos
-#        key: ${{runner.os}}-kokkos
-#    - name: Install Kokkos
-#      if: steps.cache-kokkos.outputs.cache-hit != 'true'
-#      run: |
-#        sudo mkdir -p ~/dependencies/kokkos
-#        git clone --depth 1 --branch 4.2.00 https://github.com/kokkos/kokkos
-#        cd kokkos
-#        mkdir build
-#        cd build
-#        cmake .. \
-#          -DCMAKE_INSTALL_PREFIX:PATH=~/dependencies/kokkos \
-#          -DCMAKE_BUILD_TYPE=Debug \
-#          -DKokkos_ENABLE_DEBUG=ON \
-#          -DKokkos_ENABLE_DEBUG_BOUNDS_CHECK=ON
-#        sudo cmake --build . --target install -j 2
-#    - name: Cache install Kokkos-Kernels
-#      id: cache-kokkos-kernels
-#      uses: actions/cache@v3
-#      with:
-#        path: ~/dependencies/kokkos_kernels
-#        key: ${{runner.os}}-kokkos-kernels
-#    - name: Install Kokkos-Kernels
-#      if: steps.cache-kokkos-kernels.outputs.cache-hit != 'true'
-#      run: |
-#        sudo mkdir -p ~/dependencies/kokkos_kernels
-#        export Kokkos_DIR=~/dependencies/kokkos
-#          git clone https://github.com/kokkos/kokkos-kernels
-#        cd kokkos-kernels
-#        mkdir build
-#        cd build
-#        cmake .. \
-#          -DCMAKE_INSTALL_PREFIX:PATH=~/dependencies/kokkos_kernels \
-#          -DCMAKE_BUILD_TYPE=Debug
-#        sudo cmake --build . --target install -j 2
-#    - name: Clone
-#      uses: actions/checkout@v4
-#      with:
-#        submodules: true
-#    - name: Test OpenTurbine
-#      run: |
-#        export KokkosKernels_DIR=~/dependencies/kokkos_kernels
-#        mkdir build
-#        cd build
-#        cmake .. \
-#          -DOTURB_ENABLE_TESTS:BOOL=ON \
-#          -DOTURB_ENABLE_BASIC_SANITIZERS=ON \
-#          -DCMAKE_BUILD_TYPE=Debug 
-#        cmake --build . -j 2
-#        ./openturbine -h
-#        ./openturbine_unit_tests
-#  Clang-Tidy:
-#    runs-on: ubuntu-latest
-#    steps:
-#    - name: Install dependencies
-#      run: sudo apt-get install libgtest-dev 
-#    - name: Cache install Kokkos
-#      id: cache-kokkos
-#      uses: actions/cache@v3
-#      with:
-#        path: ~/dependencies/kokkos
-#        key: ${{runner.os}}-kokkos
-#    - name: Install Kokkos
-#      if: steps.cache-kokkos.outputs.cache-hit != 'true'
-#      run: |
-#        sudo mkdir -p ~/dependencies/kokkos
-#        git clone --depth 1 --branch 4.2.00 https://github.com/kokkos/kokkos
-#        cd kokkos
-#        mkdir build
-#        cd build
-#        cmake .. \
-#          -DCMAKE_INSTALL_PREFIX:PATH=~/dependencies/kokkos \
-#          -DCMAKE_BUILD_TYPE=Debug \
-#          -DKokkos_ENABLE_DEBUG=ON \
-#          -DKokkos_ENABLE_DEBUG_BOUNDS_CHECK=ON
-#        sudo cmake --build . --target install -j 2
-#    - name: Cache install Kokkos-Kernels
-#      id: cache-kokkos-kernels
-#      uses: actions/cache@v3
-#      with:
-#        path: ~/dependencies/kokkos_kernels
-#        key: ${{runner.os}}-kokkos-kernels
-#    - name: Install Kokkos-Kernels
-#      if: steps.cache-kokkos-kernels.outputs.cache-hit != 'true'
-#      run: |
-#        sudo mkdir -p ~/dependencies/kokkos_kernels
-#        export Kokkos_DIR=~/dependencies/kokkos
-#          git clone https://github.com/kokkos/kokkos-kernels
-#        cd kokkos-kernels
-#        mkdir build
-#        cd build
-#        cmake .. \
-#          -DCMAKE_INSTALL_PREFIX:PATH=~/dependencies/kokkos_kernels \
-#          -DCMAKE_BUILD_TYPE=Debug
-#        sudo cmake --build . --target install -j 2
-#    - name: Clone
-#      uses: actions/checkout@v4
-#      with:
-#        submodules: true
-#    - name: Test OpenTurbine
-#      run: |
-#        export KokkosKernels_DIR=~/dependencies/kokkos_kernels
-#        mkdir build
-#        cd build
-#        cmake .. \
-#          -DOTURB_ENABLE_TESTS:BOOL=ON \
-#          -DOTURB_ENABLE_BASIC_SANITIZERS=ON \
-#          -DCMAKE_BUILD_TYPE=Debug \
-#          -DCMAKE_CXX_CLANG_TIDY="clang-tidy"
-#        cmake --build . 
-#  CppCheck:
-#    runs-on: ubuntu-latest
-#    steps:
-#    - name: Install dependencies
-#      run: sudo apt-get install libgtest-dev cppcheck 
-#    - name: Cache install Kokkos
-#      id: cache-kokkos
-#      uses: actions/cache@v3
-#      with:
-#        path: ~/dependencies/kokkos
-#        key: ${{runner.os}}-kokkos
-#    - name: Install Kokkos
-#      if: steps.cache-kokkos.outputs.cache-hit != 'true'
-#      run: |
-#        sudo mkdir -p ~/dependencies/kokkos
-#        git clone --depth 1 --branch 4.2.00 https://github.com/kokkos/kokkos
-#        cd kokkos
-#        mkdir build
-#        cd build
-#        cmake .. \
-#          -DCMAKE_INSTALL_PREFIX:PATH=~/dependencies/kokkos \
-#          -DCMAKE_BUILD_TYPE=Debug \
-#          -DKokkos_ENABLE_DEBUG=ON \
-#          -DKokkos_ENABLE_DEBUG_BOUNDS_CHECK=ON
-#        sudo cmake --build . --target install -j 2
-#    - name: Cache install Kokkos-Kernels
-#      id: cache-kokkos-kernels
-#      uses: actions/cache@v3
-#      with:
-#        path: ~/dependencies/kokkos_kernels
-#        key: ${{runner.os}}-kokkos-kernels
-#    - name: Install Kokkos-Kernels
-#      if: steps.cache-kokkos-kernels.outputs.cache-hit != 'true'
-#      run: |
-#        sudo mkdir -p ~/dependencies/kokkos_kernels
-#        export Kokkos_DIR=~/dependencies/kokkos
-#          git clone https://github.com/kokkos/kokkos-kernels
-#        cd kokkos-kernels
-#        mkdir build
-#        cd build
-#        cmake .. \
-#          -DCMAKE_INSTALL_PREFIX:PATH=~/dependencies/kokkos_kernels \
-#          -DCMAKE_BUILD_TYPE=Debug
-#        sudo cmake --build . --target install -j 2
-#    - name: Clone
-#      uses: actions/checkout@v4
-#      with:
-#        submodules: true
-#    - name: Test OpenTurbine
-#      run: |
-#        export KokkosKernels_DIR=~/dependencies/kokkos_kernels
-#        mkdir build
-#        cd build
-#        cmake .. \
-#          -DOTURB_ENABLE_TESTS:BOOL=ON \
-#          -DOTURB_ENABLE_BASIC_SANITIZERS=ON \
-#          -DCMAKE_BUILD_TYPE=Debug \
-#          -DCMAKE_CXX_CPPCHECK="cppcheck;--enable=all;--force;--suppress=missingIncludeSystem"
-#        cmake --build . 
+    - name: Run CppCheck
+      if: matrix.os == 'ubuntu-latest' && matrix.compiler == 'llvm'
+      run: |
+        export KokkosKernels_DIR=~/dependencies/kokkos_kernels
+        mkdir build-cppcheck
+        cd build-cppcheck
+        cmake .. \
+          -DOTURB_ENABLE_TESTS:BOOL=ON \
+          -DOTURB_ENABLE_BASIC_SANITIZERS=ON \
+          -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} \
+          -DCMAKE_CXX_CPPCHECK="cppcheck;--enable=all;--force;--suppress=missingIncludeSystem"
+        cmake --build . -j 1
+    - name: Run Clang-Tidy
+      if: matrix.os == 'ubuntu-latest' && matrix.compiler == 'llvm'
+      run: |
+        export KokkosKernels_DIR=~/dependencies/kokkos_kernels
+        mkdir build-clangtidy
+        cd build-clangtidy
+        cmake .. \
+          -DOTURB_ENABLE_TESTS:BOOL=ON \
+          -DOTURB_ENABLE_BASIC_SANITIZERS=ON \
+          -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} \
+          -DCMAKE_CXX_CLANG_TIDY="clang-tidy"
+        cmake --build . -j 1
   Formatting:
     runs-on: ubuntu-latest
     steps:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,13 @@ include(openturbine-utils)
 ########################## OPTIONS #####################################
 
 # General options for the project
-option(OTURB_ENABLE_ALL_WARNINGS "Show most warnings for most compilers" ON)
+add_compile_options(-Wall -Wextra -Wshadow -Wnon-virtual-dtor -Wpedantic -Werror)
+option(OTURB_ENABLE_BASIC_SANITIZERS "Compile with addrss and undefined behavior sanitizers" OFF)
+if(OTURB_ENABLE_BASIC_SANITIZERS)
+  add_compile_options(-fsanitize=address,undefined)
+  add_link_options(-fsanitize=address,undefined)
+endif()
+
 # option(OTURB_ENABLE_CLANG_TIDY "Compile with clang-tidy static analysis" OFF)
 # option(OTURB_ENABLE_CPPCHECK "Enable cppcheck static analysis target" OFF)
 # option(OTURB_ENABLE_FCOMPARE "Enable building fcompare when not testing" OFF)
@@ -52,10 +58,7 @@ elseif(BUILD_TYPE_UPPER STREQUAL "DEBUG" OR BUILD_TYPE_UPPER STREQUAL "RELWITHDE
 endif()
 
 # Enabling tests overrides the executable options
-# option(OTURB_ENABLE_UNIT_TESTS "Enable unit testing" ON)
 option(OTURB_ENABLE_TESTS "Enable testing suite" OFF)
-# option(OTURB_SAVE_GOLDS "Provide a directory in which to save golds during testing" OFF)
-# option(OTURB_ENABLE_FPE_TRAP_FOR_TESTS "Enable FPE trapping in tests" ON)
 
 # Options for the executable
 option(OTURB_ENABLE_OPENMP "Enable OpenMP" OFF)
@@ -122,8 +125,6 @@ if(CLANG_TIDY_EXE)
         PROPERTIES CXX_CLANG_TIDY ${CLANG_TIDY_EXE}
     )
 endif()
-
-include(set_compile_flags)
 
 # Build OpenTurbine
 add_subdirectory(src)

--- a/src/gebt_poc/gen_alpha_2D.cpp
+++ b/src/gebt_poc/gen_alpha_2D.cpp
@@ -176,7 +176,7 @@ std::tuple<State, Kokkos::View<double*>> GeneralizedAlphaTimeIntegrator::AlphaSt
         // Check for convergence based on energy criterion for dynamic problems
         if (this->problem_type_ == ProblemType::kDynamic &&
             time_stepper_.GetNumberOfIterations() > 0) {
-            if (is_converged_ = IsConverged(residuals, soln_increments)) {
+            if ((is_converged_ = IsConverged(residuals, soln_increments))) {
                 break;
             }
         }
@@ -186,7 +186,7 @@ std::tuple<State, Kokkos::View<double*>> GeneralizedAlphaTimeIntegrator::AlphaSt
             this->time_stepper_, residuals
         );
 
-        if (is_converged_ = IsConverged(residuals)) {
+        if ((is_converged_ = IsConverged(residuals))) {
             break;
         }
 

--- a/src/gebt_poc/solver.cpp
+++ b/src/gebt_poc/solver.cpp
@@ -254,9 +254,10 @@ void ElementalStaticForcesResidual(
                 kNumberOfLieGroupComponents,
                 KOKKOS_LAMBDA(const size_t component) {
                     residual(node_count * kNumberOfLieGroupComponents + component) +=
-                        q_weight *
-                        (shape_function_derivative_vector(node_count) * elastic_forces_fc(component) +
-                         jacobian * shape_function_vector(node_count) * elastic_forces_fd(component));
+                        q_weight * (shape_function_derivative_vector(node_count) *
+                                        elastic_forces_fc(component) +
+                                    jacobian * shape_function_vector(node_count) *
+                                        elastic_forces_fd(component));
                 }
             );
         }
@@ -424,7 +425,8 @@ void ElementalInertialForcesResidual(
                 kNumberOfLieGroupComponents,
                 KOKKOS_LAMBDA(const size_t component) {
                     residual(node_count * kNumberOfLieGroupComponents + component) +=
-                        q_weight * (jacobian * shape_function_vector(node_count) * inertial_f(component));
+                        q_weight *
+                        (jacobian * shape_function_vector(node_count) * inertial_f(component));
                 }
             );
         }

--- a/src/gebt_poc/solver.cpp
+++ b/src/gebt_poc/solver.cpp
@@ -252,11 +252,11 @@ void ElementalStaticForcesResidual(
             const auto q_weight = quadrature.GetQuadratureWeights()[j];
             Kokkos::parallel_for(
                 kNumberOfLieGroupComponents,
-                KOKKOS_LAMBDA(const size_t i) {
-                    residual(node_count * kNumberOfLieGroupComponents + i) +=
+                KOKKOS_LAMBDA(const size_t component) {
+                    residual(node_count * kNumberOfLieGroupComponents + component) +=
                         q_weight *
-                        (shape_function_derivative_vector(node_count) * elastic_forces_fc(i) +
-                         jacobian * shape_function_vector(node_count) * elastic_forces_fd(i));
+                        (shape_function_derivative_vector(node_count) * elastic_forces_fc(component) +
+                         jacobian * shape_function_vector(node_count) * elastic_forces_fd(component));
                 }
             );
         }
@@ -422,9 +422,9 @@ void ElementalInertialForcesResidual(
             const auto q_weight = quadrature.GetQuadratureWeights()[j];
             Kokkos::parallel_for(
                 kNumberOfLieGroupComponents,
-                KOKKOS_LAMBDA(const size_t i) {
-                    residual(node_count * kNumberOfLieGroupComponents + i) +=
-                        q_weight * (jacobian * shape_function_vector(node_count) * inertial_f(i));
+                KOKKOS_LAMBDA(const size_t component) {
+                    residual(node_count * kNumberOfLieGroupComponents + component) +=
+                        q_weight * (jacobian * shape_function_vector(node_count) * inertial_f(component));
                 }
             );
         }

--- a/tests/unit_tests/gebt_poc/test_johnson_static_beam.h
+++ b/tests/unit_tests/gebt_poc/test_johnson_static_beam.h
@@ -309,6 +309,7 @@ std::vector<std::vector<double>> expected_iteration = {
      0.,
      0.,
      0.,
+     0.,
      0.},
 
     // row 10
@@ -346,6 +347,7 @@ std::vector<std::vector<double>> expected_iteration = {
      0.,
      0.,
      0.,
+     0.,
      0.},
 
     // row 11
@@ -379,6 +381,7 @@ std::vector<std::vector<double>> expected_iteration = {
      -598.8568878284098,
      3011.6568357098067,
      12.613171084084712,
+     0.,
      0.,
      0.,
      0.,
@@ -687,7 +690,6 @@ std::vector<std::vector<double>> expected_iteration = {
      0., -69305.0204561978,
      0., 0.,
      0., 59835.5860401419,
-     0., 0.,
      0., 0.,
      0., 0.,
      0., 0.},


### PR DESCRIPTION
Improves the current CI workflow to hopefully improve ergonomics going forward.

First, the formatting checks no longer end CI if they fail, providing feedback on unit test correctness even if you forgot to run clang-format before pushing.  

Second, the correctness checks have been broken into two sections: release and debug.  release is run on both Ubuntu and MacOSX.  Debug is run on Ubuntu and includes address sanitizer and undefined behavior sanitizer to improve error detection.  The warning level has also been significantly increased for OpenTurbine with warnings now taken as errors.  

Third, checks using clang-tidy and cppcheck have been added to help identify areas for improving our usage of C++.  They pass now, but throw many warnings.  We should work to have a fully clean build (no warnings) from both of those tools.  