### PR TITLE
Use Sparse Matrix for AssembleSystem Function

### DIFF
--- a/src/restruct_poc/solver/assemble_system.hpp
+++ b/src/restruct_poc/solver/assemble_system.hpp
@@ -6,11 +6,11 @@
 #include <Kokkos_Core.hpp>
 #include <Kokkos_Profiling_ScopedRegion.hpp>
 
-#include "solver.hpp"
-#include "populate_sparse_indices.hpp"
-#include "populate_sparse_row_ptrs.hpp"
 #include "compute_number_of_non_zeros.hpp"
 #include "copy_into_sparse_matrix.hpp"
+#include "populate_sparse_indices.hpp"
+#include "populate_sparse_row_ptrs.hpp"
+#include "solver.hpp"
 
 #include "src/restruct_poc/beams/beams.hpp"
 #include "src/restruct_poc/system/assemble_elastic_stiffness_matrix.hpp"
@@ -25,7 +25,9 @@ namespace openturbine {
 template <typename Subview_NxN, typename Subview_N>
 void AssembleSystem(Solver& solver, Beams& beams, Subview_NxN St_11, Subview_N R_system) {
     auto region = Kokkos::Profiling::ScopedRegion("Assemble System");
-    using KernelHandle = typename KokkosKernels::Experimental::KokkosKernelsHandle<int, int, double, Kokkos::DefaultExecutionSpace, Kokkos::DefaultExecutionSpace::memory_space, Kokkos::DefaultExecutionSpace::memory_space>;
+    using KernelHandle = typename KokkosKernels::Experimental::KokkosKernelsHandle<
+        int, int, double, Kokkos::DefaultExecutionSpace, Kokkos::DefaultExecutionSpace::memory_space,
+        Kokkos::DefaultExecutionSpace::memory_space>;
     KernelHandle kh;
     kh.create_spgemm_handle();
     kh.create_spadd_handle();
@@ -50,14 +52,25 @@ void AssembleSystem(Solver& solver, Beams& beams, Subview_NxN St_11, Subview_N R
     auto num_rows = solver.K.extent(0);
     auto num_columns = solver.K.extent(1);
     auto num_non_zero = 0;
-    Kokkos::parallel_reduce("ComputeNumberOfNonZeros", beams.num_elems, ComputeNumberOfNonZeros{beams.elem_indices}, num_non_zero);
+    Kokkos::parallel_reduce(
+        "ComputeNumberOfNonZeros", beams.num_elems, ComputeNumberOfNonZeros{beams.elem_indices},
+        num_non_zero
+    );
 
-    auto row_ptrs = Kokkos::View<int*>("row_ptrs", num_rows+1);
+    auto row_ptrs = Kokkos::View<int*>("row_ptrs", num_rows + 1);
     auto indices = Kokkos::View<int*>("indices", num_non_zero);
-    Kokkos::parallel_for("PopulateSparseRowPtrs", 1, PopulateSparseRowPtrs{beams.elem_indices, row_ptrs});
-    Kokkos::parallel_for("PopulateSparseIndices", 1, PopulateSparseIndices{beams.elem_indices, beams.node_state_indices, indices});
+    Kokkos::parallel_for(
+        "PopulateSparseRowPtrs", 1, PopulateSparseRowPtrs{beams.elem_indices, row_ptrs}
+    );
+    Kokkos::parallel_for(
+        "PopulateSparseIndices", 1,
+        PopulateSparseIndices{beams.elem_indices, beams.node_state_indices, indices}
+    );
 
-    using crs_matrix_type = KokkosSparse::CrsMatrix<double, int, Kokkos::Device<Kokkos::DefaultExecutionSpace, Kokkos::DefaultExecutionSpace::memory_space>, void, int>;
+    using crs_matrix_type = KokkosSparse::CrsMatrix<
+        double, int,
+        Kokkos::Device<Kokkos::DefaultExecutionSpace, Kokkos::DefaultExecutionSpace::memory_space>,
+        void, int>;
     Kokkos::fence();
     auto K_values = Kokkos::View<double*>("K values", num_non_zero);
     auto K = crs_matrix_type("K", num_rows, num_columns, num_non_zero, K_values, row_ptrs, indices);
@@ -69,8 +82,12 @@ void AssembleSystem(Solver& solver, Beams& beams, Subview_NxN St_11, Subview_N R
     auto sparse_matrix_policy = Kokkos::TeamPolicy<>(num_rows, Kokkos::AUTO());
     sparse_matrix_policy.set_scratch_size(1, Kokkos::PerTeam(row_data_size + col_idx_size));
 
-    Kokkos::parallel_for("CopyIntoSparseMatrix", sparse_matrix_policy, CopyIntoSparseMatrix{K, solver.K});
-    Kokkos::parallel_for("CopyIntoSparseMatrix", sparse_matrix_policy, CopyIntoSparseMatrix{T, solver.T});
+    Kokkos::parallel_for(
+        "CopyIntoSparseMatrix", sparse_matrix_policy, CopyIntoSparseMatrix{K, solver.K}
+    );
+    Kokkos::parallel_for(
+        "CopyIntoSparseMatrix", sparse_matrix_policy, CopyIntoSparseMatrix{T, solver.T}
+    );
 
     Kokkos::fence();
     crs_matrix_type static_system_matrix;
@@ -82,7 +99,9 @@ void AssembleSystem(Solver& solver, Beams& beams, Subview_NxN St_11, Subview_N R
     Kokkos::deep_copy(solver.K, 0.);
     AssembleMassMatrix(beams, beta_prime, solver.K);
     AssembleGyroscopicInertiaMatrix(beams, gamma_prime, solver.K);
-    Kokkos::parallel_for("CopyIntoSparseMatrix", sparse_matrix_policy, CopyIntoSparseMatrix{K, solver.K});
+    Kokkos::parallel_for(
+        "CopyIntoSparseMatrix", sparse_matrix_policy, CopyIntoSparseMatrix{K, solver.K}
+    );
 
     Kokkos::fence();
     crs_matrix_type system_matrix;
@@ -91,15 +110,18 @@ void AssembleSystem(Solver& solver, Beams& beams, Subview_NxN St_11, Subview_N R
 
     Kokkos::deep_copy(St_11, 0.);
     Kokkos::fence();
-    Kokkos::parallel_for("Copy into St_11", sparse_matrix_policy, KOKKOS_LAMBDA(Kokkos::TeamPolicy<>::member_type member) {
-        auto i = member.league_rank();
-        auto row = system_matrix.row(i);
-        auto row_map = system_matrix.graph.row_map;
-        auto cols = system_matrix.graph.entries;
-        Kokkos::parallel_for(Kokkos::TeamThreadRange(member, row.length), [=](int entry) {
-            St_11(i, cols(row_map(i) + entry)) = row.value(entry);
-        });
-    });   
+    Kokkos::parallel_for(
+        "Copy into St_11", sparse_matrix_policy,
+        KOKKOS_LAMBDA(Kokkos::TeamPolicy<>::member_type member) {
+            auto i = member.league_rank();
+            auto row = system_matrix.row(i);
+            auto row_map = system_matrix.graph.row_map;
+            auto cols = system_matrix.graph.entries;
+            Kokkos::parallel_for(Kokkos::TeamThreadRange(member, row.length), [=](int entry) {
+                St_11(i, cols(row_map(i) + entry)) = row.value(entry);
+            });
+        }
+    );
 }
 
 }  // namespace openturbine

--- a/src/restruct_poc/solver/assemble_system.hpp
+++ b/src/restruct_poc/solver/assemble_system.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <KokkosBlas.hpp>
+#include <KokkosSparse.hpp>
 #include <Kokkos_Core.hpp>
 #include <Kokkos_Profiling_ScopedRegion.hpp>
 
@@ -36,7 +37,95 @@ void AssembleSystem(Solver& solver, Beams& beams, Subview_NxN St_11, Subview_N R
     AssembleElasticStiffnessMatrix(beams, solver.K);
     AssembleInertialStiffnessMatrix(beams, solver.K);
 
-    KokkosBlas::gemm("N", "N", 1.0, solver.K, solver.T, 0.0, St_11);
+    auto num_rows = solver.K.extent(0);
+    auto num_columns = solver.K.extent(1);
+    auto num_non_zero = (beams.max_elem_nodes * 6) * (beams.max_elem_nodes * 6) * beams.num_elems; //make this a reduction
+    auto row_ptrs = Kokkos::View<int*>("row_ptrs", num_rows+1);
+    auto indices = Kokkos::View<int*>("indices", num_non_zero);
+    auto K_values = Kokkos::View<double*>("K values", num_non_zero);
+    auto T_values = Kokkos::View<double*>("T values", num_non_zero);
+    Kokkos::parallel_for(1, KOKKOS_LAMBDA(int) {
+      auto rows_so_far = 0;
+      for(int i_elem = 0; i_elem < beams.num_elems; ++i_elem) {
+        auto elem_indices = beams.elem_indices;
+        auto idx = elem_indices[i_elem];
+        auto num_nodes = idx.num_nodes;
+        for(int i = 0; i < num_nodes*kLieAlgebraComponents; ++i) {
+            row_ptrs(rows_so_far + 1) = row_ptrs(rows_so_far) + num_nodes * kLieAlgebraComponents;
+            ++rows_so_far;
+        }
+        
+      }
+    });
+    Kokkos::parallel_for(1, KOKKOS_LAMBDA(int) {
+      auto entries_so_far = 0;
+      for(int i_elem = 0; i_elem < beams.num_elems; ++i_elem) {
+        auto node_state_indices = beams.node_state_indices;
+        auto elem_indices = beams.elem_indices;
+        auto idx = elem_indices[i_elem];
+        auto num_nodes = idx.num_nodes;
+        for(int j_index = 0; j_index < num_nodes; ++j_index) {
+          for(int n = 0; n < kLieAlgebraComponents; ++n) {
+            for(int i_index = 0; i_index < num_nodes; ++i_index) {
+              const auto i = i_index + idx.node_range.first;
+              const auto column_start = node_state_indices(i)*kLieAlgebraComponents;
+              for(int m = 0; m < kLieAlgebraComponents; ++m) {
+                  indices(entries_so_far) = column_start + m;
+                  ++entries_so_far;
+              }
+            }
+          }
+        }
+      }
+    });
+
+    using crs_matrix_type = KokkosSparse::CrsMatrix<double, int, Kokkos::Device<Kokkos::Cuda, Kokkos::CudaSpace>, void, int>;
+    auto K = crs_matrix_type("K", num_rows, num_columns, num_non_zero, K_values, row_ptrs, indices);
+    auto T = crs_matrix_type("T", num_rows, num_columns, num_non_zero, T_values, row_ptrs, indices);
+
+    auto sk = solver.K;
+    auto row_data = Kokkos::View<double*>("row_data", num_columns);
+    auto col_idx = Kokkos::View<int*>("row_data", num_columns);
+    Kokkos::parallel_for(1, KOKKOS_LAMBDA(int) {
+        for(int i = 0; i < num_rows; ++i) {
+            auto row = K.row(i);
+            auto row_map = K.graph.row_map;
+            auto cols = K.graph.entries;
+            for(int entry = 0; entry < row.length; ++entry) {
+                col_idx(entry) = cols(row_map(i) + entry);
+                row_data(entry) = sk(i, col_idx(entry));
+            }
+            K.replaceValues(i, col_idx.data(), row.length, row_data.data());
+        }
+    });
+    
+    auto st = solver.T;
+    Kokkos::parallel_for(1, KOKKOS_LAMBDA(int) {
+        for(int i = 0; i < num_rows; ++i) {
+            auto row = T.row(i);
+            auto row_map = T.graph.row_map;
+            auto cols = T.graph.entries;
+            for(int entry = 0; entry < row.length; ++entry) {
+                col_idx(entry) = cols(row_map(i) + entry);
+                row_data(entry) = st(i, col_idx(entry));
+            }
+            T.replaceValues(i, col_idx.data(), row.length, row_data.data());
+        }
+    });
+
+    Kokkos::deep_copy(St_11, 0.);
+    
+    crs_matrix_type local_St_11 = KokkosSparse::spgemm<crs_matrix_type>(K, false, T, false);
+    Kokkos::parallel_for(1, KOKKOS_LAMBDA(int) {
+        for(int i = 0; i < num_rows; ++i) {
+            auto row = local_St_11.row(i);
+            auto row_map = local_St_11.graph.row_map;
+            auto cols = local_St_11.graph.entries;
+            for(int entry = 0; entry < row.length; ++entry) {
+                St_11(i, cols(row_map(i) + entry)) = row.value(entry);
+            }
+        }
+    });   
 
     if (solver.is_dynamic_solve) {
         Kokkos::deep_copy(solver.K, 0.);

--- a/src/restruct_poc/solver/assemble_system.hpp
+++ b/src/restruct_poc/solver/assemble_system.hpp
@@ -44,7 +44,7 @@ void AssembleSystem(Solver& solver, Beams& beams, Subview_NxN St_11, Subview_N R
     auto indices = Kokkos::View<int*>("indices", num_non_zero);
     auto K_values = Kokkos::View<double*>("K values", num_non_zero);
     auto T_values = Kokkos::View<double*>("T values", num_non_zero);
-    Kokkos::parallel_for(1, KOKKOS_LAMBDA(int) {
+    Kokkos::parallel_for("Populate Sparse Row Ptrs", 1, KOKKOS_LAMBDA(int) {
       auto rows_so_far = 0;
       for(int i_elem = 0; i_elem < beams.num_elems; ++i_elem) {
         auto elem_indices = beams.elem_indices;
@@ -57,7 +57,7 @@ void AssembleSystem(Solver& solver, Beams& beams, Subview_NxN St_11, Subview_N R
         
       }
     });
-    Kokkos::parallel_for(1, KOKKOS_LAMBDA(int) {
+    Kokkos::parallel_for("Populate Sparse Indices", 1, KOKKOS_LAMBDA(int) {
       auto entries_so_far = 0;
       for(int i_elem = 0; i_elem < beams.num_elems; ++i_elem) {
         auto node_state_indices = beams.node_state_indices;
@@ -84,47 +84,57 @@ void AssembleSystem(Solver& solver, Beams& beams, Subview_NxN St_11, Subview_N R
     auto T = crs_matrix_type("T", num_rows, num_columns, num_non_zero, T_values, row_ptrs, indices);
 
     auto sk = solver.K;
-    auto row_data = Kokkos::View<double*>("row_data", num_columns);
-    auto col_idx = Kokkos::View<int*>("row_data", num_columns);
-    Kokkos::parallel_for(1, KOKKOS_LAMBDA(int) {
-        for(int i = 0; i < num_rows; ++i) {
-            auto row = K.row(i);
-            auto row_map = K.graph.row_map;
-            auto cols = K.graph.entries;
-            for(int entry = 0; entry < row.length; ++entry) {
-                col_idx(entry) = cols(row_map(i) + entry);
-                row_data(entry) = sk(i, col_idx(entry));
-            }
+
+    auto row_data_size = Kokkos::View<double*>::shmem_size(num_columns);
+    auto col_idx_size = Kokkos::View<int*>::shmem_size(num_columns);
+    auto sparse_matrix_policy = Kokkos::TeamPolicy<>(num_rows, Kokkos::AUTO());
+    sparse_matrix_policy.set_scratch_size(1, Kokkos::PerTeam(row_data_size + col_idx_size));
+    Kokkos::parallel_for("Copy into Sparse Matrix", sparse_matrix_policy, KOKKOS_LAMBDA(Kokkos::TeamPolicy<>::member_type member) {
+        auto i = member.league_rank();
+        auto row = K.row(i);
+        auto row_map = K.graph.row_map;
+        auto cols = K.graph.entries;
+        auto row_data = Kokkos::View<double*, Kokkos::DefaultExecutionSpace::scratch_memory_space, Kokkos::MemoryTraits<Kokkos::Unmanaged>>(member.team_scratch(1), num_columns);
+        auto col_idx = Kokkos::View<int*, Kokkos::DefaultExecutionSpace::scratch_memory_space, Kokkos::MemoryTraits<Kokkos::Unmanaged>>(member.team_scratch(1), num_columns);
+        Kokkos::parallel_for(Kokkos::TeamThreadRange(member, row.length), [=](int entry) {
+            col_idx(entry) = cols(row_map(i) + entry);
+            row_data(entry) = sk(i, col_idx(entry));
+        });
+        member.team_barrier();
+        Kokkos::single(Kokkos::PerTeam(member), [=](){
             K.replaceValues(i, col_idx.data(), row.length, row_data.data());
-        }
+        });
     });
     
     auto st = solver.T;
-    Kokkos::parallel_for(1, KOKKOS_LAMBDA(int) {
-        for(int i = 0; i < num_rows; ++i) {
-            auto row = T.row(i);
-            auto row_map = T.graph.row_map;
-            auto cols = T.graph.entries;
-            for(int entry = 0; entry < row.length; ++entry) {
-                col_idx(entry) = cols(row_map(i) + entry);
-                row_data(entry) = st(i, col_idx(entry));
-            }
+    Kokkos::parallel_for("Copy into Sparse Matrix", sparse_matrix_policy, KOKKOS_LAMBDA(Kokkos::TeamPolicy<>::member_type member) {
+        auto i = member.league_rank();
+        auto row = T.row(i);
+        auto row_map = T.graph.row_map;
+        auto cols = T.graph.entries;
+        auto row_data = Kokkos::View<double*, Kokkos::DefaultExecutionSpace::scratch_memory_space, Kokkos::MemoryTraits<Kokkos::Unmanaged>>(member.team_scratch(1), num_columns);
+        auto col_idx = Kokkos::View<int*, Kokkos::DefaultExecutionSpace::scratch_memory_space, Kokkos::MemoryTraits<Kokkos::Unmanaged>>(member.team_scratch(1), num_columns);
+        Kokkos::parallel_for(Kokkos::TeamThreadRange(member, row.length), [=](int entry) {
+            col_idx(entry) = cols(row_map(i) + entry);
+            row_data(entry) = st(i, col_idx(entry));
+        });
+        member.team_barrier();
+        Kokkos::single(Kokkos::PerTeam(member), [=](){
             T.replaceValues(i, col_idx.data(), row.length, row_data.data());
-        }
+        });
     });
 
     Kokkos::deep_copy(St_11, 0.);
     
     crs_matrix_type local_St_11 = KokkosSparse::spgemm<crs_matrix_type>(K, false, T, false);
-    Kokkos::parallel_for(1, KOKKOS_LAMBDA(int) {
-        for(int i = 0; i < num_rows; ++i) {
-            auto row = local_St_11.row(i);
-            auto row_map = local_St_11.graph.row_map;
-            auto cols = local_St_11.graph.entries;
-            for(int entry = 0; entry < row.length; ++entry) {
-                St_11(i, cols(row_map(i) + entry)) = row.value(entry);
-            }
-        }
+    Kokkos::parallel_for("Copy into St_11", sparse_matrix_policy, KOKKOS_LAMBDA(Kokkos::TeamPolicy<>::member_type member) {
+        auto i = member.league_rank();
+        auto row = local_St_11.row(i);
+        auto row_map = local_St_11.graph.row_map;
+        auto cols = local_St_11.graph.entries;
+        Kokkos::parallel_for(Kokkos::TeamThreadRange(member, row.length), [=](int entry) {
+            St_11(i, cols(row_map(i) + entry)) = row.value(entry);
+        });
     });   
 
     if (solver.is_dynamic_solve) {

--- a/src/restruct_poc/solver/assemble_system.hpp
+++ b/src/restruct_poc/solver/assemble_system.hpp
@@ -2,6 +2,7 @@
 
 #include <KokkosBlas.hpp>
 #include <KokkosSparse.hpp>
+#include <KokkosSparse_spadd.hpp>
 #include <Kokkos_Core.hpp>
 #include <Kokkos_Profiling_ScopedRegion.hpp>
 
@@ -17,9 +18,100 @@
 
 namespace openturbine {
 
+struct CopyIntoSparseMatrix {
+    using crs_matrix_type = KokkosSparse::CrsMatrix<double, int, Kokkos::Device<Kokkos::DefaultExecutionSpace, Kokkos::DefaultExecutionSpace::memory_space>, void, int>;
+    using row_data_type = Kokkos::View<double*, Kokkos::DefaultExecutionSpace::scratch_memory_space, Kokkos::MemoryTraits<Kokkos::Unmanaged>>;
+    using col_idx_type = Kokkos::View<int*, Kokkos::DefaultExecutionSpace::scratch_memory_space, Kokkos::MemoryTraits<Kokkos::Unmanaged>>;
+    crs_matrix_type sparse;
+    Kokkos::View<const double**> dense;
+
+    KOKKOS_FUNCTION
+    void operator()(Kokkos::TeamPolicy<>::member_type member) const {
+        auto i = member.league_rank();
+        auto row = sparse.row(i);
+        auto row_map = sparse.graph.row_map;
+        auto cols = sparse.graph.entries;
+        auto row_data = row_data_type(member.team_scratch(1), row.length);
+        auto col_idx = col_idx_type(member.team_scratch(1), row.length);
+        Kokkos::parallel_for(Kokkos::TeamThreadRange(member, row.length), [=](int entry) {
+            col_idx(entry) = cols(row_map(i) + entry);
+            row_data(entry) = dense(i, col_idx(entry));
+        });
+        member.team_barrier();
+        Kokkos::single(Kokkos::PerTeam(member), [=](){
+            sparse.replaceValues(i, col_idx.data(), row.length, row_data.data());
+        });
+    }
+};
+
+struct ComputeNumberOfNonZeros {
+    Kokkos::View<Beams::ElemIndices*>::const_type elem_indices;
+    
+    KOKKOS_FUNCTION
+    void operator()(int i_elem, int& update) const {
+        auto idx = elem_indices[i_elem];
+        auto num_nodes = idx.num_nodes;
+        update += (num_nodes*6) * (num_nodes*6);
+    }
+};
+
+struct PopulateSparseRowPtrs {
+    Kokkos::View<Beams::ElemIndices*>::const_type elem_indices;
+    Kokkos::View<int*> row_ptrs;
+
+    KOKKOS_FUNCTION
+    void operator()(int) const {
+      const auto num_elems = elem_indices.extent(0);
+      auto rows_so_far = 0;
+      for(int i_elem = 0; i_elem < num_elems; ++i_elem) {
+        auto idx = elem_indices[i_elem];
+        auto num_nodes = idx.num_nodes;
+        for(int i = 0; i < num_nodes*kLieAlgebraComponents; ++i) {
+            row_ptrs(rows_so_far + 1) = row_ptrs(rows_so_far) + num_nodes * kLieAlgebraComponents;
+            ++rows_so_far;
+        }
+        
+      }
+    }
+};
+
+struct PopulateSparseIndices {
+    Kokkos::View<Beams::ElemIndices*>::const_type elem_indices;
+    Kokkos::View<int*>::const_type node_state_indices;    
+    Kokkos::View<int*> indices;
+
+    KOKKOS_FUNCTION
+    void operator()(int) const {
+      const auto num_elems = elem_indices.extent(0);
+      auto entries_so_far = 0;
+      for(int i_elem = 0; i_elem < num_elems; ++i_elem) {
+        auto idx = elem_indices[i_elem];
+        auto num_nodes = idx.num_nodes;
+        for(int j_index = 0; j_index < num_nodes; ++j_index) {
+          for(int n = 0; n < kLieAlgebraComponents; ++n) {
+            for(int i_index = 0; i_index < num_nodes; ++i_index) {
+              const auto i = i_index + idx.node_range.first;
+              const auto column_start = node_state_indices(i)*kLieAlgebraComponents;
+              for(int m = 0; m < kLieAlgebraComponents; ++m) {
+                  indices(entries_so_far) = column_start + m;
+                  ++entries_so_far;
+              }
+            }
+          }
+        }
+      }
+    }
+
+};
+
 template <typename Subview_NxN, typename Subview_N>
 void AssembleSystem(Solver& solver, Beams& beams, Subview_NxN St_11, Subview_N R_system) {
     auto region = Kokkos::Profiling::ScopedRegion("Assemble System");
+    using KernelHandle = typename KokkosKernels::Experimental::KokkosKernelsHandle<int, int, double, Kokkos::DefaultExecutionSpace, Kokkos::DefaultExecutionSpace::memory_space, Kokkos::DefaultExecutionSpace::memory_space>;
+    KernelHandle kh;
+    kh.create_spgemm_handle();
+    kh.create_spadd_handle();
+
     Kokkos::deep_copy(solver.T, 0.);
     Kokkos::parallel_for(
         "TangentOperator", solver.num_system_nodes,
@@ -40,116 +132,56 @@ void AssembleSystem(Solver& solver, Beams& beams, Subview_NxN St_11, Subview_N R
     auto num_rows = solver.K.extent(0);
     auto num_columns = solver.K.extent(1);
     auto num_non_zero = 0;
-    Kokkos::parallel_reduce("compute number of non-zeros", beams.num_elems, KOKKOS_LAMBDA(int i_elem, int& update) {
-        auto elem_indices = beams.elem_indices;
-        auto idx = elem_indices[i_elem];
-        auto num_nodes = idx.num_nodes;
-        update += (num_nodes*6) * (num_nodes*6);
-    }, num_non_zero);
+    Kokkos::parallel_reduce("ComputeNumberOfNonZeros", beams.num_elems, ComputeNumberOfNonZeros{beams.elem_indices}, num_non_zero);
 
     auto row_ptrs = Kokkos::View<int*>("row_ptrs", num_rows+1);
     auto indices = Kokkos::View<int*>("indices", num_non_zero);
+    Kokkos::parallel_for("PopulateSparseRowPtrs", 1, PopulateSparseRowPtrs{beams.elem_indices, row_ptrs});
+    Kokkos::parallel_for("Populate Sparse Indices", 1, PopulateSparseIndices{beams.elem_indices, beams.node_state_indices, indices});
+
+    using crs_matrix_type = KokkosSparse::CrsMatrix<double, int, Kokkos::Device<Kokkos::DefaultExecutionSpace, Kokkos::DefaultExecutionSpace::memory_space>, void, int>;
+    Kokkos::fence();
     auto K_values = Kokkos::View<double*>("K values", num_non_zero);
-    auto T_values = Kokkos::View<double*>("T values", num_non_zero);
-    Kokkos::parallel_for("Populate Sparse Row Ptrs", 1, KOKKOS_LAMBDA(int) {
-      auto rows_so_far = 0;
-      for(int i_elem = 0; i_elem < beams.num_elems; ++i_elem) {
-        auto elem_indices = beams.elem_indices;
-        auto idx = elem_indices[i_elem];
-        auto num_nodes = idx.num_nodes;
-        for(int i = 0; i < num_nodes*kLieAlgebraComponents; ++i) {
-            row_ptrs(rows_so_far + 1) = row_ptrs(rows_so_far) + num_nodes * kLieAlgebraComponents;
-            ++rows_so_far;
-        }
-        
-      }
-    });
-    Kokkos::parallel_for("Populate Sparse Indices", 1, KOKKOS_LAMBDA(int) {
-      auto entries_so_far = 0;
-      for(int i_elem = 0; i_elem < beams.num_elems; ++i_elem) {
-        auto node_state_indices = beams.node_state_indices;
-        auto elem_indices = beams.elem_indices;
-        auto idx = elem_indices[i_elem];
-        auto num_nodes = idx.num_nodes;
-        for(int j_index = 0; j_index < num_nodes; ++j_index) {
-          for(int n = 0; n < kLieAlgebraComponents; ++n) {
-            for(int i_index = 0; i_index < num_nodes; ++i_index) {
-              const auto i = i_index + idx.node_range.first;
-              const auto column_start = node_state_indices(i)*kLieAlgebraComponents;
-              for(int m = 0; m < kLieAlgebraComponents; ++m) {
-                  indices(entries_so_far) = column_start + m;
-                  ++entries_so_far;
-              }
-            }
-          }
-        }
-      }
-    });
-
-    using crs_matrix_type = KokkosSparse::CrsMatrix<double, int, Kokkos::Device<Kokkos::Cuda, Kokkos::CudaSpace>, void, int>;
     auto K = crs_matrix_type("K", num_rows, num_columns, num_non_zero, K_values, row_ptrs, indices);
+    auto T_values = Kokkos::View<double*>("T values", num_non_zero);
     auto T = crs_matrix_type("T", num_rows, num_columns, num_non_zero, T_values, row_ptrs, indices);
-
-    auto sk = solver.K;
 
     auto row_data_size = Kokkos::View<double*>::shmem_size(num_columns);
     auto col_idx_size = Kokkos::View<int*>::shmem_size(num_columns);
     auto sparse_matrix_policy = Kokkos::TeamPolicy<>(num_rows, Kokkos::AUTO());
     sparse_matrix_policy.set_scratch_size(1, Kokkos::PerTeam(row_data_size + col_idx_size));
-    Kokkos::parallel_for("Copy into Sparse Matrix", sparse_matrix_policy, KOKKOS_LAMBDA(Kokkos::TeamPolicy<>::member_type member) {
-        auto i = member.league_rank();
-        auto row = K.row(i);
-        auto row_map = K.graph.row_map;
-        auto cols = K.graph.entries;
-        auto row_data = Kokkos::View<double*, Kokkos::DefaultExecutionSpace::scratch_memory_space, Kokkos::MemoryTraits<Kokkos::Unmanaged>>(member.team_scratch(1), num_columns);
-        auto col_idx = Kokkos::View<int*, Kokkos::DefaultExecutionSpace::scratch_memory_space, Kokkos::MemoryTraits<Kokkos::Unmanaged>>(member.team_scratch(1), num_columns);
-        Kokkos::parallel_for(Kokkos::TeamThreadRange(member, row.length), [=](int entry) {
-            col_idx(entry) = cols(row_map(i) + entry);
-            row_data(entry) = sk(i, col_idx(entry));
-        });
-        member.team_barrier();
-        Kokkos::single(Kokkos::PerTeam(member), [=](){
-            K.replaceValues(i, col_idx.data(), row.length, row_data.data());
-        });
-    });
-    
-    auto st = solver.T;
-    Kokkos::parallel_for("Copy into Sparse Matrix", sparse_matrix_policy, KOKKOS_LAMBDA(Kokkos::TeamPolicy<>::member_type member) {
-        auto i = member.league_rank();
-        auto row = T.row(i);
-        auto row_map = T.graph.row_map;
-        auto cols = T.graph.entries;
-        auto row_data = Kokkos::View<double*, Kokkos::DefaultExecutionSpace::scratch_memory_space, Kokkos::MemoryTraits<Kokkos::Unmanaged>>(member.team_scratch(1), num_columns);
-        auto col_idx = Kokkos::View<int*, Kokkos::DefaultExecutionSpace::scratch_memory_space, Kokkos::MemoryTraits<Kokkos::Unmanaged>>(member.team_scratch(1), num_columns);
-        Kokkos::parallel_for(Kokkos::TeamThreadRange(member, row.length), [=](int entry) {
-            col_idx(entry) = cols(row_map(i) + entry);
-            row_data(entry) = st(i, col_idx(entry));
-        });
-        member.team_barrier();
-        Kokkos::single(Kokkos::PerTeam(member), [=](){
-            T.replaceValues(i, col_idx.data(), row.length, row_data.data());
-        });
-    });
+
+    Kokkos::parallel_for("Copy into Sparse Matrix", sparse_matrix_policy, CopyIntoSparseMatrix{K, solver.K});
+    Kokkos::parallel_for("Copy into Sparse Matrix", sparse_matrix_policy, CopyIntoSparseMatrix{T, solver.T});
+
+    Kokkos::fence();
+    crs_matrix_type static_system_matrix;
+    KokkosSparse::spgemm_symbolic(kh, K, false, T, false, static_system_matrix);
+    KokkosSparse::spgemm_numeric(kh, K, false, T, false, static_system_matrix);
+
+    auto beta_prime = (solver.is_dynamic_solve) ? solver.beta_prime : 0.;
+    auto gamma_prime = (solver.is_dynamic_solve) ? solver.gamma_prime : 0.;
+    Kokkos::deep_copy(solver.K, 0.);
+    AssembleMassMatrix(beams, beta_prime, solver.K);
+    AssembleGyroscopicInertiaMatrix(beams, gamma_prime, solver.K);
+    Kokkos::parallel_for("Copy into Sparse Matrix", sparse_matrix_policy, CopyIntoSparseMatrix{K, solver.K});
+
+    Kokkos::fence();
+    crs_matrix_type system_matrix;
+    KokkosSparse::spadd_symbolic(&kh, K, static_system_matrix, system_matrix);
+    KokkosSparse::spadd_numeric(&kh, 1., K, 1., static_system_matrix, system_matrix);
 
     Kokkos::deep_copy(St_11, 0.);
-    
-    crs_matrix_type local_St_11 = KokkosSparse::spgemm<crs_matrix_type>(K, false, T, false);
+    Kokkos::fence();
     Kokkos::parallel_for("Copy into St_11", sparse_matrix_policy, KOKKOS_LAMBDA(Kokkos::TeamPolicy<>::member_type member) {
         auto i = member.league_rank();
-        auto row = local_St_11.row(i);
-        auto row_map = local_St_11.graph.row_map;
-        auto cols = local_St_11.graph.entries;
+        auto row = system_matrix.row(i);
+        auto row_map = system_matrix.graph.row_map;
+        auto cols = system_matrix.graph.entries;
         Kokkos::parallel_for(Kokkos::TeamThreadRange(member, row.length), [=](int entry) {
             St_11(i, cols(row_map(i) + entry)) = row.value(entry);
         });
     });   
-
-    if (solver.is_dynamic_solve) {
-        Kokkos::deep_copy(solver.K, 0.);
-        AssembleMassMatrix(beams, solver.beta_prime, solver.K);
-        AssembleGyroscopicInertiaMatrix(beams, solver.gamma_prime, solver.K);
-        KokkosBlas::update(0., solver.K, 1., solver.K, 1., St_11);
-    }
 }
 
 }  // namespace openturbine

--- a/src/restruct_poc/solver/compute_number_of_non_zeros.hpp
+++ b/src/restruct_poc/solver/compute_number_of_non_zeros.hpp
@@ -1,0 +1,16 @@
+#include <Kokkos_Core.hpp>
+
+#include "src/restruct_poc/beams/beams.hpp"
+
+namespace openturbine {
+    struct ComputeNumberOfNonZeros {
+    Kokkos::View<Beams::ElemIndices*>::const_type elem_indices;
+    
+    KOKKOS_FUNCTION
+    void operator()(int i_elem, int& update) const {
+        auto idx = elem_indices[i_elem];
+        auto num_nodes = idx.num_nodes;
+        update += (num_nodes*6) * (num_nodes*6);
+    }
+};
+}

--- a/src/restruct_poc/solver/compute_number_of_non_zeros.hpp
+++ b/src/restruct_poc/solver/compute_number_of_non_zeros.hpp
@@ -3,14 +3,14 @@
 #include "src/restruct_poc/beams/beams.hpp"
 
 namespace openturbine {
-    struct ComputeNumberOfNonZeros {
+struct ComputeNumberOfNonZeros {
     Kokkos::View<Beams::ElemIndices*>::const_type elem_indices;
-    
+
     KOKKOS_FUNCTION
     void operator()(int i_elem, int& update) const {
         auto idx = elem_indices[i_elem];
         auto num_nodes = idx.num_nodes;
-        update += (num_nodes*6) * (num_nodes*6);
+        update += (num_nodes * 6) * (num_nodes * 6);
     }
 };
-}
+}  // namespace openturbine

--- a/src/restruct_poc/solver/copy_into_sparse_matrix.hpp
+++ b/src/restruct_poc/solver/copy_into_sparse_matrix.hpp
@@ -1,11 +1,18 @@
-#include <Kokkos_Core.hpp>
 #include <KokkosSparse.hpp>
+#include <Kokkos_Core.hpp>
 
 namespace openturbine {
 struct CopyIntoSparseMatrix {
-    using crs_matrix_type = KokkosSparse::CrsMatrix<double, int, Kokkos::Device<Kokkos::DefaultExecutionSpace, Kokkos::DefaultExecutionSpace::memory_space>, void, int>;
-    using row_data_type = Kokkos::View<double*, Kokkos::DefaultExecutionSpace::scratch_memory_space, Kokkos::MemoryTraits<Kokkos::Unmanaged>>;
-    using col_idx_type = Kokkos::View<int*, Kokkos::DefaultExecutionSpace::scratch_memory_space, Kokkos::MemoryTraits<Kokkos::Unmanaged>>;
+    using crs_matrix_type = KokkosSparse::CrsMatrix<
+        double, int,
+        Kokkos::Device<Kokkos::DefaultExecutionSpace, Kokkos::DefaultExecutionSpace::memory_space>,
+        void, int>;
+    using row_data_type = Kokkos::View<
+        double*, Kokkos::DefaultExecutionSpace::scratch_memory_space,
+        Kokkos::MemoryTraits<Kokkos::Unmanaged>>;
+    using col_idx_type = Kokkos::View<
+        int*, Kokkos::DefaultExecutionSpace::scratch_memory_space,
+        Kokkos::MemoryTraits<Kokkos::Unmanaged>>;
     crs_matrix_type sparse;
     Kokkos::View<const double**> dense;
 
@@ -22,9 +29,9 @@ struct CopyIntoSparseMatrix {
             row_data(entry) = dense(i, col_idx(entry));
         });
         member.team_barrier();
-        Kokkos::single(Kokkos::PerTeam(member), [=](){
+        Kokkos::single(Kokkos::PerTeam(member), [=]() {
             sparse.replaceValues(i, col_idx.data(), row.length, row_data.data());
         });
     }
 };
-}
+}  // namespace openturbine

--- a/src/restruct_poc/solver/copy_into_sparse_matrix.hpp
+++ b/src/restruct_poc/solver/copy_into_sparse_matrix.hpp
@@ -1,0 +1,30 @@
+#include <Kokkos_Core.hpp>
+#include <KokkosSparse.hpp>
+
+namespace openturbine {
+struct CopyIntoSparseMatrix {
+    using crs_matrix_type = KokkosSparse::CrsMatrix<double, int, Kokkos::Device<Kokkos::DefaultExecutionSpace, Kokkos::DefaultExecutionSpace::memory_space>, void, int>;
+    using row_data_type = Kokkos::View<double*, Kokkos::DefaultExecutionSpace::scratch_memory_space, Kokkos::MemoryTraits<Kokkos::Unmanaged>>;
+    using col_idx_type = Kokkos::View<int*, Kokkos::DefaultExecutionSpace::scratch_memory_space, Kokkos::MemoryTraits<Kokkos::Unmanaged>>;
+    crs_matrix_type sparse;
+    Kokkos::View<const double**> dense;
+
+    KOKKOS_FUNCTION
+    void operator()(Kokkos::TeamPolicy<>::member_type member) const {
+        auto i = member.league_rank();
+        auto row = sparse.row(i);
+        auto row_map = sparse.graph.row_map;
+        auto cols = sparse.graph.entries;
+        auto row_data = row_data_type(member.team_scratch(1), row.length);
+        auto col_idx = col_idx_type(member.team_scratch(1), row.length);
+        Kokkos::parallel_for(Kokkos::TeamThreadRange(member, row.length), [=](int entry) {
+            col_idx(entry) = cols(row_map(i) + entry);
+            row_data(entry) = dense(i, col_idx(entry));
+        });
+        member.team_barrier();
+        Kokkos::single(Kokkos::PerTeam(member), [=](){
+            sparse.replaceValues(i, col_idx.data(), row.length, row_data.data());
+        });
+    }
+};
+}

--- a/src/restruct_poc/solver/populate_sparse_indices.hpp
+++ b/src/restruct_poc/solver/populate_sparse_indices.hpp
@@ -5,29 +5,29 @@
 namespace openturbine {
 struct PopulateSparseIndices {
     Kokkos::View<Beams::ElemIndices*>::const_type elem_indices;
-    Kokkos::View<int*>::const_type node_state_indices;    
+    Kokkos::View<int*>::const_type node_state_indices;
     Kokkos::View<int*> indices;
 
     KOKKOS_FUNCTION
     void operator()(int) const {
-      const auto num_elems = elem_indices.extent(0);
-      auto entries_so_far = 0;
-      for(int i_elem = 0; i_elem < num_elems; ++i_elem) {
-        auto idx = elem_indices[i_elem];
-        auto num_nodes = idx.num_nodes;
-        for(int j_index = 0; j_index < num_nodes; ++j_index) {
-          for(int n = 0; n < kLieAlgebraComponents; ++n) {
-            for(int i_index = 0; i_index < num_nodes; ++i_index) {
-              const auto i = i_index + idx.node_range.first;
-              const auto column_start = node_state_indices(i)*kLieAlgebraComponents;
-              for(int m = 0; m < kLieAlgebraComponents; ++m) {
-                  indices(entries_so_far) = column_start + m;
-                  ++entries_so_far;
-              }
+        const auto num_elems = elem_indices.extent(0);
+        auto entries_so_far = 0;
+        for (int i_elem = 0; i_elem < num_elems; ++i_elem) {
+            auto idx = elem_indices[i_elem];
+            auto num_nodes = idx.num_nodes;
+            for (int j_index = 0; j_index < num_nodes; ++j_index) {
+                for (int n = 0; n < kLieAlgebraComponents; ++n) {
+                    for (int i_index = 0; i_index < num_nodes; ++i_index) {
+                        const auto i = i_index + idx.node_range.first;
+                        const auto column_start = node_state_indices(i) * kLieAlgebraComponents;
+                        for (int m = 0; m < kLieAlgebraComponents; ++m) {
+                            indices(entries_so_far) = column_start + m;
+                            ++entries_so_far;
+                        }
+                    }
+                }
             }
-          }
         }
-      }
     }
 };
-}
+}  // namespace openturbine

--- a/src/restruct_poc/solver/populate_sparse_indices.hpp
+++ b/src/restruct_poc/solver/populate_sparse_indices.hpp
@@ -1,0 +1,33 @@
+#include <Kokkos_Core.hpp>
+
+#include "src/restruct_poc/beams/beams.hpp"
+
+namespace openturbine {
+struct PopulateSparseIndices {
+    Kokkos::View<Beams::ElemIndices*>::const_type elem_indices;
+    Kokkos::View<int*>::const_type node_state_indices;    
+    Kokkos::View<int*> indices;
+
+    KOKKOS_FUNCTION
+    void operator()(int) const {
+      const auto num_elems = elem_indices.extent(0);
+      auto entries_so_far = 0;
+      for(int i_elem = 0; i_elem < num_elems; ++i_elem) {
+        auto idx = elem_indices[i_elem];
+        auto num_nodes = idx.num_nodes;
+        for(int j_index = 0; j_index < num_nodes; ++j_index) {
+          for(int n = 0; n < kLieAlgebraComponents; ++n) {
+            for(int i_index = 0; i_index < num_nodes; ++i_index) {
+              const auto i = i_index + idx.node_range.first;
+              const auto column_start = node_state_indices(i)*kLieAlgebraComponents;
+              for(int m = 0; m < kLieAlgebraComponents; ++m) {
+                  indices(entries_so_far) = column_start + m;
+                  ++entries_so_far;
+              }
+            }
+          }
+        }
+      }
+    }
+};
+}

--- a/src/restruct_poc/solver/populate_sparse_row_ptrs.hpp
+++ b/src/restruct_poc/solver/populate_sparse_row_ptrs.hpp
@@ -9,17 +9,17 @@ struct PopulateSparseRowPtrs {
 
     KOKKOS_FUNCTION
     void operator()(int) const {
-      const auto num_elems = elem_indices.extent(0);
-      auto rows_so_far = 0;
-      for(int i_elem = 0; i_elem < num_elems; ++i_elem) {
-        auto idx = elem_indices[i_elem];
-        auto num_nodes = idx.num_nodes;
-        for(int i = 0; i < num_nodes*kLieAlgebraComponents; ++i) {
-            row_ptrs(rows_so_far + 1) = row_ptrs(rows_so_far) + num_nodes * kLieAlgebraComponents;
-            ++rows_so_far;
+        const auto num_elems = elem_indices.extent(0);
+        auto rows_so_far = 0;
+        for (int i_elem = 0; i_elem < num_elems; ++i_elem) {
+            auto idx = elem_indices[i_elem];
+            auto num_nodes = idx.num_nodes;
+            for (int i = 0; i < num_nodes * kLieAlgebraComponents; ++i) {
+                row_ptrs(rows_so_far + 1) =
+                    row_ptrs(rows_so_far) + num_nodes * kLieAlgebraComponents;
+                ++rows_so_far;
+            }
         }
-        
-      }
     }
 };
-}
+}  // namespace openturbine

--- a/src/restruct_poc/solver/populate_sparse_row_ptrs.hpp
+++ b/src/restruct_poc/solver/populate_sparse_row_ptrs.hpp
@@ -1,0 +1,25 @@
+#include <Kokkos_Core.hpp>
+
+#include "src/restruct_poc/beams/beams.hpp"
+
+namespace openturbine {
+struct PopulateSparseRowPtrs {
+    Kokkos::View<Beams::ElemIndices*>::const_type elem_indices;
+    Kokkos::View<int*> row_ptrs;
+
+    KOKKOS_FUNCTION
+    void operator()(int) const {
+      const auto num_elems = elem_indices.extent(0);
+      auto rows_so_far = 0;
+      for(int i_elem = 0; i_elem < num_elems; ++i_elem) {
+        auto idx = elem_indices[i_elem];
+        auto num_nodes = idx.num_nodes;
+        for(int i = 0; i < num_nodes*kLieAlgebraComponents; ++i) {
+            row_ptrs(rows_so_far + 1) = row_ptrs(rows_so_far) + num_nodes * kLieAlgebraComponents;
+            ++rows_so_far;
+        }
+        
+      }
+    }
+};
+}

--- a/tests/unit_tests/restruct_poc/CMakeLists.txt
+++ b/tests/unit_tests/restruct_poc/CMakeLists.txt
@@ -9,6 +9,10 @@ target_sources(
     test_rotor.cpp
     test_math.cpp
     test_utilities.cpp
+    solver/test_compute_number_of_non_zeros.cpp
+    solver/test_copy_into_sparse_matrix.cpp
+    solver/test_populate_sparse_indices.cpp
+    solver/test_populate_sparse_row_ptrs.cpp
     system/test_integrate_matrix.cpp
     system/test_integrate_elastic_stiffness_matrix.cpp
     system/test_integrate_residual_vector.cpp

--- a/tests/unit_tests/restruct_poc/solver/test_compute_number_of_non_zeros.cpp
+++ b/tests/unit_tests/restruct_poc/solver/test_compute_number_of_non_zeros.cpp
@@ -1,0 +1,35 @@
+#include <Kokkos_Core.hpp>
+#include <gtest/gtest.h>
+
+#include "src/restruct_poc/solver/compute_number_of_non_zeros.hpp"
+
+namespace openturbine::restruct_poc::tests {
+
+TEST(ComputeNumberOfNonZeros, SingleElement) {
+    auto elem_indices_host = Kokkos::View<Beams::ElemIndices[1], Kokkos::HostSpace>("elem_indices_host");
+    auto elem_indices = Kokkos::View<Beams::ElemIndices[1]>("elem_indices");
+
+    elem_indices_host(0).num_nodes = 5;
+    Kokkos::deep_copy(elem_indices, elem_indices_host);
+    auto num_non_zero = 0;
+    Kokkos::parallel_reduce(1, ComputeNumberOfNonZeros{elem_indices}, num_non_zero);
+    constexpr auto num_dof = 5*6;
+    constexpr auto expected_num_non_zero = num_dof * num_dof;
+    EXPECT_EQ(num_non_zero, expected_num_non_zero);
+}
+
+TEST(ComputeNumberOfNonZeros, TwoElements) {
+    auto elem_indices_host = Kokkos::View<Beams::ElemIndices[2], Kokkos::HostSpace>("elem_indices_host");
+    auto elem_indices = Kokkos::View<Beams::ElemIndices[2]>("elem_indices");
+
+    elem_indices_host(0).num_nodes = 5;
+    elem_indices_host(1).num_nodes = 3;
+    Kokkos::deep_copy(elem_indices, elem_indices_host);
+    auto num_non_zero = 0;
+    Kokkos::parallel_reduce(2, ComputeNumberOfNonZeros{elem_indices}, num_non_zero);
+    constexpr auto num_dof_elem1 = 5*6;
+    constexpr auto num_dof_elem2 = 3*6;
+    constexpr auto expected_num_non_zero = num_dof_elem1 * num_dof_elem1 + num_dof_elem2 * num_dof_elem2;
+    EXPECT_EQ(num_non_zero, expected_num_non_zero);
+}
+}

--- a/tests/unit_tests/restruct_poc/solver/test_compute_number_of_non_zeros.cpp
+++ b/tests/unit_tests/restruct_poc/solver/test_compute_number_of_non_zeros.cpp
@@ -6,20 +6,22 @@
 namespace openturbine::restruct_poc::tests {
 
 TEST(ComputeNumberOfNonZeros, SingleElement) {
-    auto elem_indices_host = Kokkos::View<Beams::ElemIndices[1], Kokkos::HostSpace>("elem_indices_host");
+    auto elem_indices_host =
+        Kokkos::View<Beams::ElemIndices[1], Kokkos::HostSpace>("elem_indices_host");
     auto elem_indices = Kokkos::View<Beams::ElemIndices[1]>("elem_indices");
 
     elem_indices_host(0).num_nodes = 5;
     Kokkos::deep_copy(elem_indices, elem_indices_host);
     auto num_non_zero = 0;
     Kokkos::parallel_reduce(1, ComputeNumberOfNonZeros{elem_indices}, num_non_zero);
-    constexpr auto num_dof = 5*6;
+    constexpr auto num_dof = 5 * 6;
     constexpr auto expected_num_non_zero = num_dof * num_dof;
     EXPECT_EQ(num_non_zero, expected_num_non_zero);
 }
 
 TEST(ComputeNumberOfNonZeros, TwoElements) {
-    auto elem_indices_host = Kokkos::View<Beams::ElemIndices[2], Kokkos::HostSpace>("elem_indices_host");
+    auto elem_indices_host =
+        Kokkos::View<Beams::ElemIndices[2], Kokkos::HostSpace>("elem_indices_host");
     auto elem_indices = Kokkos::View<Beams::ElemIndices[2]>("elem_indices");
 
     elem_indices_host(0).num_nodes = 5;
@@ -27,9 +29,10 @@ TEST(ComputeNumberOfNonZeros, TwoElements) {
     Kokkos::deep_copy(elem_indices, elem_indices_host);
     auto num_non_zero = 0;
     Kokkos::parallel_reduce(2, ComputeNumberOfNonZeros{elem_indices}, num_non_zero);
-    constexpr auto num_dof_elem1 = 5*6;
-    constexpr auto num_dof_elem2 = 3*6;
-    constexpr auto expected_num_non_zero = num_dof_elem1 * num_dof_elem1 + num_dof_elem2 * num_dof_elem2;
+    constexpr auto num_dof_elem1 = 5 * 6;
+    constexpr auto num_dof_elem2 = 3 * 6;
+    constexpr auto expected_num_non_zero =
+        num_dof_elem1 * num_dof_elem1 + num_dof_elem2 * num_dof_elem2;
     EXPECT_EQ(num_non_zero, expected_num_non_zero);
 }
-}
+}  // namespace openturbine::restruct_poc::tests

--- a/tests/unit_tests/restruct_poc/solver/test_copy_into_sparse_matrix.cpp
+++ b/tests/unit_tests/restruct_poc/solver/test_copy_into_sparse_matrix.cpp
@@ -1,0 +1,178 @@
+#include <Kokkos_Core.hpp>
+#include <KokkosSparse.hpp>
+#include <gtest/gtest.h>
+
+#include "src/restruct_poc/solver/copy_into_sparse_matrix.hpp"
+
+namespace openturbine::restruct_poc::tests {
+
+auto createDenseMatrix_1x1() {
+    auto dense = Kokkos::View<double[1][1]>("dense");
+    auto dense_host_data = std::array{3.};
+    auto dense_host = Kokkos::View<double[1][1], Kokkos::HostSpace>(dense_host_data.data());
+    auto dense_mirror = Kokkos::create_mirror(dense);
+    Kokkos::deep_copy(dense_mirror, dense_host);
+    Kokkos::deep_copy(dense, dense_mirror);
+    return dense;
+}
+
+auto createRowPtrs_1x1() {
+    auto row_ptrs = Kokkos::View<int[2]>("row_ptrs");
+    auto row_ptrs_host_data = std::array{0, 1};
+    auto row_ptrs_host = Kokkos::View<int[2], Kokkos::HostSpace>(row_ptrs_host_data.data());
+    Kokkos::deep_copy(row_ptrs, row_ptrs_host);
+    return row_ptrs;
+}
+
+TEST(CopyIntoSparseMatrix, SingleEntry) {
+    using device_type =  Kokkos::Device<Kokkos::DefaultExecutionSpace, Kokkos::DefaultExecutionSpace::memory_space>;
+    using crs_matrix_type = KokkosSparse::CrsMatrix<double, int, device_type, void, int>;
+
+    constexpr auto num_rows = 1;
+    constexpr auto num_columns = 1;
+    constexpr auto num_non_zero = 1;
+
+    auto dense = createDenseMatrix_1x1();
+
+    auto values = Kokkos::View<double[num_non_zero]>("values");
+    auto row_ptrs = createRowPtrs_1x1();
+    auto indices = Kokkos::View<int[num_non_zero]>("indices");
+    auto sparse = crs_matrix_type("sparse", num_rows, num_columns, num_non_zero, values, row_ptrs, indices);
+
+    auto row_data_size = Kokkos::View<double*>::shmem_size(num_columns);
+    auto col_idx_size = Kokkos::View<int*>::shmem_size(num_columns);
+    auto sparse_matrix_policy = Kokkos::TeamPolicy<>(num_rows, Kokkos::AUTO());
+    sparse_matrix_policy.set_scratch_size(1, Kokkos::PerTeam(row_data_size + col_idx_size));
+
+    Kokkos::parallel_for("CopyIntoSparseMatrix", sparse_matrix_policy, CopyIntoSparseMatrix{sparse, dense});
+
+    auto values_mirror = Kokkos::create_mirror(values);
+    Kokkos::deep_copy(values_mirror, values);
+    ASSERT_EQ(values_mirror(0), 3.);
+}
+
+auto createDenseMatrix_3x3() {
+    auto dense = Kokkos::View<double[3][3]>("dense");
+    auto dense_host_data = std::array{1., 0., 0., 0., 2., 0., 0., 0., 3.};
+    auto dense_host = Kokkos::View<double[3][3], Kokkos::HostSpace>(dense_host_data.data());
+    auto dense_mirror = Kokkos::create_mirror(dense);
+    Kokkos::deep_copy(dense_mirror, dense_host);
+    Kokkos::deep_copy(dense, dense_mirror);
+    return dense;
+}
+
+auto createRowPtrs_3x3() {
+    auto row_ptrs = Kokkos::View<int[4]>("row_ptrs");
+    auto row_ptrs_host_data = std::array{0, 1, 2, 3};
+    auto row_ptrs_host = Kokkos::View<int[4], Kokkos::HostSpace>(row_ptrs_host_data.data());
+    Kokkos::deep_copy(row_ptrs, row_ptrs_host);
+    return row_ptrs;
+}
+
+auto createIndices_3x3() {
+    auto indices = Kokkos::View<int[3]>("indices");
+    auto indices_host_data = std::array{0, 1, 2};
+    auto indices_host = Kokkos::View<int[3], Kokkos::HostSpace>(indices_host_data.data());
+    Kokkos::deep_copy(indices, indices_host);
+    return indices;
+}
+
+TEST(CopyIntoSparseMatrix, Diagonal) {
+    using device_type =  Kokkos::Device<Kokkos::DefaultExecutionSpace, Kokkos::DefaultExecutionSpace::memory_space>;
+    using crs_matrix_type = KokkosSparse::CrsMatrix<double, int, device_type, void, int>;
+
+    constexpr auto num_rows = 3;
+    constexpr auto num_columns = 3;
+    constexpr auto num_non_zero = 3;
+
+    auto dense = createDenseMatrix_3x3();
+
+    auto values = Kokkos::View<double[num_non_zero]>("values");
+    auto row_ptrs = createRowPtrs_3x3();
+    auto indices = createIndices_3x3();
+    auto sparse = crs_matrix_type("sparse", num_rows, num_columns, num_non_zero, values, row_ptrs, indices);
+
+    auto row_data_size = Kokkos::View<double*>::shmem_size(num_columns);
+    auto col_idx_size = Kokkos::View<int*>::shmem_size(num_columns);
+    auto sparse_matrix_policy = Kokkos::TeamPolicy<>(num_rows, Kokkos::AUTO());
+    sparse_matrix_policy.set_scratch_size(1, Kokkos::PerTeam(row_data_size + col_idx_size));
+
+    Kokkos::parallel_for("CopyIntoSparseMatrix", sparse_matrix_policy, CopyIntoSparseMatrix{sparse, dense});
+
+    auto values_mirror = Kokkos::create_mirror(values);
+    Kokkos::deep_copy(values_mirror, values);
+    ASSERT_EQ(values_mirror(0), 1.);
+    ASSERT_EQ(values_mirror(1), 2.);
+    ASSERT_EQ(values_mirror(2), 3.);
+}
+
+auto createDenseMatrix_5x5() {
+    auto dense = Kokkos::View<double[5][5]>("dense");
+    auto dense_host_data = std::array{1., 2., 3., 00., 00.,
+                                      4., 5., 6., 00., 00.,
+                                      7., 8., 9., 00., 00.,
+                                      0., 0., 0., 10., 11.,
+                                      0., 0., 0., 12., 13.};
+    auto dense_host = Kokkos::View<double[5][5], Kokkos::HostSpace>(dense_host_data.data());
+    auto dense_mirror = Kokkos::create_mirror(dense);
+    Kokkos::deep_copy(dense_mirror, dense_host);
+    Kokkos::deep_copy(dense, dense_mirror);
+    return dense;
+}
+
+auto createRowPtrs_5x5() {
+    auto row_ptrs = Kokkos::View<int[6]>("row_ptrs");
+    auto row_ptrs_host_data = std::array{0, 3, 6, 9, 11, 13};
+    auto row_ptrs_host = Kokkos::View<int[6], Kokkos::HostSpace>(row_ptrs_host_data.data());
+    Kokkos::deep_copy(row_ptrs, row_ptrs_host);
+    return row_ptrs;
+}
+
+auto createIndices_5x5() {
+    auto indices = Kokkos::View<int[13]>("indices");
+    auto indices_host_data = std::array{0, 1, 2, 0, 1, 2, 0, 1, 2, 3, 4, 3, 4};
+    auto indices_host = Kokkos::View<int[13], Kokkos::HostSpace>(indices_host_data.data());
+    Kokkos::deep_copy(indices, indices_host);
+    return indices;
+}
+
+TEST(CopyIntoSparseMatrix, Block) {
+    using device_type =  Kokkos::Device<Kokkos::DefaultExecutionSpace, Kokkos::DefaultExecutionSpace::memory_space>;
+    using crs_matrix_type = KokkosSparse::CrsMatrix<double, int, device_type, void, int>;
+
+    constexpr auto num_rows = 5;
+    constexpr auto num_columns = 5;
+    constexpr auto num_non_zero = 13;
+
+    auto dense = createDenseMatrix_5x5();
+
+    auto values = Kokkos::View<double[num_non_zero]>("values");
+    auto row_ptrs = createRowPtrs_5x5();
+    auto indices = createIndices_5x5();
+    auto sparse = crs_matrix_type("sparse", num_rows, num_columns, num_non_zero, values, row_ptrs, indices);
+
+    auto row_data_size = Kokkos::View<double*>::shmem_size(num_columns);
+    auto col_idx_size = Kokkos::View<int*>::shmem_size(num_columns);
+    auto sparse_matrix_policy = Kokkos::TeamPolicy<>(num_rows, Kokkos::AUTO());
+    sparse_matrix_policy.set_scratch_size(1, Kokkos::PerTeam(row_data_size + col_idx_size));
+
+    Kokkos::parallel_for("CopyIntoSparseMatrix", sparse_matrix_policy, CopyIntoSparseMatrix{sparse, dense});
+
+    auto values_mirror = Kokkos::create_mirror(values);
+    Kokkos::deep_copy(values_mirror, values);
+    ASSERT_EQ(values_mirror(0), 1.);
+    ASSERT_EQ(values_mirror(1), 2.);
+    ASSERT_EQ(values_mirror(2), 3.);
+    ASSERT_EQ(values_mirror(3), 4.);
+    ASSERT_EQ(values_mirror(4), 5.);
+    ASSERT_EQ(values_mirror(5), 6.);
+    ASSERT_EQ(values_mirror(6), 7.);
+    ASSERT_EQ(values_mirror(7), 8.);
+    ASSERT_EQ(values_mirror(8), 9.);
+    ASSERT_EQ(values_mirror(9), 10.);
+    ASSERT_EQ(values_mirror(10), 11.);
+    ASSERT_EQ(values_mirror(11), 12.);
+    ASSERT_EQ(values_mirror(12), 13.);
+}
+
+}

--- a/tests/unit_tests/restruct_poc/solver/test_copy_into_sparse_matrix.cpp
+++ b/tests/unit_tests/restruct_poc/solver/test_copy_into_sparse_matrix.cpp
@@ -1,5 +1,5 @@
-#include <Kokkos_Core.hpp>
 #include <KokkosSparse.hpp>
+#include <Kokkos_Core.hpp>
 #include <gtest/gtest.h>
 
 #include "src/restruct_poc/solver/copy_into_sparse_matrix.hpp"
@@ -25,7 +25,8 @@ auto createRowPtrs_1x1() {
 }
 
 TEST(CopyIntoSparseMatrix, SingleEntry) {
-    using device_type =  Kokkos::Device<Kokkos::DefaultExecutionSpace, Kokkos::DefaultExecutionSpace::memory_space>;
+    using device_type =
+        Kokkos::Device<Kokkos::DefaultExecutionSpace, Kokkos::DefaultExecutionSpace::memory_space>;
     using crs_matrix_type = KokkosSparse::CrsMatrix<double, int, device_type, void, int>;
 
     constexpr auto num_rows = 1;
@@ -37,14 +38,17 @@ TEST(CopyIntoSparseMatrix, SingleEntry) {
     auto values = Kokkos::View<double[num_non_zero]>("values");
     auto row_ptrs = createRowPtrs_1x1();
     auto indices = Kokkos::View<int[num_non_zero]>("indices");
-    auto sparse = crs_matrix_type("sparse", num_rows, num_columns, num_non_zero, values, row_ptrs, indices);
+    auto sparse =
+        crs_matrix_type("sparse", num_rows, num_columns, num_non_zero, values, row_ptrs, indices);
 
     auto row_data_size = Kokkos::View<double*>::shmem_size(num_columns);
     auto col_idx_size = Kokkos::View<int*>::shmem_size(num_columns);
     auto sparse_matrix_policy = Kokkos::TeamPolicy<>(num_rows, Kokkos::AUTO());
     sparse_matrix_policy.set_scratch_size(1, Kokkos::PerTeam(row_data_size + col_idx_size));
 
-    Kokkos::parallel_for("CopyIntoSparseMatrix", sparse_matrix_policy, CopyIntoSparseMatrix{sparse, dense});
+    Kokkos::parallel_for(
+        "CopyIntoSparseMatrix", sparse_matrix_policy, CopyIntoSparseMatrix{sparse, dense}
+    );
 
     auto values_mirror = Kokkos::create_mirror(values);
     Kokkos::deep_copy(values_mirror, values);
@@ -78,7 +82,8 @@ auto createIndices_3x3() {
 }
 
 TEST(CopyIntoSparseMatrix, Diagonal) {
-    using device_type =  Kokkos::Device<Kokkos::DefaultExecutionSpace, Kokkos::DefaultExecutionSpace::memory_space>;
+    using device_type =
+        Kokkos::Device<Kokkos::DefaultExecutionSpace, Kokkos::DefaultExecutionSpace::memory_space>;
     using crs_matrix_type = KokkosSparse::CrsMatrix<double, int, device_type, void, int>;
 
     constexpr auto num_rows = 3;
@@ -90,14 +95,17 @@ TEST(CopyIntoSparseMatrix, Diagonal) {
     auto values = Kokkos::View<double[num_non_zero]>("values");
     auto row_ptrs = createRowPtrs_3x3();
     auto indices = createIndices_3x3();
-    auto sparse = crs_matrix_type("sparse", num_rows, num_columns, num_non_zero, values, row_ptrs, indices);
+    auto sparse =
+        crs_matrix_type("sparse", num_rows, num_columns, num_non_zero, values, row_ptrs, indices);
 
     auto row_data_size = Kokkos::View<double*>::shmem_size(num_columns);
     auto col_idx_size = Kokkos::View<int*>::shmem_size(num_columns);
     auto sparse_matrix_policy = Kokkos::TeamPolicy<>(num_rows, Kokkos::AUTO());
     sparse_matrix_policy.set_scratch_size(1, Kokkos::PerTeam(row_data_size + col_idx_size));
 
-    Kokkos::parallel_for("CopyIntoSparseMatrix", sparse_matrix_policy, CopyIntoSparseMatrix{sparse, dense});
+    Kokkos::parallel_for(
+        "CopyIntoSparseMatrix", sparse_matrix_policy, CopyIntoSparseMatrix{sparse, dense}
+    );
 
     auto values_mirror = Kokkos::create_mirror(values);
     Kokkos::deep_copy(values_mirror, values);
@@ -108,11 +116,8 @@ TEST(CopyIntoSparseMatrix, Diagonal) {
 
 auto createDenseMatrix_5x5() {
     auto dense = Kokkos::View<double[5][5]>("dense");
-    auto dense_host_data = std::array{1., 2., 3., 00., 00.,
-                                      4., 5., 6., 00., 00.,
-                                      7., 8., 9., 00., 00.,
-                                      0., 0., 0., 10., 11.,
-                                      0., 0., 0., 12., 13.};
+    auto dense_host_data = std::array{1.,  2.,  3., 00., 00., 4.,  5.,  6., 00., 00., 7.,  8., 9.,
+                                      00., 00., 0., 0.,  0.,  10., 11., 0., 0.,  0.,  12., 13.};
     auto dense_host = Kokkos::View<double[5][5], Kokkos::HostSpace>(dense_host_data.data());
     auto dense_mirror = Kokkos::create_mirror(dense);
     Kokkos::deep_copy(dense_mirror, dense_host);
@@ -137,7 +142,8 @@ auto createIndices_5x5() {
 }
 
 TEST(CopyIntoSparseMatrix, Block) {
-    using device_type =  Kokkos::Device<Kokkos::DefaultExecutionSpace, Kokkos::DefaultExecutionSpace::memory_space>;
+    using device_type =
+        Kokkos::Device<Kokkos::DefaultExecutionSpace, Kokkos::DefaultExecutionSpace::memory_space>;
     using crs_matrix_type = KokkosSparse::CrsMatrix<double, int, device_type, void, int>;
 
     constexpr auto num_rows = 5;
@@ -149,14 +155,17 @@ TEST(CopyIntoSparseMatrix, Block) {
     auto values = Kokkos::View<double[num_non_zero]>("values");
     auto row_ptrs = createRowPtrs_5x5();
     auto indices = createIndices_5x5();
-    auto sparse = crs_matrix_type("sparse", num_rows, num_columns, num_non_zero, values, row_ptrs, indices);
+    auto sparse =
+        crs_matrix_type("sparse", num_rows, num_columns, num_non_zero, values, row_ptrs, indices);
 
     auto row_data_size = Kokkos::View<double*>::shmem_size(num_columns);
     auto col_idx_size = Kokkos::View<int*>::shmem_size(num_columns);
     auto sparse_matrix_policy = Kokkos::TeamPolicy<>(num_rows, Kokkos::AUTO());
     sparse_matrix_policy.set_scratch_size(1, Kokkos::PerTeam(row_data_size + col_idx_size));
 
-    Kokkos::parallel_for("CopyIntoSparseMatrix", sparse_matrix_policy, CopyIntoSparseMatrix{sparse, dense});
+    Kokkos::parallel_for(
+        "CopyIntoSparseMatrix", sparse_matrix_policy, CopyIntoSparseMatrix{sparse, dense}
+    );
 
     auto values_mirror = Kokkos::create_mirror(values);
     Kokkos::deep_copy(values_mirror, values);
@@ -175,4 +184,4 @@ TEST(CopyIntoSparseMatrix, Block) {
     ASSERT_EQ(values_mirror(12), 13.);
 }
 
-}
+}  // namespace openturbine::restruct_poc::tests

--- a/tests/unit_tests/restruct_poc/solver/test_populate_sparse_indices.cpp
+++ b/tests/unit_tests/restruct_poc/solver/test_populate_sparse_indices.cpp
@@ -1,0 +1,73 @@
+#include <Kokkos_Core.hpp>
+#include <gtest/gtest.h>
+
+#include "src/restruct_poc/solver/populate_sparse_indices.hpp"
+
+namespace openturbine::restruct_poc::tests {
+
+TEST(PopulateSparseIndices, SingleElement) {
+    constexpr auto num_nodes = 5;
+    constexpr auto num_dof = num_nodes * 6;
+
+    auto elem_indices_host = Kokkos::View<Beams::ElemIndices[1], Kokkos::HostSpace>("elem_indices_host");
+    auto elem_indices = Kokkos::View<Beams::ElemIndices[1]>("elem_indices");
+    elem_indices_host(0).num_nodes = num_nodes;
+    elem_indices_host(0).node_range.first = 0;
+    Kokkos::deep_copy(elem_indices, elem_indices_host);
+
+    auto node_state_indices = Kokkos::View<int[num_nodes]>("node_state_indices");
+    auto node_state_indices_host_data = std::array{0, 1, 2, 3, 4};
+    auto node_state_indices_host = Kokkos::View<int[num_nodes], Kokkos::HostSpace>(node_state_indices_host_data.data());
+    Kokkos::deep_copy(node_state_indices, node_state_indices_host);
+    auto indices = Kokkos::View<int[num_dof*num_dof]>("indices");
+
+    Kokkos::parallel_for(1, PopulateSparseIndices{elem_indices, node_state_indices, indices});
+
+    auto indices_host = Kokkos::create_mirror(indices);
+    Kokkos::deep_copy(indices_host, indices);
+    for(int row = 0; row < num_dof; ++row) {
+        for(int column = 0; column < num_dof; ++column) {
+            ASSERT_EQ(indices_host(row*num_dof + column), column);
+        }
+    }
+}
+
+TEST(PopulateSparseIndices, TwoElements) {
+    constexpr auto elem1_num_nodes = 5;
+    constexpr auto elem1_num_dof = elem1_num_nodes * 6;
+    constexpr auto elem2_num_nodes = 3;
+    constexpr auto elem2_num_dof = elem2_num_nodes * 6;
+    constexpr auto num_nodes = elem1_num_nodes + elem2_num_nodes;
+
+    auto elem_indices_host = Kokkos::View<Beams::ElemIndices[2], Kokkos::HostSpace>("elem_indices_host");
+    auto elem_indices = Kokkos::View<Beams::ElemIndices[2]>("elem_indices");
+    elem_indices_host(0).num_nodes = elem1_num_nodes;
+    elem_indices_host(0).node_range.first = 0;
+    elem_indices_host(1).num_nodes = elem2_num_nodes;
+    elem_indices_host(1).node_range.first = elem1_num_nodes;
+    Kokkos::deep_copy(elem_indices, elem_indices_host);
+
+    auto node_state_indices = Kokkos::View<int[num_nodes]>("node_state_indices");
+    auto node_state_indices_host_data = std::array{0, 1, 2, 3, 4, 5, 6, 7};
+    auto node_state_indices_host = Kokkos::View<int[num_nodes], Kokkos::HostSpace>(node_state_indices_host_data.data());
+    Kokkos::deep_copy(node_state_indices, node_state_indices_host);
+    auto indices = Kokkos::View<int[elem1_num_dof*elem1_num_dof + elem2_num_dof*elem2_num_dof]>("indices");
+
+    Kokkos::parallel_for(1, PopulateSparseIndices{elem_indices, node_state_indices, indices});
+
+    auto indices_host = Kokkos::create_mirror(indices);
+    Kokkos::deep_copy(indices_host, indices);
+    for(int row = 0; row < elem1_num_dof; ++row) {
+        for(int column = 0; column < elem1_num_dof; ++column) {
+            EXPECT_EQ(indices_host(row*elem1_num_dof + column), column);
+        }
+    }
+
+    auto* indices_host_elem_2 = &indices_host(elem1_num_dof*elem1_num_dof);
+    for(int row = 0; row < elem2_num_dof; ++row) {
+        for(int column = 0; column < elem2_num_dof; ++column) {
+            EXPECT_EQ(indices_host_elem_2[row*elem2_num_dof + column], column + elem1_num_dof);
+        }
+    }
+}
+}

--- a/tests/unit_tests/restruct_poc/solver/test_populate_sparse_indices.cpp
+++ b/tests/unit_tests/restruct_poc/solver/test_populate_sparse_indices.cpp
@@ -9,7 +9,8 @@ TEST(PopulateSparseIndices, SingleElement) {
     constexpr auto num_nodes = 5;
     constexpr auto num_dof = num_nodes * 6;
 
-    auto elem_indices_host = Kokkos::View<Beams::ElemIndices[1], Kokkos::HostSpace>("elem_indices_host");
+    auto elem_indices_host =
+        Kokkos::View<Beams::ElemIndices[1], Kokkos::HostSpace>("elem_indices_host");
     auto elem_indices = Kokkos::View<Beams::ElemIndices[1]>("elem_indices");
     elem_indices_host(0).num_nodes = num_nodes;
     elem_indices_host(0).node_range.first = 0;
@@ -17,17 +18,18 @@ TEST(PopulateSparseIndices, SingleElement) {
 
     auto node_state_indices = Kokkos::View<int[num_nodes]>("node_state_indices");
     auto node_state_indices_host_data = std::array{0, 1, 2, 3, 4};
-    auto node_state_indices_host = Kokkos::View<int[num_nodes], Kokkos::HostSpace>(node_state_indices_host_data.data());
+    auto node_state_indices_host =
+        Kokkos::View<int[num_nodes], Kokkos::HostSpace>(node_state_indices_host_data.data());
     Kokkos::deep_copy(node_state_indices, node_state_indices_host);
-    auto indices = Kokkos::View<int[num_dof*num_dof]>("indices");
+    auto indices = Kokkos::View<int[num_dof * num_dof]>("indices");
 
     Kokkos::parallel_for(1, PopulateSparseIndices{elem_indices, node_state_indices, indices});
 
     auto indices_host = Kokkos::create_mirror(indices);
     Kokkos::deep_copy(indices_host, indices);
-    for(int row = 0; row < num_dof; ++row) {
-        for(int column = 0; column < num_dof; ++column) {
-            ASSERT_EQ(indices_host(row*num_dof + column), column);
+    for (int row = 0; row < num_dof; ++row) {
+        for (int column = 0; column < num_dof; ++column) {
+            ASSERT_EQ(indices_host(row * num_dof + column), column);
         }
     }
 }
@@ -39,7 +41,8 @@ TEST(PopulateSparseIndices, TwoElements) {
     constexpr auto elem2_num_dof = elem2_num_nodes * 6;
     constexpr auto num_nodes = elem1_num_nodes + elem2_num_nodes;
 
-    auto elem_indices_host = Kokkos::View<Beams::ElemIndices[2], Kokkos::HostSpace>("elem_indices_host");
+    auto elem_indices_host =
+        Kokkos::View<Beams::ElemIndices[2], Kokkos::HostSpace>("elem_indices_host");
     auto elem_indices = Kokkos::View<Beams::ElemIndices[2]>("elem_indices");
     elem_indices_host(0).num_nodes = elem1_num_nodes;
     elem_indices_host(0).node_range.first = 0;
@@ -49,25 +52,27 @@ TEST(PopulateSparseIndices, TwoElements) {
 
     auto node_state_indices = Kokkos::View<int[num_nodes]>("node_state_indices");
     auto node_state_indices_host_data = std::array{0, 1, 2, 3, 4, 5, 6, 7};
-    auto node_state_indices_host = Kokkos::View<int[num_nodes], Kokkos::HostSpace>(node_state_indices_host_data.data());
+    auto node_state_indices_host =
+        Kokkos::View<int[num_nodes], Kokkos::HostSpace>(node_state_indices_host_data.data());
     Kokkos::deep_copy(node_state_indices, node_state_indices_host);
-    auto indices = Kokkos::View<int[elem1_num_dof*elem1_num_dof + elem2_num_dof*elem2_num_dof]>("indices");
+    auto indices =
+        Kokkos::View<int[elem1_num_dof * elem1_num_dof + elem2_num_dof * elem2_num_dof]>("indices");
 
     Kokkos::parallel_for(1, PopulateSparseIndices{elem_indices, node_state_indices, indices});
 
     auto indices_host = Kokkos::create_mirror(indices);
     Kokkos::deep_copy(indices_host, indices);
-    for(int row = 0; row < elem1_num_dof; ++row) {
-        for(int column = 0; column < elem1_num_dof; ++column) {
-            EXPECT_EQ(indices_host(row*elem1_num_dof + column), column);
+    for (int row = 0; row < elem1_num_dof; ++row) {
+        for (int column = 0; column < elem1_num_dof; ++column) {
+            EXPECT_EQ(indices_host(row * elem1_num_dof + column), column);
         }
     }
 
-    auto* indices_host_elem_2 = &indices_host(elem1_num_dof*elem1_num_dof);
-    for(int row = 0; row < elem2_num_dof; ++row) {
-        for(int column = 0; column < elem2_num_dof; ++column) {
-            EXPECT_EQ(indices_host_elem_2[row*elem2_num_dof + column], column + elem1_num_dof);
+    auto* indices_host_elem_2 = &indices_host(elem1_num_dof * elem1_num_dof);
+    for (int row = 0; row < elem2_num_dof; ++row) {
+        for (int column = 0; column < elem2_num_dof; ++column) {
+            EXPECT_EQ(indices_host_elem_2[row * elem2_num_dof + column], column + elem1_num_dof);
         }
     }
 }
-}
+}  // namespace openturbine::restruct_poc::tests

--- a/tests/unit_tests/restruct_poc/solver/test_populate_sparse_row_ptrs.cpp
+++ b/tests/unit_tests/restruct_poc/solver/test_populate_sparse_row_ptrs.cpp
@@ -6,46 +6,50 @@
 namespace openturbine::restruct_poc::tests {
 
 TEST(PopulateSparseRowPtrs, SingleElement) {
-    auto elem_indices_host = Kokkos::View<Beams::ElemIndices[1], Kokkos::HostSpace>("elem_indices_host");
+    auto elem_indices_host =
+        Kokkos::View<Beams::ElemIndices[1], Kokkos::HostSpace>("elem_indices_host");
     auto elem_indices = Kokkos::View<Beams::ElemIndices[1]>("elem_indices");
     elem_indices_host(0).num_nodes = 5;
     Kokkos::deep_copy(elem_indices, elem_indices_host);
 
-    constexpr auto num_rows = 5*6;
-    auto row_ptrs = Kokkos::View<int[num_rows+1]>("row_ptrs");
+    constexpr auto num_rows = 5 * 6;
+    auto row_ptrs = Kokkos::View<int[num_rows + 1]>("row_ptrs");
 
     Kokkos::parallel_for(1, PopulateSparseRowPtrs{elem_indices, row_ptrs});
-    
+
     auto row_ptrs_host = Kokkos::create_mirror(row_ptrs);
     Kokkos::deep_copy(row_ptrs_host, row_ptrs);
-    for(int row = 0; row < num_rows+1; ++row) {
-      EXPECT_EQ(row_ptrs_host(row), num_rows*row);
+    for (int row = 0; row < num_rows + 1; ++row) {
+        EXPECT_EQ(row_ptrs_host(row), num_rows * row);
     }
-    
 }
 
 TEST(PopulateSparseRowPtrs, TwoElements) {
-    auto elem_indices_host = Kokkos::View<Beams::ElemIndices[2], Kokkos::HostSpace>("elem_indices_host");
+    auto elem_indices_host =
+        Kokkos::View<Beams::ElemIndices[2], Kokkos::HostSpace>("elem_indices_host");
     auto elem_indices = Kokkos::View<Beams::ElemIndices[2]>("elem_indices");
     elem_indices_host(0).num_nodes = 5;
     elem_indices_host(1).num_nodes = 3;
     Kokkos::deep_copy(elem_indices, elem_indices_host);
 
-    constexpr auto elem1_rows = 5*6;
-    constexpr auto elem2_rows = 3*6;
+    constexpr auto elem1_rows = 5 * 6;
+    constexpr auto elem2_rows = 3 * 6;
     constexpr auto num_rows = elem1_rows + elem2_rows;
-    auto row_ptrs = Kokkos::View<int[num_rows+1]>("row_ptrs");
+    auto row_ptrs = Kokkos::View<int[num_rows + 1]>("row_ptrs");
 
     Kokkos::parallel_for(1, PopulateSparseRowPtrs{elem_indices, row_ptrs});
-    
+
     auto row_ptrs_host = Kokkos::create_mirror(row_ptrs);
     Kokkos::deep_copy(row_ptrs_host, row_ptrs);
-    for(int row = 0; row < elem1_rows+1; ++row) {
-      EXPECT_EQ(row_ptrs_host(row), elem1_rows*row);
+    for (int row = 0; row < elem1_rows + 1; ++row) {
+        EXPECT_EQ(row_ptrs_host(row), elem1_rows * row);
     }
-    for(int row = elem1_rows*(elem1_rows+1); row < elem1_rows+1+elem2_rows; ++row) {
-        EXPECT_EQ(row_ptrs_host(row), elem1_rows*(elem1_rows+1) + elem2_rows*(row - elem1_rows*(elem1_rows+1)));
+    for (int row = elem1_rows * (elem1_rows + 1); row < elem1_rows + 1 + elem2_rows; ++row) {
+        EXPECT_EQ(
+            row_ptrs_host(row),
+            elem1_rows * (elem1_rows + 1) + elem2_rows * (row - elem1_rows * (elem1_rows + 1))
+        );
     }
 }
 
-}
+}  // namespace openturbine::restruct_poc::tests

--- a/tests/unit_tests/restruct_poc/solver/test_populate_sparse_row_ptrs.cpp
+++ b/tests/unit_tests/restruct_poc/solver/test_populate_sparse_row_ptrs.cpp
@@ -1,0 +1,51 @@
+#include <Kokkos_Core.hpp>
+#include <gtest/gtest.h>
+
+#include "src/restruct_poc/solver/populate_sparse_row_ptrs.hpp"
+
+namespace openturbine::restruct_poc::tests {
+
+TEST(PopulateSparseRowPtrs, SingleElement) {
+    auto elem_indices_host = Kokkos::View<Beams::ElemIndices[1], Kokkos::HostSpace>("elem_indices_host");
+    auto elem_indices = Kokkos::View<Beams::ElemIndices[1]>("elem_indices");
+    elem_indices_host(0).num_nodes = 5;
+    Kokkos::deep_copy(elem_indices, elem_indices_host);
+
+    constexpr auto num_rows = 5*6;
+    auto row_ptrs = Kokkos::View<int[num_rows+1]>("row_ptrs");
+
+    Kokkos::parallel_for(1, PopulateSparseRowPtrs{elem_indices, row_ptrs});
+    
+    auto row_ptrs_host = Kokkos::create_mirror(row_ptrs);
+    Kokkos::deep_copy(row_ptrs_host, row_ptrs);
+    for(int row = 0; row < num_rows+1; ++row) {
+      EXPECT_EQ(row_ptrs_host(row), num_rows*row);
+    }
+    
+}
+
+TEST(PopulateSparseRowPtrs, TwoElements) {
+    auto elem_indices_host = Kokkos::View<Beams::ElemIndices[2], Kokkos::HostSpace>("elem_indices_host");
+    auto elem_indices = Kokkos::View<Beams::ElemIndices[2]>("elem_indices");
+    elem_indices_host(0).num_nodes = 5;
+    elem_indices_host(1).num_nodes = 3;
+    Kokkos::deep_copy(elem_indices, elem_indices_host);
+
+    constexpr auto elem1_rows = 5*6;
+    constexpr auto elem2_rows = 3*6;
+    constexpr auto num_rows = elem1_rows + elem2_rows;
+    auto row_ptrs = Kokkos::View<int[num_rows+1]>("row_ptrs");
+
+    Kokkos::parallel_for(1, PopulateSparseRowPtrs{elem_indices, row_ptrs});
+    
+    auto row_ptrs_host = Kokkos::create_mirror(row_ptrs);
+    Kokkos::deep_copy(row_ptrs_host, row_ptrs);
+    for(int row = 0; row < elem1_rows+1; ++row) {
+      EXPECT_EQ(row_ptrs_host(row), elem1_rows*row);
+    }
+    for(int row = elem1_rows*(elem1_rows+1); row < elem1_rows+1+elem2_rows; ++row) {
+        EXPECT_EQ(row_ptrs_host(row), elem1_rows*(elem1_rows+1) + elem2_rows*(row - elem1_rows*(elem1_rows+1)));
+    }
+}
+
+}


### PR DESCRIPTION
This commit changes the AssembleSystem function to use a sparse matrix internally for matrix multiplication and addition.  The matrices are still initially assembled into dense matrices, and the final result is copied back into the dense system matrix, so there are no changes outside of this one function.

This commit accomplishes two goals:
1.  It is the first step in us using sparse matrices everywhere in our code for the system assembly/solve.  Future work will involve using sparse matrices for the constraint construction, system solve, and removing the current working dense matrices.  
2. It improves performance for medium/large problems significantly.  Using the 15MWRotor problem with 300 blades (instead of the standard 3) as a proxy for a large problem and running on a NVIDIA V100S GPU, we see a performance improvement from 78.5s to 33.4s.  Assemble system, which was previously the majority of the runtime, now represents a very small proportion of the runtime.  This problem runtime is now dominated by the system solve (a dense direct solve) and constraint assembly (a dense matrix multiplication).   