### PR TITLE
Fixes CPU performance regression from latest GPU optimization.

### DIFF
--- a/src/restruct_poc/AssembleElasticStiffnessMatrix.hpp
+++ b/src/restruct_poc/AssembleElasticStiffnessMatrix.hpp
@@ -11,11 +11,16 @@ namespace openturbine {
 
 inline void AssembleElasticStiffnessMatrix(Beams& beams, View_NxN K) {
     auto region = Kokkos::Profiling::ScopedRegion("Assemble Elastic Stiffness Matrix");
+    auto range_policy = std::invoke([&]() {
+        if constexpr (std::is_same_v<Kokkos::DefaultExecutionSpace, Kokkos::DefaultHostExecutionSpace>) {
+            return Kokkos::MDRangePolicy{{0, 0, 0}, {beams.num_elems, beams.max_elem_nodes, beams.max_elem_nodes}};
+        }
+        else {
+            return Kokkos::MDRangePolicy{{0, 0, 0, 0}, {beams.num_elems, beams.max_elem_nodes, beams.max_elem_nodes, beams.max_elem_qps}};
+        }
+    }); 
     Kokkos::parallel_for(
-        "IntegrateElasticStiffnessMatrix",
-        Kokkos::MDRangePolicy{
-            {0, 0, 0, 0},
-            {beams.num_elems, beams.max_elem_nodes, beams.max_elem_nodes, beams.max_elem_qps}},
+        "IntegrateElasticStiffnessMatrix", range_policy,
         IntegrateElasticStiffnessMatrix{
             beams.elem_indices,
             beams.node_state_indices,

--- a/src/restruct_poc/AssembleGyroscopicInertiaMatrix.hpp
+++ b/src/restruct_poc/AssembleGyroscopicInertiaMatrix.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <type_traits>
+
 #include <Kokkos_Core.hpp>
 #include <Kokkos_Profiling_ScopedRegion.hpp>
 
@@ -9,11 +11,16 @@ namespace openturbine {
 
 inline void AssembleGyroscopicInertiaMatrix(Beams& beams, View_NxN G) {
     auto region = Kokkos::Profiling::ScopedRegion("Assemble Gyroscopic Inertia Matrix");
+    auto range_policy = std::invoke([&]() {
+        if constexpr (std::is_same_v<Kokkos::DefaultExecutionSpace, Kokkos::DefaultHostExecutionSpace>) {
+            return Kokkos::MDRangePolicy{{0, 0, 0}, {beams.num_elems, beams.max_elem_nodes, beams.max_elem_nodes}};
+        }
+        else {
+            return Kokkos::MDRangePolicy{{0, 0, 0, 0}, {beams.num_elems, beams.max_elem_nodes, beams.max_elem_nodes, beams.max_elem_qps}};
+        }
+    });
     Kokkos::parallel_for(
-        "IntegrateMatrix",
-        Kokkos::MDRangePolicy{
-            {0, 0, 0, 0},
-            {beams.num_elems, beams.max_elem_nodes, beams.max_elem_nodes, beams.max_elem_qps}},
+        "IntegrateMatrix", range_policy,
         IntegrateMatrix{
             beams.elem_indices,
             beams.node_state_indices,

--- a/src/restruct_poc/AssembleInertialStiffnessMatrix.hpp
+++ b/src/restruct_poc/AssembleInertialStiffnessMatrix.hpp
@@ -11,11 +11,16 @@ namespace openturbine {
 
 inline void AssembleInertialStiffnessMatrix(Beams& beams, View_NxN K) {
     auto region = Kokkos::Profiling::ScopedRegion("Assemble Inertial Stiffness Matrix");
+    auto range_policy = std::invoke([&]() {
+        if constexpr (std::is_same_v<Kokkos::DefaultExecutionSpace, Kokkos::DefaultHostExecutionSpace>) {
+            return Kokkos::MDRangePolicy{{0, 0, 0}, {beams.num_elems, beams.max_elem_nodes, beams.max_elem_nodes}};
+        }
+        else {
+            return Kokkos::MDRangePolicy{{0, 0, 0, 0}, {beams.num_elems, beams.max_elem_nodes, beams.max_elem_nodes, beams.max_elem_qps}};
+        }
+    }); 
     Kokkos::parallel_for(
-        "IntegrateMatrix",
-        Kokkos::MDRangePolicy{
-            {0, 0, 0, 0},
-            {beams.num_elems, beams.max_elem_nodes, beams.max_elem_nodes, beams.max_elem_qps}},
+        "IntegrateMatrix", range_policy,
         IntegrateMatrix{
             beams.elem_indices,
             beams.node_state_indices,

--- a/src/restruct_poc/IntegrateMatrix.hpp
+++ b/src/restruct_poc/IntegrateMatrix.hpp
@@ -86,6 +86,41 @@ struct IntegrateMatrix {
     }
 
     KOKKOS_FUNCTION
+    void operator()(const int i_elem, const int i_index, const int j_index) const {
+        const auto idx = elem_indices[i_elem];
+
+        if (i_index >= idx.num_nodes || j_index >= idx.num_nodes) {
+            return;
+        }
+
+        const auto i = i_index + idx.node_range.first;
+        const auto j = j_index + idx.node_range.first;
+        auto local_M_data = Kokkos::Array<double, 36>{};
+        auto local_M =
+            Kokkos::View<double[6][6], Kokkos::MemoryTraits<Kokkos::Unmanaged>>(local_M_data.data());
+        for(int k = 0; k < idx.num_qps; ++k) {
+            const auto k_qp = idx.qp_range.first + k;
+            const auto w = qp_weight_(k_qp);
+            const auto jacobian = qp_jacobian_(k_qp);
+            const auto phi_i = shape_interp_(i, k);
+            const auto phi_j = shape_interp_(j, k);
+            const auto coeff = w * phi_i * phi_j * jacobian;
+            for (int m = 0; m < kLieAlgebraComponents; ++m) {
+                for (int n = 0; n < kLieAlgebraComponents; ++n) {
+                    local_M(m, n) += coeff * qp_M_(k_qp, m, n);
+                }
+            }
+        }
+        const auto i_gbl_start = node_state_indices(i) * kLieAlgebraComponents;
+        const auto j_gbl_start = node_state_indices(j) * kLieAlgebraComponents;
+        for (int m = 0; m < kLieAlgebraComponents; ++m) {
+            for (int n = 0; n < kLieAlgebraComponents; ++n) {
+                gbl_M_(i_gbl_start + m, j_gbl_start + n) += local_M(m, n);
+            }
+        }
+    }
+
+    KOKKOS_FUNCTION
     void operator()(const int i_elem, const int i_index, const int j_index, const int k) const {
         const auto idx = elem_indices[i_elem];
 


### PR DESCRIPTION
This last update went a little far with parallization.  A switch has been added to use an implementation of the Integration routines which has less parallelism but also less duplication of work for CPU based runs.  The results is "The best of both worlds" with respect to performance on CPU and GPU.  