### PR TITLE
Fixes errors when building on GPU.  

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,6 @@ include(openturbine-utils)
 ########################## OPTIONS #####################################
 
 # General options for the project
-add_compile_options(-Wall -Wextra -Wshadow -Wnon-virtual-dtor -Wpedantic -Werror)
 option(OTURB_ENABLE_BASIC_SANITIZERS "Compile with addrss and undefined behavior sanitizers" OFF)
 if(OTURB_ENABLE_BASIC_SANITIZERS)
   add_compile_options(-fsanitize=address,undefined)
@@ -71,6 +70,10 @@ set(OTURB_PRECISION "DOUBLE" CACHE STRING "Floating point precision SINGLE or DO
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_EXTENSIONS OFF)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
+if(OTURB_ENABLE_CUDA)
+else()
+  add_compile_options(-Wall -Wextra -Wshadow -Wnon-virtual-dtor -Wpedantic -Werror)
+endif()
 
 if(OTURB_ENABLE_CUDA)
   enable_language(CUDA)

--- a/src/gebt_poc/dynamic_beam_element.h
+++ b/src/gebt_poc/dynamic_beam_element.h
@@ -112,9 +112,9 @@ public:
                     }(team_member, delta_gen_coords_node);
                     team_member.team_barrier();
                     const auto psi_times_psi = [&](auto& member, ScratchView2D_3x3::const_type psi) {
-                        auto psi_times_psi = ScratchView2D_3x3(member.team_scratch(0));
-                        gemm::invoke(member, 1., psi, psi, 0., psi_times_psi);
-                        return psi_times_psi;
+                        auto psi_x_psi = ScratchView2D_3x3(member.team_scratch(0));
+                        gemm::invoke(member, 1., psi, psi, 0., psi_x_psi);
+                        return psi_x_psi;
                     }(team_member, psi_cross_prod_matrix);
                     const auto factor_1 = (1.0 - std::cos(phi)) / (phi * phi);
                     const auto factor_2 = (1.0 - std::sin(phi) / phi) / (phi * phi);

--- a/src/gebt_poc/static_beam_element.h
+++ b/src/gebt_poc/static_beam_element.h
@@ -57,54 +57,6 @@ public:
         using ScratchView2D_6x6 = Kokkos::View<double[6][6], scratch_space, unmanaged_memory>;
         using ScratchView2D_3x3 = Kokkos::View<double[3][3], scratch_space, unmanaged_memory>;
 
-        auto create_cross_product_matrix =
-            KOKKOS_LAMBDA(auto& member, ScratchView1D_Vector::const_type vector)
-                ->ScratchView2D_3x3::const_type {
-            auto output = ScratchView2D_3x3(member.team_scratch(0));
-            Kokkos::single(Kokkos::PerTeam(member), [&]() {
-                output(0, 0) = 0.;
-                output(0, 1) = -vector(2);
-                output(0, 2) = vector(1);
-                output(1, 0) = vector(2);
-                output(1, 1) = 0.;
-                output(1, 2) = -vector(0);
-                output(2, 0) = -vector(1);
-                output(2, 1) = vector(0);
-                output(2, 2) = 0.;
-            });
-            return output;
-        };
-
-        auto get_nodal_delta =
-            KOKKOS_LAMBDA(
-                auto& member, std::size_t node, double scale, LieAlgebraFieldView::const_type delta
-            )
-                ->ScratchView1D_Vector::const_type {
-            auto nodal_delta = ScratchView1D_Vector(member.team_scratch(0));
-            Kokkos::parallel_for(Kokkos::ThreadVectorRange(member, 3), [&](std::size_t i) {
-                nodal_delta(i) = delta(node, 3 + i) / scale;
-            });
-            return nodal_delta;
-        };
-
-        auto get_initial_operator = KOKKOS_LAMBDA(auto& member) {
-            auto initial_operator = ScratchView2D_6x6(member.team_scratch(0));
-            Kokkos::parallel_for(
-                Kokkos::ThreadVectorMDRange(member, 6, 6),
-                [&](std::size_t i, std::size_t j) {
-                    initial_operator(i, j) = i == j;
-                }
-            );
-            return initial_operator;
-        };
-
-        auto compute_psi_times_psi = KOKKOS_LAMBDA(auto& member, ScratchView2D_3x3::const_type psi)
-                                         ->ScratchView2D_3x3::const_type {
-            auto psi_times_psi = ScratchView2D_3x3(member.team_scratch(0));
-            gemm::invoke(member, 1., psi, psi, 0., psi_times_psi);
-            return psi_times_psi;
-        };
-
         const auto n_nodes = delta_gen_coords.extent(0);
         auto policy = Kokkos::TeamPolicy<>(n_nodes, Kokkos::AUTO(), Kokkos::AUTO());
         const auto scratch_size = ScratchView1D_Vector::shmem_size() +
@@ -115,12 +67,26 @@ public:
         Kokkos::deep_copy(tangent_operator, 0.0);
         Kokkos::parallel_for(
             policy,
-            KOKKOS_LAMBDA(const member_type& member) {
+            KOKKOS_LAMBDA(const Kokkos::TeamPolicy<>::member_type& member) {
                 const auto node = member.league_rank();
-                const auto delta_gen_coords_node =
-                    get_nodal_delta(member, node, h, delta_gen_coords);
-                const auto tangent_operator_node = get_initial_operator(member);
-
+                const auto delta_gen_coords_node = [&](auto& member
+                                                   ) -> ScratchView1D_Vector::const_type {
+                    auto nodal_delta = ScratchView1D_Vector(member.team_scratch(0));
+                    Kokkos::parallel_for(Kokkos::ThreadVectorRange(member, 3), [&](std::size_t i) {
+                        nodal_delta(i) = delta_gen_coords(node, 3 + i) / h;
+                    });
+                    return nodal_delta;
+                }(member);
+                const auto tangent_operator_node = [&](auto& member) {
+                    auto initial_operator = ScratchView2D_6x6(member.team_scratch(0));
+                    Kokkos::parallel_for(
+                        Kokkos::ThreadVectorMDRange(member, 6, 6),
+                        [&](std::size_t i, std::size_t j) {
+                            initial_operator(i, j) = i == j;
+                        }
+                    );
+                    return initial_operator;
+                }(member);
                 member.team_barrier();
                 const double phi = std::sqrt(
                     delta_gen_coords_node(0) * delta_gen_coords_node(0) +
@@ -128,10 +94,28 @@ public:
                     delta_gen_coords_node(2) * delta_gen_coords_node(2)
                 );
                 if (phi > Tolerance) {
-                    const auto psi_cross_prod_matrix =
-                        create_cross_product_matrix(member, delta_gen_coords_node);
+                    const auto psi_cross_prod_matrix = [&](auto& member,
+                                                           ScratchView1D_Vector::const_type vector) {
+                        auto output = ScratchView2D_3x3(member.team_scratch(0));
+                        Kokkos::single(Kokkos::PerTeam(member), [&]() {
+                            output(0, 0) = 0.;
+                            output(0, 1) = -vector(2);
+                            output(0, 2) = vector(1);
+                            output(1, 0) = vector(2);
+                            output(1, 1) = 0.;
+                            output(1, 2) = -vector(0);
+                            output(2, 0) = -vector(1);
+                            output(2, 1) = vector(0);
+                            output(2, 2) = 0.;
+                        });
+                        return output;
+                    }(member, delta_gen_coords_node);
                     member.team_barrier();
-                    const auto psi_times_psi = compute_psi_times_psi(member, psi_cross_prod_matrix);
+                    const auto psi_times_psi = [&](auto& member, ScratchView2D_3x3::const_type psi) {
+                        auto psi_times_psi = ScratchView2D_3x3(member.team_scratch(0));
+                        gemm::invoke(member, 1., psi, psi, 0., psi_times_psi);
+                        return psi_times_psi;
+                    }(member, psi_cross_prod_matrix);
                     const auto factor_1 = (std::cos(phi) - 1.0) / (phi * phi);
                     const auto factor_2 = (1.0 - std::sin(phi) / phi) / (phi * phi);
                     member.team_barrier();

--- a/src/gebt_poc/static_beam_element.h
+++ b/src/gebt_poc/static_beam_element.h
@@ -67,8 +67,8 @@ public:
         Kokkos::deep_copy(tangent_operator, 0.0);
         Kokkos::parallel_for(
             policy,
-            KOKKOS_LAMBDA(const Kokkos::TeamPolicy<>::member_type& member) {
-                const auto node = member.league_rank();
+            KOKKOS_LAMBDA(const Kokkos::TeamPolicy<>::member_type& team_member) {
+                const auto node = team_member.league_rank();
                 const auto delta_gen_coords_node = [&](auto& member
                                                    ) -> ScratchView1D_Vector::const_type {
                     auto nodal_delta = ScratchView1D_Vector(member.team_scratch(0));
@@ -76,7 +76,7 @@ public:
                         nodal_delta(i) = delta_gen_coords(node, 3 + i) / h;
                     });
                     return nodal_delta;
-                }(member);
+                }(team_member);
                 const auto tangent_operator_node = [&](auto& member) {
                     auto initial_operator = ScratchView2D_6x6(member.team_scratch(0));
                     Kokkos::parallel_for(
@@ -86,8 +86,8 @@ public:
                         }
                     );
                     return initial_operator;
-                }(member);
-                member.team_barrier();
+                }(team_member);
+                team_member.team_barrier();
                 const double phi = std::sqrt(
                     delta_gen_coords_node(0) * delta_gen_coords_node(0) +
                     delta_gen_coords_node(1) * delta_gen_coords_node(1) +
@@ -109,18 +109,18 @@ public:
                             output(2, 2) = 0.;
                         });
                         return output;
-                    }(member, delta_gen_coords_node);
-                    member.team_barrier();
+                    }(team_member, delta_gen_coords_node);
+                    team_member.team_barrier();
                     const auto psi_times_psi = [&](auto& member, ScratchView2D_3x3::const_type psi) {
                         auto psi_times_psi = ScratchView2D_3x3(member.team_scratch(0));
                         gemm::invoke(member, 1., psi, psi, 0., psi_times_psi);
                         return psi_times_psi;
-                    }(member, psi_cross_prod_matrix);
+                    }(team_member, psi_cross_prod_matrix);
                     const auto factor_1 = (std::cos(phi) - 1.0) / (phi * phi);
                     const auto factor_2 = (1.0 - std::sin(phi) / phi) / (phi * phi);
-                    member.team_barrier();
+                    team_member.team_barrier();
                     Kokkos::parallel_for(
-                        Kokkos::ThreadVectorMDRange(member, 3, 3),
+                        Kokkos::ThreadVectorMDRange(team_member, 3, 3),
                         [&](std::size_t i, std::size_t j) {
                             tangent_operator_node(3 + i, 3 + j) +=
                                 factor_1 * psi_cross_prod_matrix(i, j) +
@@ -129,9 +129,9 @@ public:
                     );
                 }
 
-                member.team_barrier();
+                team_member.team_barrier();
                 Kokkos::parallel_for(
-                    Kokkos::ThreadVectorMDRange(member, 6, 6),
+                    Kokkos::ThreadVectorMDRange(team_member, 6, 6),
                     [&](std::size_t i, std::size_t j) {
                         tangent_operator(node * 6 + i, node * 6 + j) = tangent_operator_node(i, j);
                     }

--- a/src/gebt_poc/static_beam_element.h
+++ b/src/gebt_poc/static_beam_element.h
@@ -112,9 +112,9 @@ public:
                     }(team_member, delta_gen_coords_node);
                     team_member.team_barrier();
                     const auto psi_times_psi = [&](auto& member, ScratchView2D_3x3::const_type psi) {
-                        auto psi_times_psi = ScratchView2D_3x3(member.team_scratch(0));
-                        gemm::invoke(member, 1., psi, psi, 0., psi_times_psi);
-                        return psi_times_psi;
+                        auto psi_x_psi = ScratchView2D_3x3(member.team_scratch(0));
+                        gemm::invoke(member, 1., psi, psi, 0., psi_x_psi);
+                        return psi_x_psi;
                     }(team_member, psi_cross_prod_matrix);
                     const auto factor_1 = (std::cos(phi) - 1.0) / (phi * phi);
                     const auto factor_2 = (1.0 - std::sin(phi) / phi) / (phi * phi);

--- a/src/restruct_poc/beams_methods.cpp
+++ b/src/restruct_poc/beams_methods.cpp
@@ -6,23 +6,38 @@
 
 namespace oturb {
 
+struct UpdateNodeState {
+    Kokkos::View<size_t*> node_state_indices;
+    View_Nx7 node_u;
+    View_Nx6 node_u_dot;
+    View_Nx6 node_u_ddot;
+
+    View_Nx7 Q;
+    View_Nx6 V;
+    View_Nx6 A;
+
+    KOKKOS_FUNCTION
+    void operator()(size_t i) const {
+        auto j = node_state_indices(i);
+        for (size_t k = 0; k < kLieGroupComponents; k++) {
+            node_u(i, k) = Q(j, k);
+        }
+        for (size_t k = 0; k < kLieAlgebraComponents; k++) {
+            node_u_dot(i, k) = V(j, k);
+        }
+        for (size_t k = 0; k < kLieAlgebraComponents; k++) {
+            node_u_ddot(i, k) = A(j, k);
+        }
+    }
+};
+
 // Update node states (displacement, velocity, acceleration) and interpolate to quadrature points
 void UpdateState(Beams& beams, View_Nx7 Q, View_Nx6 V, View_Nx6 A) {
     // Copy displacement, velocity, and acceleration to nodes
     Kokkos::parallel_for(
         "UpdateNodeState", beams.num_nodes,
-        KOKKOS_LAMBDA(size_t i) {
-            auto j = beams.node_state_indices(i);
-            for (size_t k = 0; k < kLieGroupComponents; k++) {
-                beams.node_u(i, k) = Q(j, k);
-            }
-            for (size_t k = 0; k < kLieAlgebraComponents; k++) {
-                beams.node_u_dot(i, k) = V(j, k);
-            }
-            for (size_t k = 0; k < kLieAlgebraComponents; k++) {
-                beams.node_u_ddot(i, k) = A(j, k);
-            }
-        }
+        UpdateNodeState{
+            beams.node_state_indices, beams.node_u, beams.node_u_dot, beams.node_u_ddot, Q, V, A}
     );
 
     // Interpolate node state to quadrature points
@@ -30,9 +45,19 @@ void UpdateState(Beams& beams, View_Nx7 Q, View_Nx6 V, View_Nx6 A) {
         "InterpolateQPState", beams.num_elems,
         InterpolateQPState{
             beams.elem_indices, beams.shape_interp, beams.shape_deriv, beams.qp_jacobian,
-            beams.node_u, beams.node_u_dot, beams.node_u_ddot, beams.qp_u, beams.qp_u_prime,
-            beams.qp_r, beams.qp_r_prime, beams.qp_u_dot, beams.qp_omega, beams.qp_u_ddot,
-            beams.qp_omega_dot}
+            beams.node_u, beams.qp_u, beams.qp_u_prime, beams.qp_r, beams.qp_r_prime}
+    );
+    Kokkos::parallel_for(
+        "InterpolateQPVelocity", beams.num_elems,
+        InterpolateQPVelocity{
+            beams.elem_indices, beams.shape_interp, beams.shape_deriv, beams.qp_jacobian,
+            beams.node_u_dot, beams.qp_u_dot, beams.qp_omega}
+    );
+    Kokkos::parallel_for(
+        "InterpolateQPAcceleration", beams.num_elems,
+        InterpolateQPAcceleration{
+            beams.elem_indices, beams.shape_interp, beams.shape_deriv, beams.qp_jacobian,
+            beams.node_u_ddot, beams.qp_u_ddot, beams.qp_omega_dot}
     );
 
     // Calculate RR0 matrix
@@ -74,15 +99,55 @@ void UpdateState(Beams& beams, View_Nx7 Q, View_Nx6 V, View_Nx6 A) {
 
     // Calculate Forces
     Kokkos::parallel_for(
-        "CalculateForces", beams.num_qps,
-        CalculateForcesAndMatrices{
-            beams.gravity,   beams.qp_Muu,   beams.qp_Cuu,       beams.qp_x0_prime, beams.qp_u_prime,
-            beams.qp_u_ddot, beams.qp_omega, beams.qp_omega_dot, beams.qp_strain,   beams.M1_3x3,
-            beams.M2_3x3,    beams.M3_3x3,   beams.M4_3x3,       beams.M5_3x3,      beams.M6_3x3,
-            beams.M7_3x3,    beams.V1_3,     beams.V2_3,         beams.V3_3,        beams.M8_3x3,
-            beams.M9_3x3,    beams.qp_Fc,    beams.qp_Fd,        beams.qp_Fi,       beams.qp_Fg,
-            beams.qp_Ouu,    beams.qp_Puu,   beams.qp_Quu,       beams.qp_Guu,      beams.qp_Kuu,
-        }
+        "CalculateMassMatrixComponents", beams.num_qps,
+        CalculateMassMatrixComponents{beams.qp_Muu, beams.V1_3, beams.M7_3x3, beams.M1_3x3}
+    );
+    Kokkos::parallel_for(
+        "CalculateTemporaryVariables", beams.num_qps,
+        CalculateTemporaryVariables{beams.qp_x0_prime, beams.qp_u_prime, beams.V2_3, beams.M4_3x3}
+    );
+    Kokkos::parallel_for(
+        "CalculateForceFC", beams.num_qps,
+        CalculateForceFC{beams.qp_Cuu, beams.qp_strain, beams.qp_Fc, beams.M5_3x3, beams.M6_3x3}
+    );
+    Kokkos::parallel_for(
+        "CalculateForceFD", beams.num_qps, CalculateForceFD{beams.M4_3x3, beams.qp_Fc, beams.qp_Fd}
+    );
+    Kokkos::parallel_for(
+        "CalculateInertialForces", beams.num_qps,
+        CalculateInertialForces{
+            beams.qp_Muu, beams.qp_u_ddot, beams.qp_omega, beams.qp_omega_dot, beams.M1_3x3,
+            beams.M2_3x3, beams.M3_3x3, beams.M7_3x3, beams.V1_3, beams.V2_3, beams.M8_3x3,
+            beams.qp_Fi}
+    );
+    Kokkos::parallel_for(
+        "CalculateGravityForce", beams.num_qps,
+        CalculateGravityForce{beams.gravity, beams.qp_Muu, beams.M1_3x3, beams.V2_3, beams.qp_Fg}
+    );
+    Kokkos::parallel_for(
+        "CalculateOuu", beams.num_qps,
+        CalculateOuu{beams.qp_Cuu, beams.M4_3x3, beams.M5_3x3, beams.M6_3x3, beams.qp_Ouu}
+    );
+    Kokkos::parallel_for(
+        "CalculatePuu", beams.num_qps,
+        CalculatePuu{beams.qp_Cuu, beams.M4_3x3, beams.M6_3x3, beams.qp_Puu}
+    );
+    Kokkos::parallel_for(
+        "CalculateQuu", beams.num_qps,
+        CalculateQuu{beams.qp_Cuu, beams.M4_3x3, beams.M6_3x3, beams.M8_3x3, beams.qp_Quu}
+    );
+    Kokkos::parallel_for(
+        "CalculateGyroscopicMatrix", beams.num_qps,
+        CalculateGyroscopicMatrix{
+            beams.qp_Muu, beams.qp_omega, beams.M2_3x3, beams.M7_3x3, beams.V1_3, beams.V2_3,
+            beams.V3_3, beams.M8_3x3, beams.qp_Guu}
+    );
+    Kokkos::parallel_for(
+        "CalculateInertiaStiffnessMatrix", beams.num_qps,
+        CalculateInertiaStiffnessMatrix{
+            beams.qp_Muu, beams.qp_u_ddot, beams.qp_omega, beams.qp_omega_dot, beams.M2_3x3,
+            beams.M3_3x3, beams.M7_3x3, beams.V1_3, beams.V2_3, beams.M8_3x3, beams.M9_3x3,
+            beams.qp_Kuu}
     );
 
     // Calculate nodal force vectors


### PR DESCRIPTION
The main programming issue was calling deep_copy() on GPU.  There was also an unknown linker issue related to our use of RDC.  Its nature is not fully understood, but can be fixed by using smaller kernels.

Linking still fails on solver.cpp, so this commit is just the first round of fixes.