### PR TITLE
Type aliases and other minor fixes

### DIFF
--- a/src/restruct_poc/beams/beam_section.hpp
+++ b/src/restruct_poc/beams/beam_section.hpp
@@ -11,10 +11,7 @@ struct BeamSection {
     Array_6x6 M_star;  // Mass matrix in material frame
     Array_6x6 C_star;  // Stiffness matrix in material frame
 
-    BeamSection(
-        double s, std::array<std::array<double, 6>, 6> mass,
-        std::array<std::array<double, 6>, 6> stiffness
-    )
+    BeamSection(double s, Array_6x6 mass, Array_6x6 stiffness)
         : s(s), M_star(std::move(mass)), C_star(std::move(stiffness)) {}
 };
 

--- a/src/restruct_poc/beams/beam_section.hpp
+++ b/src/restruct_poc/beams/beam_section.hpp
@@ -2,12 +2,14 @@
 
 #include <array>
 
+#include "src/restruct_poc/types.hpp"
+
 namespace openturbine {
 
 struct BeamSection {
-    double s;                                     // Position of section in element on range [0, 1]
-    std::array<std::array<double, 6>, 6> M_star;  // Mass matrix in material frame
-    std::array<std::array<double, 6>, 6> C_star;  // Stiffness matrix in material frame
+    double s;          // Position of section in element on range [0, 1]
+    Array_6x6 M_star;  // Mass matrix in material frame
+    Array_6x6 C_star;  // Stiffness matrix in material frame
 
     BeamSection(
         double s, std::array<std::array<double, 6>, 6> mass,

--- a/src/restruct_poc/beams/beams_input.hpp
+++ b/src/restruct_poc/beams/beams_input.hpp
@@ -18,7 +18,7 @@ struct BeamsInput {
     size_t NumElements() const { return elements.size(); };
 
     size_t NumNodes() const {
-        size_t num_nodes = 0;
+        size_t num_nodes{0};
         for (const auto& e : this->elements) {
             num_nodes += e.nodes.size();
         }
@@ -26,7 +26,7 @@ struct BeamsInput {
     }
 
     size_t NumQuadraturePoints() const {
-        size_t num_qps = 0;
+        size_t num_qps{0};
         for (const auto& e : this->elements) {
             num_qps += e.quadrature.size();
         }
@@ -34,7 +34,7 @@ struct BeamsInput {
     }
 
     size_t MaxElemNodes() const {
-        size_t max_elem_nodes = 0;
+        size_t max_elem_nodes{0};
         for (const auto& e : this->elements) {
             max_elem_nodes = std::max(max_elem_nodes, e.nodes.size());
         }
@@ -42,7 +42,7 @@ struct BeamsInput {
     }
 
     size_t MaxElemQuadraturePoints() const {
-        size_t max_elem_qps = 0;
+        size_t max_elem_qps{0};
         for (const auto& e : this->elements) {
             max_elem_qps = std::max(max_elem_qps, e.quadrature.size());
         }

--- a/src/restruct_poc/beams/set_node_state_indices.hpp
+++ b/src/restruct_poc/beams/set_node_state_indices.hpp
@@ -6,6 +6,7 @@ namespace openturbine {
 
 struct SetNodeStateIndices {
     Kokkos::View<int*> node_state_indices;
+
     KOKKOS_FUNCTION
     void operator()(int i) const { node_state_indices(i) = i; }
 };

--- a/src/restruct_poc/types.hpp
+++ b/src/restruct_poc/types.hpp
@@ -10,6 +10,7 @@ static constexpr int kVectorComponents = 3;
 
 static constexpr double kTolerance = 1.e-16;
 
+// Create some type aliases for Kokkos views to improve readability
 using View_3x3 = Kokkos::View<double[3][3]>;
 using View_3x4 = Kokkos::View<double[3][4]>;
 using View_6x6 = Kokkos::View<double[6][6]>;
@@ -27,6 +28,9 @@ using View_Nx7 = Kokkos::View<double* [7]>;
 using View_Nx3x4 = Kokkos::View<double* [3][4]>;
 using View_Nx3x3 = Kokkos::View<double* [3][3]>;
 using View_Nx6x6 = Kokkos::View<double* [6][6]>;
+
+// Define some type aliases for std::arrays to improve readability
+using Array_6x6 = std::array<std::array<double, 6>, 6>;
 
 // Atomic
 using View_NxN_atomic = Kokkos::View<double**, Kokkos::MemoryTraits<Kokkos::Atomic>>;

--- a/src/restruct_poc/types.hpp
+++ b/src/restruct_poc/types.hpp
@@ -4,36 +4,36 @@
 
 namespace openturbine {
 
-static constexpr int kLieAlgebraComponents = 6;
 static constexpr int kLieGroupComponents = 7;
+static constexpr int kLieAlgebraComponents = 6;
 static constexpr int kVectorComponents = 3;
 
 static constexpr double kTolerance = 1.e-16;
 
 // Create some type aliases for Kokkos views to improve readability
+// 1D views
+using View_3 = Kokkos::View<double[3]>;
+using View_Quaternion = Kokkos::View<double[4]>;
+using View_N = Kokkos::View<double*>;
+// 2D views
 using View_3x3 = Kokkos::View<double[3][3]>;
 using View_3x4 = Kokkos::View<double[3][4]>;
 using View_6x6 = Kokkos::View<double[6][6]>;
-
-using View_N = Kokkos::View<double*>;
-using View_3 = Kokkos::View<double[3]>;
-using View_Quaternion = Kokkos::View<double[4]>;
-
-using View_NxN = Kokkos::View<double**>;
 using View_Nx3 = Kokkos::View<double* [3]>;
 using View_Nx4 = Kokkos::View<double* [4]>;
 using View_Nx6 = Kokkos::View<double* [6]>;
 using View_Nx7 = Kokkos::View<double* [7]>;
-
-using View_Nx3x4 = Kokkos::View<double* [3][4]>;
+using View_NxN = Kokkos::View<double**>;
+// 3D views
 using View_Nx3x3 = Kokkos::View<double* [3][3]>;
+using View_Nx3x4 = Kokkos::View<double* [3][4]>;
 using View_Nx6x6 = Kokkos::View<double* [6][6]>;
 
-// Define some type aliases for std::arrays to improve readability
+// Define some type aliases for 2D std::arrays to improve readability
 using Array_6x6 = std::array<std::array<double, 6>, 6>;
 
 // Atomic
-using View_NxN_atomic = Kokkos::View<double**, Kokkos::MemoryTraits<Kokkos::Atomic>>;
 using View_N_atomic = Kokkos::View<double*, Kokkos::MemoryTraits<Kokkos::Atomic>>;
+using View_NxN_atomic = Kokkos::View<double**, Kokkos::MemoryTraits<Kokkos::Atomic>>;
 
 }  // namespace openturbine

--- a/src/restruct_poc/types.hpp
+++ b/src/restruct_poc/types.hpp
@@ -4,9 +4,9 @@
 
 namespace openturbine {
 
-static constexpr int kLieGroupComponents = 7;
-static constexpr int kLieAlgebraComponents = 6;
 static constexpr int kVectorComponents = 3;
+static constexpr int kLieAlgebraComponents = 6;
+static constexpr int kLieGroupComponents = 7;
 
 static constexpr double kTolerance = 1.e-16;
 


### PR DESCRIPTION
Some quick code quality related improvements. Specifically

- Additional type aliases introduced into `types.hpp` as well as reorganizing the file
- Use of braced initialization in the code as [preferred mode of initialization](https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#es23-prefer-the--initializer-syntax)