### PR TITLE
Fixes CI environment on MacOS

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,27 +12,27 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-13]
         compiler: [gcc-10, llvm]
         build_type: [Release, Debug]
         exclude: 
-          - os: macos-latest
+          - os: macos-13
             compiler: gcc-10
         include:
           - os: ubuntu-latest
             install_deps: sudo apt-get install gfortran libgtest-dev libblas-dev liblapack-dev liblapacke-dev
-          - os: macos-latest
+          - os: macos-13
             install_deps: brew install gfortran gcc googletest openblas lapack
     steps:
     - name: Setup Cpp
-      uses: aminya/setup-cpp@v1
+      uses: aminya/setup-cpp@v0.37.0
       with:
         compiler: ${{ matrix.compiler }}
         cmake: true
         ninja: true
-        clangtidy: true
-        cppcheck: true
-        ccache: true
+        clangtidy: ${{matrix.os != 'macos-latest' }}
+        cppcheck: ${{matrix.os != 'macos-latest' }}
+        ccache: ${{matrix.os != 'macos-latest' }}
     - name: Install dependencies
       run: |
         ${{matrix.install_deps}}
@@ -70,7 +70,7 @@ jobs:
         if [ ${{matrix.os}} = 'ubuntu-latest' ]; then
           git clone --depth 1 --branch develop https://github.com/kokkos/kokkos-kernels
         fi
-        if [ ${{matrix.os}} = 'macos-latest' ]; then
+        if [ ${{matrix.os}} = 'macos-13' ]; then
           export FC=gfortran-13
           git clone --depth 1 --branch develop https://github.com/kokkos/kokkos-kernels
         fi


### PR DESCRIPTION
This commit fixes CI failures when testing on MacOS-latest by pinning to MacOS-13.

MacOS-latest uses arm processors on GitHub.  The setup library we use does not seem to work on this latest hardware.  Also, the link stage for OpenTurbine fails in this case because some system libraries that it finds are x86 when it is building for the native arm.  Sticking to 13 and x86 will let us keep testing on Mac and improve our trust in CI.  Once MacOS-latest has become better supported, we can look at introducing it into our process.