### PR TITLE
Quadrature to views

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ include(openturbine-utils)
 ########################## OPTIONS #####################################
 
 # General options for the project
-add_compile_options(-Wall -Wextra -Wshadow -Wnon-virtual-dtor -Wpedantic -Werror)
+add_compile_options("$<$<COMPILE_LANGUAGE:CXX>:-Werror;-Wall;-Wextra;-Wshadow;-Wnon-virtual-dtor;-Wpedantic>")
 option(OTURB_ENABLE_BASIC_SANITIZERS "Compile with addrss and undefined behavior sanitizers" OFF)
 if(OTURB_ENABLE_BASIC_SANITIZERS)
   add_compile_options(-fsanitize=address,undefined)

--- a/src/gebt_poc/ElementalInertialForcesResidual.hpp
+++ b/src/gebt_poc/ElementalInertialForcesResidual.hpp
@@ -3,11 +3,11 @@
 #include <KokkosBlas.hpp>
 #include <Kokkos_Core.hpp>
 
-#include "src/gebt_poc/element.h"
 #include "src/gebt_poc/InterpolateNodalValueDerivatives.hpp"
 #include "src/gebt_poc/InterpolateNodalValues.hpp"
 #include "src/gebt_poc/NodalInertialForces.hpp"
 #include "src/gebt_poc/SectionalMassMatrix.hpp"
+#include "src/gebt_poc/element.h"
 #include "src/gebt_poc/interpolation.h"
 #include "src/gebt_poc/quadrature.h"
 #include "src/gebt_poc/section.h"
@@ -19,7 +19,7 @@ namespace openturbine::gebt_poc {
 inline void ElementalInertialForcesResidual(
     LieGroupFieldView::const_type position_vectors, LieGroupFieldView::const_type gen_coords,
     LieAlgebraFieldView::const_type velocity, LieAlgebraFieldView::const_type acceleration,
-    View2D_6x6::const_type mass_matrix, const Quadrature& quadrature, View1D residual
+    View2D_6x6::const_type mass_matrix, Quadrature quadrature, View1D residual
 ) {
     const auto n_nodes = gen_coords.extent(0);
     const auto order = n_nodes - 1;
@@ -38,23 +38,79 @@ inline void ElementalInertialForcesResidual(
     auto sectional_mass_matrix = View2D_6x6("sectional_mass_matrix");
     auto inertial_f = View1D_LieAlgebra("inertial_f");
 
+    auto policy = Kokkos::TeamPolicy<>(1, Kokkos::AUTO(), Kokkos::AUTO());
+    using scratch_space = Kokkos::DefaultExecutionSpace::scratch_memory_space;
+    using unmanaged_memory = Kokkos::MemoryTraits<Kokkos::Unmanaged>;
+    using ScratchView1D = Kokkos::View<double*, scratch_space, unmanaged_memory>;
+    using ScratchView2D = Kokkos::View<double**, scratch_space, unmanaged_memory>;
+    const auto team_scratch_size =
+        5 * ScratchView2D::shmem_size(n_quad_pts, n_nodes) + ScratchView1D::shmem_size(n_nodes);
+    const auto thread_scratch_size = ScratchView1D::shmem_size(n_nodes);
+    auto shape_functions = View2D("shape functions", n_quad_pts, n_nodes);
+    auto shape_function_derivatives = View2D("shape function derivatives", n_quad_pts, n_nodes);
+    policy.set_scratch_size(
+        0, Kokkos::PerTeam(team_scratch_size), Kokkos::PerThread(thread_scratch_size)
+    );
+    Kokkos::parallel_for(
+        policy,
+        KOKKOS_LAMBDA(const Kokkos::TeamPolicy<>::member_type& member) {
+            auto shapes = ComputeLagrangePolynomials(member, order, quadrature.points);
+            auto derivatives =
+                ComputeLagrangePolynomialDerivatives(member, order, quadrature.points);
+            member.team_barrier();
+            Kokkos::parallel_for(
+                Kokkos::ThreadVectorMDRange(member, shapes.extent(0), shapes.extent(1)),
+                [&](std::size_t i, std::size_t j) {
+                    shape_functions(i, j) = shapes(i, j);
+                    shape_function_derivatives(i, j) = derivatives(i, j);
+                }
+            );
+        }
+    );
     Kokkos::deep_copy(residual, 0.);
     for (size_t i = 0; i < n_nodes; ++i) {
         const auto node_count = i;
         for (size_t j = 0; j < n_quad_pts; ++j) {
             // Calculate required interpolated values at the quadrature point
-            const auto q_pt = quadrature.points(j);
-            auto shape_function = LagrangePolynomial(order, q_pt);
-            auto shape_function_derivative = LagrangePolynomialDerivative(order, q_pt);
-            auto shape_function_vector = gen_alpha_solver::create_vector(shape_function);
-            auto shape_function_derivative_vector =
-                gen_alpha_solver::create_vector(shape_function_derivative);
+            auto shape_function_vector = View1D("sfv", n_nodes);
+            auto shape_function_derivative_vector = View1D("sfv", n_nodes);
+            Kokkos::parallel_for(
+                n_nodes,
+                KOKKOS_LAMBDA(std::size_t k) {
+                    shape_function_vector(k) = shape_functions(j, k);
+                    shape_function_derivative_vector(k) = shape_function_derivatives(j, k);
+                }
+            );
 
             auto jacobian = CalculateJacobian(nodes, shape_function_derivative_vector);
-            InterpolateNodalValues(gen_coords, shape_function, gen_coords_qp);
-            InterpolateNodalValues(position_vectors, shape_function, position_vector_qp);
-            InterpolateNodalValues(velocity, shape_function, velocity_qp);
-            InterpolateNodalValues(acceleration, shape_function, acceleration_qp);
+            Kokkos::parallel_for(
+                policy,
+                KOKKOS_LAMBDA(const Kokkos::TeamPolicy<>::member_type& member) {
+                    auto gen_coords_interp =
+                        InterpolateNodalValues(member, gen_coords, shape_function_vector);
+                    auto position_interp =
+                        InterpolateNodalValues(member, position_vectors, shape_function_vector);
+                    auto velocity_interp =
+                        InterpolateNodalValues(member, velocity, shape_function_vector);
+                    auto acceleration_interp =
+                        InterpolateNodalValues(member, acceleration, shape_function_vector);
+                    member.team_barrier();
+                    Kokkos::parallel_for(
+                        Kokkos::ThreadVectorRange(member, LieGroupComponents),
+                        [&](std::size_t component) {
+                            gen_coords_qp(component) = gen_coords_interp(component);
+                            position_vector_qp(component) = position_interp(component);
+                        }
+                    );
+                    Kokkos::parallel_for(
+                        Kokkos::ThreadVectorRange(member, LieAlgebraComponents),
+                        [&](std::size_t component) {
+                            velocity_qp(component) = velocity_interp(component);
+                            acceleration_qp(component) = acceleration_interp(component);
+                        }
+                    );
+                }
+            );
 
             // Calculate the sectional mass matrix in inertial basis
             auto rotation_0 = gen_alpha_solver::EulerParameterToRotationMatrix(

--- a/src/gebt_poc/ElementalInertialMatrices.hpp
+++ b/src/gebt_poc/ElementalInertialMatrices.hpp
@@ -3,12 +3,12 @@
 #include <KokkosBlas.hpp>
 #include <Kokkos_Core.hpp>
 
-#include "src/gebt_poc/element.h"
 #include "src/gebt_poc/InterpolateNodalValueDerivatives.hpp"
 #include "src/gebt_poc/InterpolateNodalValues.hpp"
 #include "src/gebt_poc/NodalDynamicStiffnessMatrix.hpp"
 #include "src/gebt_poc/NodalGyroscopicMatrix.hpp"
 #include "src/gebt_poc/SectionalMassMatrix.hpp"
+#include "src/gebt_poc/element.h"
 #include "src/gebt_poc/interpolation.h"
 #include "src/gebt_poc/quadrature.h"
 #include "src/gebt_poc/section.h"
@@ -20,7 +20,7 @@ namespace openturbine::gebt_poc {
 inline void ElementalInertialMatrices(
     LieGroupFieldView::const_type position_vectors, LieGroupFieldView::const_type gen_coords,
     LieAlgebraFieldView::const_type velocity, LieAlgebraFieldView::const_type acceleration,
-    View2D_6x6::const_type mass_matrix, const Quadrature& quadrature, View2D element_mass_matrix,
+    View2D_6x6::const_type mass_matrix, Quadrature quadrature, View2D element_mass_matrix,
     View2D element_gyroscopic_matrix, View2D element_dynamic_stiffness_matrix
 ) {
     const auto n_nodes = gen_coords.extent(0);
@@ -41,28 +41,87 @@ inline void ElementalInertialMatrices(
     auto acceleration_qp = View1D_LieAlgebra("acceleration_qp");
     auto sectional_mass_matrix = View2D_6x6("sectional_mass_matrix");
 
+    auto policy = Kokkos::TeamPolicy<>(1, Kokkos::AUTO(), Kokkos::AUTO());
+    using scratch_space = Kokkos::DefaultExecutionSpace::scratch_memory_space;
+    using unmanaged_memory = Kokkos::MemoryTraits<Kokkos::Unmanaged>;
+    using ScratchView1D = Kokkos::View<double*, scratch_space, unmanaged_memory>;
+    using ScratchView2D = Kokkos::View<double**, scratch_space, unmanaged_memory>;
+    const auto team_scratch_size =
+        5 * ScratchView2D::shmem_size(n_quad_pts, n_nodes) + ScratchView1D::shmem_size(n_nodes);
+    const auto thread_scratch_size = ScratchView1D::shmem_size(n_nodes);
+    auto shape_functions = View2D("shape functions", n_quad_pts, n_nodes);
+    auto shape_function_derivatives = View2D("shape function derivatives", n_quad_pts, n_nodes);
+    policy.set_scratch_size(
+        0, Kokkos::PerTeam(team_scratch_size), Kokkos::PerThread(thread_scratch_size)
+    );
+    Kokkos::parallel_for(
+        policy,
+        KOKKOS_LAMBDA(const Kokkos::TeamPolicy<>::member_type& member) {
+            auto shapes = ComputeLagrangePolynomials(member, order, quadrature.points);
+            auto derivatives =
+                ComputeLagrangePolynomialDerivatives(member, order, quadrature.points);
+            member.team_barrier();
+            Kokkos::parallel_for(
+                Kokkos::ThreadVectorMDRange(member, shapes.extent(0), shapes.extent(1)),
+                [&](std::size_t i, std::size_t j) {
+                    shape_functions(i, j) = shapes(i, j);
+                    shape_function_derivatives(i, j) = derivatives(i, j);
+                }
+            );
+        }
+    );
+
     Kokkos::deep_copy(element_mass_matrix, 0.);
 
     for (size_t k = 0; k < n_quad_pts; ++k) {
         // Calculate required interpolated values at the quadrature point
-        const auto q_pt = quadrature.points(k);
-        auto shape_function = LagrangePolynomial(order, q_pt);
-        auto shape_function_derivative = LagrangePolynomialDerivative(order, q_pt);
-        auto shape_function_vector = gen_alpha_solver::create_vector(shape_function);
-        auto shape_function_derivative_vector =
-            gen_alpha_solver::create_vector(shape_function_derivative);
+        auto shape_function_vector = View1D("sfv", n_nodes);
+        auto shape_function_derivative_vector = View1D("sfv", n_nodes);
+        Kokkos::parallel_for(
+            n_nodes,
+            KOKKOS_LAMBDA(std::size_t l) {
+                shape_function_vector(l) = shape_functions(k, l);
+                shape_function_derivative_vector(l) = shape_function_derivatives(k, l);
+            }
+        );
 
         auto jacobian = CalculateJacobian(nodes, shape_function_derivative_vector);
-        InterpolateNodalValues(gen_coords, shape_function, gen_coords_qp);
-        InterpolateNodalValueDerivatives(
-            gen_coords, shape_function_derivative, jacobian, gen_coords_derivatives_qp
+        Kokkos::parallel_for(
+            policy,
+            KOKKOS_LAMBDA(const Kokkos::TeamPolicy<>::member_type& member) {
+                auto gen_coords_interp =
+                    InterpolateNodalValues(member, gen_coords, shape_function_vector);
+                auto gen_coord_deriv_interp = InterpolateNodalValueDerivatives(
+                    member, gen_coords, shape_function_derivative_vector, jacobian
+                );
+                auto position_interp =
+                    InterpolateNodalValues(member, position_vectors, shape_function_vector);
+                auto position_deriv_interp = InterpolateNodalValueDerivatives(
+                    member, position_vectors, shape_function_derivative_vector, jacobian
+                );
+                auto velocity_interp =
+                    InterpolateNodalValues(member, velocity, shape_function_vector);
+                auto acceleration_interp =
+                    InterpolateNodalValues(member, acceleration, shape_function_vector);
+                member.team_barrier();
+                Kokkos::parallel_for(
+                    Kokkos::ThreadVectorRange(member, LieGroupComponents),
+                    [&](std::size_t component) {
+                        gen_coords_qp(component) = gen_coords_interp(component);
+                        position_vector_qp(component) = position_interp(component);
+                        gen_coords_derivatives_qp(component) = gen_coord_deriv_interp(component);
+                        pos_vector_derivatives_qp(component) = position_deriv_interp(component);
+                    }
+                );
+                Kokkos::parallel_for(
+                    Kokkos::ThreadVectorRange(member, LieAlgebraComponents),
+                    [&](std::size_t component) {
+                        velocity_qp(component) = velocity_interp(component);
+                        acceleration_qp(component) = acceleration_interp(component);
+                    }
+                );
+            }
         );
-        InterpolateNodalValues(position_vectors, shape_function, position_vector_qp);
-        InterpolateNodalValueDerivatives(
-            position_vectors, shape_function_derivative, jacobian, pos_vector_derivatives_qp
-        );
-        InterpolateNodalValues(velocity, shape_function, velocity_qp);
-        InterpolateNodalValues(acceleration, shape_function, acceleration_qp);
 
         // Calculate the sectional mass matrix in inertial basis
         auto rotation_0 = gen_alpha_solver::EulerParameterToRotationMatrix(
@@ -83,29 +142,54 @@ inline void ElementalInertialMatrices(
             velocity_qp, acceleration_qp, sectional_mass_matrix, dynamic_stiffness_matrix
         );
 
-        const auto q_weight = quadrature.weights(k);
-        for (size_t i = 0; i < n_nodes; ++i) {
-            for (size_t j = 0; j < n_nodes; ++j) {
-                const auto pair6 = Kokkos::make_pair(0, 6);
-                const auto pair_i =
-                    Kokkos::make_pair(i * LieAlgebraComponents, (i + 1) * LieAlgebraComponents);
-                const auto pair_j =
-                    Kokkos::make_pair(j * LieAlgebraComponents, (j + 1) * LieAlgebraComponents);
-                const auto a = q_weight * shape_function[i] * shape_function[j] * jacobian;
-                KokkosBlas::axpy(
-                    a, Kokkos::subview(sectional_mass_matrix, pair6, pair6),
-                    Kokkos::subview(element_mass_matrix, pair_i, pair_j)
-                );
-                KokkosBlas::axpy(
-                    a, Kokkos::subview(gyroscopic_matrix, pair6, pair6),
-                    Kokkos::subview(element_gyroscopic_matrix, pair_i, pair_j)
-                );
-                KokkosBlas::axpy(
-                    a, Kokkos::subview(dynamic_stiffness_matrix, pair6, pair6),
-                    Kokkos::subview(element_dynamic_stiffness_matrix, pair_i, pair_j)
+        Kokkos::parallel_for(
+            policy,
+            KOKKOS_LAMBDA(const Kokkos::TeamPolicy<>::member_type& member) {
+                Kokkos::parallel_for(
+                    Kokkos::ThreadVectorMDRange(member, n_nodes, n_nodes, 6, 6),
+                    [&](std::size_t i, std::size_t j, std::size_t m, std::size_t n) {
+                        const auto a = quadrature.weights(k) * shape_function_vector(i) *
+                                       shape_function_vector(j) * jacobian;
+                        const auto mass_contribution = a * sectional_mass_matrix(m, n);
+                        const auto gyroscopic_contribution = a * gyroscopic_matrix(m, n);
+                        const auto stiffness_contribution = a * dynamic_stiffness_matrix(m, n);
+                        Kokkos::atomic_add(
+                            &element_mass_matrix(i * 6 + m, j * 6 + n), mass_contribution
+                        );
+                        Kokkos::atomic_add(
+                            &element_gyroscopic_matrix(i * 6 + m, j * 6 + n), gyroscopic_contribution
+                        );
+                        Kokkos::atomic_add(
+                            &element_dynamic_stiffness_matrix(i * 6 + m, j * 6 + n),
+                            stiffness_contribution
+                        );
+                    }
                 );
             }
-        }
+        );
+        // const auto q_weight = quadrature.weights(k);
+        // for (size_t i = 0; i < n_nodes; ++i) {
+        //     for (size_t j = 0; j < n_nodes; ++j) {
+        //         const auto pair6 = Kokkos::make_pair(0, 6);
+        //         const auto pair_i =
+        //             Kokkos::make_pair(i * LieAlgebraComponents, (i + 1) * LieAlgebraComponents);
+        //         const auto pair_j =
+        //             Kokkos::make_pair(j * LieAlgebraComponents, (j + 1) * LieAlgebraComponents);
+        //         const auto a = q_weight * shape_function[i] * shape_function[j] * jacobian;
+        //         KokkosBlas::axpy(
+        //             a, Kokkos::subview(sectional_mass_matrix, pair6, pair6),
+        //             Kokkos::subview(element_mass_matrix, pair_i, pair_j)
+        //         );
+        //         KokkosBlas::axpy(
+        //             a, Kokkos::subview(gyroscopic_matrix, pair6, pair6),
+        //             Kokkos::subview(element_gyroscopic_matrix, pair_i, pair_j)
+        //         );
+        //         KokkosBlas::axpy(
+        //             a, Kokkos::subview(dynamic_stiffness_matrix, pair6, pair6),
+        //             Kokkos::subview(element_dynamic_stiffness_matrix, pair_i, pair_j)
+        //         );
+        //     }
+        // }
     }
 }
 }  // namespace openturbine::gebt_poc

--- a/src/gebt_poc/ElementalInertialMatrices.hpp
+++ b/src/gebt_poc/ElementalInertialMatrices.hpp
@@ -3,6 +3,7 @@
 #include <KokkosBlas.hpp>
 #include <Kokkos_Core.hpp>
 
+#include "src/gebt_poc/element.h"
 #include "src/gebt_poc/InterpolateNodalValueDerivatives.hpp"
 #include "src/gebt_poc/InterpolateNodalValues.hpp"
 #include "src/gebt_poc/NodalDynamicStiffnessMatrix.hpp"
@@ -24,7 +25,7 @@ inline void ElementalInertialMatrices(
 ) {
     const auto n_nodes = gen_coords.extent(0);
     const auto order = n_nodes - 1;
-    const auto n_quad_pts = quadrature.GetNumberOfQuadraturePoints();
+    const auto n_quad_pts = quadrature.points.extent(0);
 
     auto nodes = Kokkos::View<double* [3]>("nodes", n_nodes);
     Kokkos::deep_copy(
@@ -44,7 +45,7 @@ inline void ElementalInertialMatrices(
 
     for (size_t k = 0; k < n_quad_pts; ++k) {
         // Calculate required interpolated values at the quadrature point
-        const auto q_pt = quadrature.GetQuadraturePoints()[k];
+        const auto q_pt = quadrature.points(k);
         auto shape_function = LagrangePolynomial(order, q_pt);
         auto shape_function_derivative = LagrangePolynomialDerivative(order, q_pt);
         auto shape_function_vector = gen_alpha_solver::create_vector(shape_function);
@@ -82,7 +83,7 @@ inline void ElementalInertialMatrices(
             velocity_qp, acceleration_qp, sectional_mass_matrix, dynamic_stiffness_matrix
         );
 
-        const auto q_weight = quadrature.GetQuadratureWeights()[k];
+        const auto q_weight = quadrature.weights(k);
         for (size_t i = 0; i < n_nodes; ++i) {
             for (size_t j = 0; j < n_nodes; ++j) {
                 const auto pair6 = Kokkos::make_pair(0, 6);

--- a/src/gebt_poc/ElementalInertialMatrices.hpp
+++ b/src/gebt_poc/ElementalInertialMatrices.hpp
@@ -167,29 +167,6 @@ inline void ElementalInertialMatrices(
                 );
             }
         );
-        // const auto q_weight = quadrature.weights(k);
-        // for (size_t i = 0; i < n_nodes; ++i) {
-        //     for (size_t j = 0; j < n_nodes; ++j) {
-        //         const auto pair6 = Kokkos::make_pair(0, 6);
-        //         const auto pair_i =
-        //             Kokkos::make_pair(i * LieAlgebraComponents, (i + 1) * LieAlgebraComponents);
-        //         const auto pair_j =
-        //             Kokkos::make_pair(j * LieAlgebraComponents, (j + 1) * LieAlgebraComponents);
-        //         const auto a = q_weight * shape_function[i] * shape_function[j] * jacobian;
-        //         KokkosBlas::axpy(
-        //             a, Kokkos::subview(sectional_mass_matrix, pair6, pair6),
-        //             Kokkos::subview(element_mass_matrix, pair_i, pair_j)
-        //         );
-        //         KokkosBlas::axpy(
-        //             a, Kokkos::subview(gyroscopic_matrix, pair6, pair6),
-        //             Kokkos::subview(element_gyroscopic_matrix, pair_i, pair_j)
-        //         );
-        //         KokkosBlas::axpy(
-        //             a, Kokkos::subview(dynamic_stiffness_matrix, pair6, pair6),
-        //             Kokkos::subview(element_dynamic_stiffness_matrix, pair_i, pair_j)
-        //         );
-        //     }
-        // }
     }
 }
 }  // namespace openturbine::gebt_poc

--- a/src/gebt_poc/ElementalStaticStiffnessMatrix.hpp
+++ b/src/gebt_poc/ElementalStaticStiffnessMatrix.hpp
@@ -3,7 +3,6 @@
 #include <KokkosBlas.hpp>
 #include <Kokkos_Core.hpp>
 
-#include "src/gebt_poc/element.h"
 #include "src/gebt_poc/CalculateSectionalStrain.hpp"
 #include "src/gebt_poc/InterpolateNodalValueDerivatives.hpp"
 #include "src/gebt_poc/InterpolateNodalValues.hpp"
@@ -11,6 +10,7 @@
 #include "src/gebt_poc/NodalElasticForces.hpp"
 #include "src/gebt_poc/NodalStaticStiffnessMatrixComponents.hpp"
 #include "src/gebt_poc/SectionalStiffness.hpp"
+#include "src/gebt_poc/element.h"
 #include "src/gebt_poc/interpolation.h"
 #include "src/gebt_poc/quadrature.h"
 #include "src/gebt_poc/section.h"
@@ -21,7 +21,7 @@
 namespace openturbine::gebt_poc {
 inline void ElementalStaticStiffnessMatrix(
     LieGroupFieldView::const_type position_vectors, LieGroupFieldView::const_type gen_coords,
-    View2D_6x6::const_type stiffness, const Quadrature& quadrature, View2D stiffness_matrix
+    View2D_6x6::const_type stiffness, Quadrature quadrature, View2D stiffness_matrix
 ) {
     const auto n_nodes = gen_coords.extent(0);
     const auto order = n_nodes - 1;
@@ -44,26 +44,78 @@ inline void ElementalStaticStiffnessMatrix(
     auto P_matrix = View2D_6x6("P_matrix");
     auto Q_matrix = View2D_6x6("Q_matrix");
 
+    auto policy = Kokkos::TeamPolicy<>(1, Kokkos::AUTO(), Kokkos::AUTO());
+    using scratch_space = Kokkos::DefaultExecutionSpace::scratch_memory_space;
+    using unmanaged_memory = Kokkos::MemoryTraits<Kokkos::Unmanaged>;
+    using ScratchView1D = Kokkos::View<double*, scratch_space, unmanaged_memory>;
+    using ScratchView2D = Kokkos::View<double**, scratch_space, unmanaged_memory>;
+    const auto team_scratch_size =
+        5 * ScratchView2D::shmem_size(n_quad_pts, n_nodes) + ScratchView1D::shmem_size(n_nodes);
+    const auto thread_scratch_size = ScratchView1D::shmem_size(n_nodes);
+    auto shape_functions = View2D("shape functions", n_quad_pts, n_nodes);
+    auto shape_function_derivatives = View2D("shape function derivatives", n_quad_pts, n_nodes);
+    policy.set_scratch_size(
+        0, Kokkos::PerTeam(team_scratch_size), Kokkos::PerThread(thread_scratch_size)
+    );
+    Kokkos::parallel_for(
+        policy,
+        KOKKOS_LAMBDA(const Kokkos::TeamPolicy<>::member_type& member) {
+            auto shapes = ComputeLagrangePolynomials(member, order, quadrature.points);
+            auto derivatives =
+                ComputeLagrangePolynomialDerivatives(member, order, quadrature.points);
+            member.team_barrier();
+            Kokkos::parallel_for(
+                Kokkos::ThreadVectorMDRange(member, shapes.extent(0), shapes.extent(1)),
+                [&](std::size_t i, std::size_t j) {
+                    shape_functions(i, j) = shapes(i, j);
+                    shape_function_derivatives(i, j) = derivatives(i, j);
+                }
+            );
+        }
+    );
+
     Kokkos::deep_copy(stiffness_matrix, 0.);
     for (size_t i = 0; i < n_nodes; ++i) {
         for (size_t j = 0; j < n_nodes; ++j) {
             for (size_t k = 0; k < n_quad_pts; ++k) {
                 // Calculate required interpolated values at the quadrature point
-                const auto q_pt = quadrature.points(k);
-                auto shape_function = LagrangePolynomial(order, q_pt);
-                auto shape_function_derivative = LagrangePolynomialDerivative(order, q_pt);
-                auto shape_function_vector = gen_alpha_solver::create_vector(shape_function);
-                auto shape_function_derivative_vector =
-                    gen_alpha_solver::create_vector(shape_function_derivative);
+                auto shape_function_vector = View1D("sfv", n_nodes);
+                auto shape_function_derivative_vector = View1D("sfv", n_nodes);
+                Kokkos::parallel_for(
+                    n_nodes,
+                    KOKKOS_LAMBDA(std::size_t l) {
+                        shape_function_vector(l) = shape_functions(k, l);
+                        shape_function_derivative_vector(l) = shape_function_derivatives(k, l);
+                    }
+                );
 
                 auto jacobian = CalculateJacobian(nodes, shape_function_derivative_vector);
-                InterpolateNodalValues(gen_coords, shape_function, gen_coords_qp);
-                InterpolateNodalValueDerivatives(
-                    gen_coords, shape_function_derivative, jacobian, gen_coords_derivatives_qp
-                );
-                InterpolateNodalValues(position_vectors, shape_function, position_vector_qp);
-                InterpolateNodalValueDerivatives(
-                    position_vectors, shape_function_derivative, jacobian, pos_vector_derivatives_qp
+                Kokkos::parallel_for(
+                    policy,
+                    KOKKOS_LAMBDA(const Kokkos::TeamPolicy<>::member_type& member) {
+                        auto gen_coords_interp =
+                            InterpolateNodalValues(member, gen_coords, shape_function_vector);
+                        auto gen_coord_deriv_interp = InterpolateNodalValueDerivatives(
+                            member, gen_coords, shape_function_derivative_vector, jacobian
+                        );
+                        auto position_interp =
+                            InterpolateNodalValues(member, position_vectors, shape_function_vector);
+                        auto position_deriv_interp = InterpolateNodalValueDerivatives(
+                            member, position_vectors, shape_function_derivative_vector, jacobian
+                        );
+                        member.team_barrier();
+                        Kokkos::parallel_for(
+                            Kokkos::ThreadVectorRange(member, LieGroupComponents),
+                            [&](std::size_t component) {
+                                gen_coords_qp(component) = gen_coords_interp(component);
+                                position_vector_qp(component) = position_interp(component);
+                                gen_coords_derivatives_qp(component) =
+                                    gen_coord_deriv_interp(component);
+                                pos_vector_derivatives_qp(component) =
+                                    position_deriv_interp(component);
+                            }
+                        );
+                    }
                 );
 
                 // Calculate the curvature and sectional strain
@@ -95,7 +147,6 @@ inline void ElementalStaticStiffnessMatrix(
                     sectional_stiffness, O_matrix, P_matrix, Q_matrix
                 );
 
-                const auto q_weight = quadrature.weights(k);
                 Kokkos::parallel_for(
                     Kokkos::MDRangePolicy<Kokkos::DefaultExecutionSpace, Kokkos::Rank<2>>(
                         {0, 0}, {LieAlgebraComponents, LieAlgebraComponents}
@@ -103,7 +154,7 @@ inline void ElementalStaticStiffnessMatrix(
                     KOKKOS_LAMBDA(const size_t ii, const size_t jj) {
                         stiffness_matrix(
                             i * LieAlgebraComponents + ii, j * LieAlgebraComponents + jj
-                        ) += q_weight *
+                        ) += quadrature.weights(k) *
                              (shape_function_vector(i) * P_matrix(ii, jj) *
                                   shape_function_derivative_vector(j) +
                               shape_function_vector(i) * Q_matrix(ii, jj) *

--- a/src/gebt_poc/InterpolateNodalValues.hpp
+++ b/src/gebt_poc/InterpolateNodalValues.hpp
@@ -30,4 +30,47 @@ inline void InterpolateNodalValues(
     }
 }
 
+KOKKOS_INLINE_FUNCTION
+auto InterpolateNodalValues(
+    const Kokkos::TeamPolicy<>::member_type& member, View2D::const_type nodal_values,
+    View1D::const_type interpolation_function
+) {
+    using scratch_space = Kokkos::DefaultExecutionSpace::scratch_memory_space;
+    using unmanaged_memory = Kokkos::MemoryTraits<Kokkos::Unmanaged>;
+    using ScratchView1D = Kokkos::View<double*, scratch_space, unmanaged_memory>;
+    auto interpolated_values = ScratchView1D(member.team_scratch(0), nodal_values.extent(1));
+    const auto n_nodes = nodal_values.extent(0);
+    const auto n_values = interpolated_values.extent(0);
+    Kokkos::parallel_for(Kokkos::ThreadVectorRange(member, n_values), [&](std::size_t i) {
+        interpolated_values(i) = 0.;
+    });
+    member.team_barrier();
+    Kokkos::parallel_for(
+        Kokkos::ThreadVectorMDRange(member, n_nodes, n_values),
+        [&](std::size_t i, std::size_t j) {
+            auto result = nodal_values(i, j) * interpolation_function(i);
+            Kokkos::atomic_add(&interpolated_values(j), result);
+        }
+    );
+    member.team_barrier();
+    // Normalize the rotation quaternion if it is not already normalized
+    if (nodal_values.extent(1) == LieGroupComponents) {
+        Kokkos::single(Kokkos::PerTeam(member), [&]() {
+            const auto norm = std::sqrt(
+                interpolated_values(3) * interpolated_values(3) +
+                interpolated_values(4) * interpolated_values(4) +
+                interpolated_values(5) * interpolated_values(5) +
+                interpolated_values(6) * interpolated_values(6)
+            );
+            if (norm != 0. && norm != 1.) {
+                for (std::size_t i = 3; i < LieGroupComponents; ++i) {
+                    interpolated_values(i) /= norm;
+                }
+            }
+        });
+    }
+    member.team_barrier();
+    return interpolated_values;
+}
+
 }  // namespace openturbine::gebt_poc

--- a/src/gebt_poc/dynamic_beam_element.cpp
+++ b/src/gebt_poc/dynamic_beam_element.cpp
@@ -17,7 +17,7 @@ namespace openturbine::gebt_poc {
 
 DynamicBeamLinearizationParameters::DynamicBeamLinearizationParameters(
     LieGroupFieldView position_vectors, View2D_6x6 stiffness_matrix, View2D_6x6 mass_matrix,
-    UserDefinedQuadrature quadrature, std::vector<Forces*> external_forces
+    Quadrature quadrature, std::vector<Forces*> external_forces
 )
     : position_vectors_(std::move(position_vectors)),
       stiffness_matrix_(std::move(stiffness_matrix)),

--- a/src/gebt_poc/dynamic_beam_element.h
+++ b/src/gebt_poc/dynamic_beam_element.h
@@ -24,7 +24,7 @@ public:
     /// stiffness matrix, and a quadrature rule
     DynamicBeamLinearizationParameters(
         LieGroupFieldView position_vectors, View2D_6x6 stiffness_matrix, View2D_6x6 mass_matrix,
-        UserDefinedQuadrature quadrature, std::vector<Forces*> external_forces = {}
+        Quadrature quadrature, std::vector<Forces*> external_forces = {}
     );
 
     virtual void ResidualVector(
@@ -159,7 +159,7 @@ private:
     LieGroupFieldView position_vectors_;
     View2D_6x6 stiffness_matrix_;
     View2D_6x6 mass_matrix_;
-    UserDefinedQuadrature quadrature_;
+    Quadrature quadrature_;
     std::vector<Forces*> external_forces_;
 };
 

--- a/src/gebt_poc/interpolation.cpp
+++ b/src/gebt_poc/interpolation.cpp
@@ -58,39 +58,6 @@ View2D LinearlyInterpolateMatrices(View2D::const_type m1, View2D::const_type m2,
     return interpolated_matrix;
 }
 
-double LegendrePolynomial(const size_t n, const double x) {
-    if (n == 0) {
-        return 1.;
-    }
-    if (n == 1) {
-        return x;
-    }
-
-    auto n_double = static_cast<double>(n);
-    return (
-        ((2. * n_double - 1.) * x * LegendrePolynomial(n - 1, x) -
-         (n_double - 1.) * LegendrePolynomial(n - 2, x)) /
-        n_double
-    );
-}
-
-double LegendrePolynomialDerivative(const size_t n, const double x) {
-    if (n == 0) {
-        return 0.;
-    }
-    if (n == 1) {
-        return 1.;
-    }
-    if (n == 2) {
-        return (3. * x);
-    }
-
-    auto n_double = static_cast<double>(n);
-    return (
-        (2. * n_double - 1.) * LegendrePolynomial(n - 1, x) + LegendrePolynomialDerivative(n - 2, x)
-    );
-}
-
 std::vector<double> GenerateGLLPoints(const size_t order) {
     if (order < 1) {
         throw std::invalid_argument("Polynomial order must be greater than or equal to 1");

--- a/src/gebt_poc/interpolation.h
+++ b/src/gebt_poc/interpolation.h
@@ -164,7 +164,6 @@ auto ComputeLagrangePolynomials(
     using unmanaged_memory = Kokkos::MemoryTraits<Kokkos::Unmanaged>;
     using ScratchView2D = Kokkos::View<double**, scratch_space, unmanaged_memory>;
     auto gll_points = GenerateGLLPoints(member, n);
-    auto gll_point_v = GenerateGLLPoints(n);
     auto poly = ScratchView2D(member.team_scratch(0), points.extent(0), n + 1);
     member.team_barrier();
 
@@ -173,7 +172,7 @@ auto ComputeLagrangePolynomials(
         [&](std::size_t i, std::size_t j) {
             const auto x = points(i);
             const auto gll = gll_points(j);
-            if (std::abs(x - gll) < 1.e-15) {
+            if (Kokkos::abs(x - gll) < 1.e-15) {
                 poly(i, j) = 1.;
             } else {
                 poly(i, j) =

--- a/src/gebt_poc/interpolation.h
+++ b/src/gebt_poc/interpolation.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <iostream>
 #include <limits>
 
 #include "src/gebt_poc/point.h"
@@ -37,7 +38,22 @@ View2D LinearlyInterpolateMatrices(View2D::const_type, View2D::const_type, doubl
  * @param  n: Order of the Legendre polynomial
  * @param  x: Point at which the Legendre polynomial is to be evaluated
  */
-double LegendrePolynomial(const size_t n, const double x);
+KOKKOS_INLINE_FUNCTION
+static constexpr double LegendrePolynomial(const size_t n, const double x) {
+    if (n == 0) {
+        return 1.;
+    }
+    if (n == 1) {
+        return x;
+    }
+
+    auto n_double = static_cast<double>(n);
+    return (
+        ((2. * n_double - 1.) * x * LegendrePolynomial(n - 1, x) -
+         (n_double - 1.) * LegendrePolynomial(n - 2, x)) /
+        n_double
+    );
+}
 
 /*!
  * @brief  Evaluates the first derivative of Legendre polynomial of order n at point x recursively
@@ -48,7 +64,23 @@ double LegendrePolynomial(const size_t n, const double x);
  * @param  n: Order of the Legendre polynomial
  * @param  x: Point at which the derivative of the Legendre polynomial is to be evaluated
  */
-double LegendrePolynomialDerivative(const size_t n, const double x);
+KOKKOS_INLINE_FUNCTION
+static constexpr double LegendrePolynomialDerivative(const size_t n, const double x) {
+    if (n == 0) {
+        return 0.;
+    }
+    if (n == 1) {
+        return 1.;
+    }
+    if (n == 2) {
+        return (3. * x);
+    }
+
+    auto n_double = static_cast<double>(n);
+    return (
+        (2. * n_double - 1.) * LegendrePolynomial(n - 1, x) + LegendrePolynomialDerivative(n - 2, x)
+    );
+}
 
 /*!
  * @brief  Determines the (n+1) Gauss-Lobatto-Legendre points required for nodal locations
@@ -86,5 +118,125 @@ std::vector<double> LagrangePolynomial(const size_t n, const double x);
  * @return  Vector of derivative of Lagrangian interpolation functions with size n+1 for n+1 nodes
  */
 std::vector<double> LagrangePolynomialDerivative(const size_t n, const double x);
+
+KOKKOS_INLINE_FUNCTION
+auto GenerateGLLPoints(const Kokkos::TeamPolicy<>::member_type& member, const size_t order) {
+    using scratch_space = Kokkos::DefaultExecutionSpace::scratch_memory_space;
+    using unmanaged_memory = Kokkos::MemoryTraits<Kokkos::Unmanaged>;
+    using ScratchView1D = Kokkos::View<double*, scratch_space, unmanaged_memory>;
+    const auto n_nodes = order + 1;
+    auto gll_points = ScratchView1D(member.team_scratch(0), n_nodes);
+    Kokkos::single(Kokkos::PerTeam(member), [&]() {
+        gll_points(0) = -1.;
+        gll_points(order) = 1.;
+    });
+
+    Kokkos::parallel_for(Kokkos::ThreadVectorRange(member, 1, n_nodes), [&](std::size_t i) {
+        auto x_it = -std::cos(static_cast<double>(i) * M_PI / order);
+
+        for (std::size_t j = 0; j < kMaxIterations; ++j) {
+            const auto x_old = x_it;
+
+            auto legendre_poly = ScratchView1D(member.thread_scratch(0), n_nodes);
+            for (std::size_t k = 0; k < n_nodes; ++k) {
+                legendre_poly(k) = LegendrePolynomial(k, x_it);
+            }
+
+            x_it -= (x_it * legendre_poly[n_nodes - 1] - legendre_poly[n_nodes - 2]) /
+                    (n_nodes * legendre_poly[n_nodes - 1]);
+
+            if (std::abs(x_it - x_old) <= kConvergenceTolerance) {
+                break;
+            }
+        }
+
+        gll_points(i) = x_it;
+    });
+
+    return gll_points;
+}
+
+KOKKOS_INLINE_FUNCTION
+auto ComputeLagrangePolynomials(
+    const Kokkos::TeamPolicy<>::member_type& member, std::size_t n, View1D::const_type points
+) {
+    using scratch_space = Kokkos::DefaultExecutionSpace::scratch_memory_space;
+    using unmanaged_memory = Kokkos::MemoryTraits<Kokkos::Unmanaged>;
+    using ScratchView2D = Kokkos::View<double**, scratch_space, unmanaged_memory>;
+    auto gll_points = GenerateGLLPoints(member, n);
+    auto gll_point_v = GenerateGLLPoints(n);
+    auto poly = ScratchView2D(member.team_scratch(0), points.extent(0), n + 1);
+    member.team_barrier();
+
+    Kokkos::parallel_for(
+        Kokkos::ThreadVectorMDRange(member, points.extent(0), n + 1),
+        [&](std::size_t i, std::size_t j) {
+            const auto x = points(i);
+            const auto gll = gll_points(j);
+            if (std::abs(x - gll) < 1.e-15) {
+                poly(i, j) = 1.;
+            } else {
+                poly(i, j) =
+                    ((-1. / (n * (n + 1))) * ((1 - x * x) / (x - gll)) *
+                     (LegendrePolynomialDerivative(n, x) / LegendrePolynomial(n, gll)));
+            }
+        }
+    );
+
+    return poly;
+}
+
+KOKKOS_INLINE_FUNCTION
+auto ComputeLagrangePolynomialDerivatives(
+    const Kokkos::TeamPolicy<>::member_type& member, std::size_t n, View1D::const_type points
+) {
+    using scratch_space = Kokkos::DefaultExecutionSpace::scratch_memory_space;
+    using unmanaged_memory = Kokkos::MemoryTraits<Kokkos::Unmanaged>;
+    using ScratchView2D = Kokkos::View<double**, scratch_space, unmanaged_memory>;
+    auto gll_points = GenerateGLLPoints(member, n);
+    auto derivative = ScratchView2D(member.team_scratch(0), points.extent(0), n + 1);
+    member.team_barrier();
+
+    const auto n_double = static_cast<double>(n);
+    Kokkos::parallel_for(
+        Kokkos::ThreadVectorMDRange(member, points.extent(0), n + 1),
+        [&](std::size_t i, std::size_t j) {
+            const auto x = points(i);
+            const auto gll = gll_points(j);
+
+            if (std::abs(x - gll) < 1.e-15) {
+                if (j == 0) {
+                    derivative(i, j) = -n_double * (n_double + 1.) / 4.;
+                } else if (j == n) {
+                    derivative(i, j) = n_double * (n_double + 1.) / 4.;
+                } else {
+                    derivative(i, j) = 0.;
+                }
+            } else {
+                derivative(i, j) = 0.;
+                auto denominator = 1.;
+                auto numerator = 1.;
+                for (size_t k = 0; k < n + 1; ++k) {
+                    if (k != j) {
+                        denominator *= (gll - gll_points(k));
+                    }
+                    numerator = 1.;
+                    for (size_t l = 0; l < n + 1; ++l) {
+                        if (l != k && l != j && k != j) {
+                            numerator *= (x - gll_points(l));
+                        }
+                        if (k == j) {
+                            numerator = 0.;
+                        }
+                    }
+                    derivative(i, j) += numerator;
+                }
+                derivative(i, j) /= denominator;
+            }
+        }
+    );
+
+    return derivative;
+}
 
 }  // namespace openturbine::gebt_poc

--- a/src/gebt_poc/quadrature.h
+++ b/src/gebt_poc/quadrature.h
@@ -7,19 +7,25 @@
 namespace openturbine::gebt_poc {
 
 struct Quadrature {
-  View1D points;
-  View1D weights;
+    View1D points;
+    View1D weights;
 };
 
 inline Quadrature CreateGaussLegendreQuadrature(int order) {
-    if(order != 7) throw;
-    static constexpr auto point_data = std::array{-0.9491079123427585, -0.7415311855993945, -0.4058451513773972, 0., 0.4058451513773972, 0.7415311855993945, 0.9491079123427585};
-    static constexpr auto weight_data = std::array{0.1294849661688697, 0.2797053914892766, 0.3818300505051189, 0.4179591836734694, 0.3818300505051189, 0.2797053914892766, 0.1294849661688697};
+    if (order != 7)
+        throw;
+    static constexpr auto point_data =
+        std::array{-0.9491079123427585, -0.7415311855993945, -0.4058451513773972, 0.,
+                   0.4058451513773972,  0.7415311855993945,  0.9491079123427585};
+    static constexpr auto weight_data =
+        std::array{0.1294849661688697, 0.2797053914892766, 0.3818300505051189, 0.4179591836734694,
+                   0.3818300505051189, 0.2797053914892766, 0.1294849661688697};
 
     auto points = View1D("points", order);
     auto weights = View1D("weights", order);
 
-    using UnmanagedView1D = Kokkos::View<const double*, Kokkos::HostSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged> >;
+    using UnmanagedView1D =
+        Kokkos::View<const double*, Kokkos::HostSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged>>;
     auto host_points = UnmanagedView1D(point_data.data(), point_data.size());
     auto host_weights = UnmanagedView1D(weight_data.data(), weight_data.size());
     Kokkos::deep_copy(points, host_points);

--- a/src/gebt_poc/static_beam_element.cpp
+++ b/src/gebt_poc/static_beam_element.cpp
@@ -34,7 +34,7 @@ void BMatrix(View2D constraints_gradient_matrix) {
 }
 
 StaticBeamLinearizationParameters::StaticBeamLinearizationParameters(
-    LieGroupFieldView position_vectors, View2D_6x6 stiffness_matrix, UserDefinedQuadrature quadrature
+    LieGroupFieldView position_vectors, View2D_6x6 stiffness_matrix, Quadrature quadrature
 )
     : position_vectors_(position_vectors),
       stiffness_matrix_(stiffness_matrix),

--- a/src/gebt_poc/static_beam_element.h
+++ b/src/gebt_poc/static_beam_element.h
@@ -25,8 +25,7 @@ public:
     /// Define a static beam element with the given position vector for the nodes, 6x6
     /// stiffness matrix, and a quadrature rule
     StaticBeamLinearizationParameters(
-        LieGroupFieldView position_vectors, View2D_6x6 stiffness_matrix,
-        Quadrature quadrature
+        LieGroupFieldView position_vectors, View2D_6x6 stiffness_matrix, Quadrature quadrature
     );
 
     virtual void ResidualVector(

--- a/src/gebt_poc/static_beam_element.h
+++ b/src/gebt_poc/static_beam_element.h
@@ -26,7 +26,7 @@ public:
     /// stiffness matrix, and a quadrature rule
     StaticBeamLinearizationParameters(
         LieGroupFieldView position_vectors, View2D_6x6 stiffness_matrix,
-        UserDefinedQuadrature quadrature
+        Quadrature quadrature
     );
 
     virtual void ResidualVector(
@@ -159,7 +159,7 @@ public:
 private:
     LieGroupFieldView position_vectors_;
     View2D_6x6 stiffness_matrix_;
-    UserDefinedQuadrature quadrature_;
+    Quadrature quadrature_;
 };
 
 }  // namespace openturbine::gebt_poc

--- a/tests/unit_tests/gebt_poc/test_ElementalInertialForcesResidual.cpp
+++ b/tests/unit_tests/gebt_poc/test_ElementalInertialForcesResidual.cpp
@@ -193,13 +193,7 @@ TEST(SolverTest, ElementalInertialForcesResidualWithNonZeroValues) {
     auto generalized_coords = Kokkos::View<double[5][7]>("generalized_coords");
     Kokkos::parallel_for(1, NonZeroValues_populate_coords{generalized_coords});
 
-    auto quadrature_points =
-        std::vector{-0.9491079123427585, -0.7415311855993945, -0.4058451513773972, 0.,
-                    0.4058451513773972,  0.7415311855993945,  0.9491079123427585};
-    auto quadrature_weights =
-        std::vector{0.1294849661688697, 0.2797053914892766, 0.3818300505051189, 0.4179591836734694,
-                    0.3818300505051189, 0.2797053914892766, 0.1294849661688697};
-    auto quadrature = UserDefinedQuadrature(quadrature_points, quadrature_weights);
+    auto quadrature = CreateGaussLegendreQuadrature(7);
 
     auto velocity = Kokkos::View<double[5][6]>("velocity");
     Kokkos::parallel_for(1, NonZeroValues_PopulateVelocity{velocity});

--- a/tests/unit_tests/gebt_poc/test_ElementalInertialMatrices.cpp
+++ b/tests/unit_tests/gebt_poc/test_ElementalInertialMatrices.cpp
@@ -200,13 +200,7 @@ TEST(SolverTest, ElementalInertialMatrices) {
     auto acceleration = Kokkos::View<double[5][6]>("acceleration");
     Kokkos::parallel_for(1, NonZeroValues_PopulateAcceleration{acceleration});
 
-    auto quadrature_points =
-        std::vector{-0.9491079123427585, -0.7415311855993945, -0.4058451513773972, 0.,
-                    0.4058451513773972,  0.7415311855993945,  0.9491079123427585};
-    auto quadrature_weights =
-        std::vector{0.1294849661688697, 0.2797053914892766, 0.3818300505051189, 0.4179591836734694,
-                    0.3818300505051189, 0.2797053914892766, 0.1294849661688697};
-    auto quadrature = UserDefinedQuadrature(quadrature_points, quadrature_weights);
+    auto quadrature = CreateGaussLegendreQuadrature(7);
 
     auto sectional_mass_matrix = gen_alpha_solver::create_matrix({
         {2., 0., 0., 0., 0.6, -0.4},  // row 1

--- a/tests/unit_tests/gebt_poc/test_ElementalStaticForcesResidual.cpp
+++ b/tests/unit_tests/gebt_poc/test_ElementalStaticForcesResidual.cpp
@@ -36,12 +36,7 @@ TEST(SolverTest, ElementalStaticForcesResidualWithZeroValues) {
     });
 
     // 7-point Gauss-Legendre quadrature
-    auto quadrature = UserDefinedQuadrature(
-        {-0.9491079123427585, -0.7415311855993945, -0.4058451513773972, 0., 0.4058451513773972,
-         0.7415311855993945, 0.9491079123427585},
-        {0.1294849661688697, 0.2797053914892766, 0.3818300505051189, 0.4179591836734694,
-         0.3818300505051189, 0.2797053914892766, 0.1294849661688697}
-    );
+    auto quadrature = CreateGaussLegendreQuadrature(7);
 
     auto residual = Kokkos::View<double[30]>("residual");
     ElementalStaticForcesResidual(
@@ -168,13 +163,7 @@ TEST(SolverTest, ElementalStaticForcesResidualWithNonZeroValues) {
         {6., 12., 18., 24., 30., 36.}   // row 6
     });
 
-    auto quadrature_points =
-        std::vector{-0.9491079123427585, -0.7415311855993945, -0.4058451513773972, 0.,
-                    0.4058451513773972,  0.7415311855993945,  0.9491079123427585};
-    auto quadrature_weights =
-        std::vector{0.1294849661688697, 0.2797053914892766, 0.3818300505051189, 0.4179591836734694,
-                    0.3818300505051189, 0.2797053914892766, 0.1294849661688697};
-    auto quadrature = UserDefinedQuadrature(quadrature_points, quadrature_weights);
+    auto quadrature = CreateGaussLegendreQuadrature(7);
 
     auto residual = Kokkos::View<double[30]>("residual");
 

--- a/tests/unit_tests/gebt_poc/test_ElementalStaticStiffnessMatrix.cpp
+++ b/tests/unit_tests/gebt_poc/test_ElementalStaticStiffnessMatrix.cpp
@@ -36,12 +36,7 @@ TEST(SolverTest, ElementalStaticStiffnessMatrixWithZeroValues) {
     });
 
     // 7-point Gauss-Legendre quadrature
-    auto quadrature = UserDefinedQuadrature(
-        {-0.9491079123427585, -0.7415311855993945, -0.4058451513773972, 0., 0.4058451513773972,
-         0.7415311855993945, 0.9491079123427585},
-        {0.1294849661688697, 0.2797053914892766, 0.3818300505051189, 0.4179591836734694,
-         0.3818300505051189, 0.2797053914892766, 0.1294849661688697}
-    );
+    auto quadrature = CreateGaussLegendreQuadrature(7);
 
     auto iteration_matrix = Kokkos::View<double[30][30]>("iteration_matrix");
     ElementalStaticStiffnessMatrix(
@@ -96,13 +91,7 @@ TEST(SolverTest, ElementalStaticStiffnessMatrixWithNonZeroValues2D) {
         {6., 12., 18., 24., 30., 36.}   // row 6
     });
 
-    auto quadrature_points =
-        std::vector{-0.9491079123427585, -0.7415311855993945, -0.4058451513773972, 0.,
-                    0.4058451513773972,  0.7415311855993945,  0.9491079123427585};
-    auto quadrature_weights =
-        std::vector{0.1294849661688697, 0.2797053914892766, 0.3818300505051189, 0.4179591836734694,
-                    0.3818300505051189, 0.2797053914892766, 0.1294849661688697};
-    auto quadrature = UserDefinedQuadrature(quadrature_points, quadrature_weights);
+    auto quadrature = CreateGaussLegendreQuadrature(7);
 
     auto iteration_matrix = Kokkos::View<double[30][30]>("iteration_matrix");
     ElementalStaticStiffnessMatrix(

--- a/tests/unit_tests/gebt_poc/test_dynamic_beam.cpp
+++ b/tests/unit_tests/gebt_poc/test_dynamic_beam.cpp
@@ -78,12 +78,7 @@ TEST(DynamicBeamTest, DynamicAnalysisWithZeroForce) {
         {-0.4, 0.2, 0., 3., 6., 9.}   // row 6
     });
 
-    auto quadrature = UserDefinedQuadrature(
-        {-0.9491079123427585, -0.7415311855993945, -0.4058451513773972, 0., 0.4058451513773972,
-         0.7415311855993945, 0.9491079123427585},
-        {0.1294849661688697, 0.2797053914892766, 0.3818300505051189, 0.4179591836734694,
-         0.3818300505051189, 0.2797053914892766, 0.1294849661688697}
-    );
+    auto quadrature = CreateGaussLegendreQuadrature(7);
 
     auto gen_coords = gen_alpha_solver::create_matrix({
         {0., 0., 0., 1., 0., 0., 0.},  // node 1
@@ -243,12 +238,7 @@ TEST(DynamicBeamTest, DynamicAnalysisCatileverWithConstantForceAtTip) {
         {0., 0., 0., 0., 0., 1.0336e-2}    // row 6
     });
 
-    auto quadrature = UserDefinedQuadrature(
-        {-0.9491079123427585, -0.7415311855993945, -0.4058451513773972, 0., 0.4058451513773972,
-         0.7415311855993945, 0.9491079123427585},
-        {0.1294849661688697, 0.2797053914892766, 0.3818300505051189, 0.4179591836734694,
-         0.3818300505051189, 0.2797053914892766, 0.1294849661688697}
-    );
+    auto quadrature = CreateGaussLegendreQuadrature(7);
 
     auto position_vectors =
         gen_alpha_solver::create_matrix({// node 1
@@ -354,12 +344,7 @@ TEST(DynamicBeamTest, DynamicAnalysisCatileverWithSinusoidalForceAtTip) {
         {0., 0., 0., 0., 0., 1.0336e-2}    // row 6
     });
 
-    auto quadrature = UserDefinedQuadrature(
-        {-0.9491079123427585, -0.7415311855993945, -0.4058451513773972, 0., 0.4058451513773972,
-         0.7415311855993945, 0.9491079123427585},
-        {0.1294849661688697, 0.2797053914892766, 0.3818300505051189, 0.4179591836734694,
-         0.3818300505051189, 0.2797053914892766, 0.1294849661688697}
-    );
+    auto quadrature = CreateGaussLegendreQuadrature(7);
 
     auto position_vectors =
         gen_alpha_solver::create_matrix({// node 1

--- a/tests/unit_tests/gebt_poc/test_johnson_static_beam.cpp
+++ b/tests/unit_tests/gebt_poc/test_johnson_static_beam.cpp
@@ -69,7 +69,7 @@ StaticBeamLinearizationParameters create_test_static_beam_parameters() {
     });
 
     auto quadrature = CreateGaussLegendreQuadrature(7);
-    
+
     return StaticBeamLinearizationParameters{position_vectors, stiffness_matrix, quadrature};
 }
 

--- a/tests/unit_tests/gebt_poc/test_johnson_static_beam.cpp
+++ b/tests/unit_tests/gebt_poc/test_johnson_static_beam.cpp
@@ -68,26 +68,8 @@ StaticBeamLinearizationParameters create_test_static_beam_parameters() {
         {6., 12., 18., 24., 30., 36.}   // row 6
     });
 
-    auto quadrature = UserDefinedQuadrature(
-        std::vector<double>{
-            -0.9491079123427585,  // point 1
-            -0.7415311855993945,  // point 2
-            -0.4058451513773972,  // point 3
-            0.,                   // point 4
-            0.4058451513773972,   // point 5
-            0.7415311855993945,   // point 6
-            0.9491079123427585    // point 7
-        },
-        std::vector<double>{
-            0.1294849661688697,  // weight 1
-            0.2797053914892766,  // weight 2
-            0.3818300505051189,  // weight 3
-            0.4179591836734694,  // weight 4
-            0.3818300505051189,  // weight 5
-            0.2797053914892766,  // weight 6
-            0.1294849661688697   // weight 7
-        }
-    );
+    auto quadrature = CreateGaussLegendreQuadrature(7);
+    
     return StaticBeamLinearizationParameters{position_vectors, stiffness_matrix, quadrature};
 }
 
@@ -216,12 +198,7 @@ TEST(StaticBeamTest, StaticBeamResidual) {
     });
 
     // Use a 7-point Gauss-Legendre quadrature for integration
-    auto quadrature = UserDefinedQuadrature(
-        {-0.9491079123427585, -0.7415311855993945, -0.4058451513773972, 0., 0.4058451513773972,
-         0.7415311855993945, 0.9491079123427585},
-        {0.1294849661688697, 0.2797053914892766, 0.3818300505051189, 0.4179591836734694,
-         0.3818300505051189, 0.2797053914892766, 0.1294849661688697}
-    );
+    auto quadrature = CreateGaussLegendreQuadrature(7);
 
     StaticBeamLinearizationParameters static_beam{position_vectors, stiffness, quadrature};
 
@@ -292,12 +269,7 @@ TEST(StaticBeamTest, StaticBeamIterationMatrix) {
     });
 
     // Use a 7-point Gauss-Legendre quadrature for integration
-    auto quadrature = UserDefinedQuadrature(
-        {-0.9491079123427585, -0.7415311855993945, -0.4058451513773972, 0., 0.4058451513773972,
-         0.7415311855993945, 0.9491079123427585},
-        {0.1294849661688697, 0.2797053914892766, 0.3818300505051189, 0.4179591836734694,
-         0.3818300505051189, 0.2797053914892766, 0.1294849661688697}
-    );
+    auto quadrature = CreateGaussLegendreQuadrature(7);
 
     StaticBeamLinearizationParameters static_beam{position_vectors, stiffness, quadrature};
 
@@ -365,12 +337,7 @@ TEST(StaticCompositeBeamTest, StaticAnalysisWithZeroForceAndNonZeroInitialGuess)
     });
 
     // Use a 7-point Gauss-Legendre quadrature for integration
-    auto quadrature = UserDefinedQuadrature(
-        {-0.9491079123427585, -0.7415311855993945, -0.4058451513773972, 0., 0.4058451513773972,
-         0.7415311855993945, 0.9491079123427585},
-        {0.1294849661688697, 0.2797053914892766, 0.3818300505051189, 0.4179591836734694,
-         0.3818300505051189, 0.2797053914892766, 0.1294849661688697}
-    );
+    auto quadrature = CreateGaussLegendreQuadrature(7);
 
     auto gen_coords = gen_alpha_solver::create_matrix({
         {0., 0., 0., 1., 0., 0., 0.},    // node 1

--- a/tests/unit_tests/gebt_poc/test_quadrature.cpp
+++ b/tests/unit_tests/gebt_poc/test_quadrature.cpp
@@ -3,29 +3,5 @@
 #include "src/gebt_poc/quadrature.h"
 
 namespace openturbine::gebt_poc {
-TEST(SolverTest, UserDefinedQuadrature) {
-    auto quadrature_points = std::vector<double>{
-        -0.9491079123427585,  // point 1
-        -0.7415311855993945,  // point 2
-        -0.4058451513773972,  // point 3
-        0.,                   // point 4
-        0.4058451513773972,   // point 5
-        0.7415311855993945,   // point 6
-        0.9491079123427585    // point 7
-    };
-    auto quadrature_weights = std::vector<double>{
-        0.1294849661688697,  // weight 1
-        0.2797053914892766,  // weight 2
-        0.3818300505051189,  // weight 3
-        0.4179591836734694,  // weight 4
-        0.3818300505051189,  // weight 5
-        0.2797053914892766,  // weight 6
-        0.1294849661688697   // weight 7
-    };
-    auto quadrature = UserDefinedQuadrature(quadrature_points, quadrature_weights);
 
-    EXPECT_EQ(quadrature.GetNumberOfQuadraturePoints(), 7);
-    EXPECT_EQ(quadrature.GetQuadraturePoints(), quadrature_points);
-    EXPECT_EQ(quadrature.GetQuadratureWeights(), quadrature_weights);
-}
 }  // namespace openturbine::gebt_poc

--- a/tests/unit_tests/gebt_poc/test_quadrature.cpp
+++ b/tests/unit_tests/gebt_poc/test_quadrature.cpp
@@ -2,6 +2,4 @@
 
 #include "src/gebt_poc/quadrature.h"
 
-namespace openturbine::gebt_poc {
-
-}  // namespace openturbine::gebt_poc
+namespace openturbine::gebt_poc {}  // namespace openturbine::gebt_poc


### PR DESCRIPTION
Changed Quadrature to just be a struct of two views, and then changed interpolation to take advantage of it now living on GPU.  The previous, BLAS-based version assumed the quadrature lived on host.  This new version is poised to take advantage of our improved parallel implementation going forward.  