### PR TITLE
Add tests and some slight refactoring of UpdateState Kernels

### DIFF
--- a/src/restruct_poc/system/calculate_Ouu.hpp
+++ b/src/restruct_poc/system/calculate_Ouu.hpp
@@ -9,6 +9,9 @@
 namespace openturbine {
 
 struct CalculateOuu {
+    using NoTranspose = KokkosBatched::Trans::NoTranspose;
+    using Default = KokkosBatched::Algo::Gemm::Default;
+    using Gemm = KokkosBatched::SerialGemm<NoTranspose, NoTranspose, Default>;
     View_Nx6x6::const_type qp_Cuu_;
     View_Nx3x3::const_type x0pupSS_;
     View_Nx3x3::const_type M_tilde_;
@@ -28,14 +31,10 @@ struct CalculateOuu {
         KokkosBlas::SerialSet::invoke(0., Ouu);
         auto Ouu_12 = Kokkos::subview(Ouu, Kokkos::make_pair(0, 3), Kokkos::make_pair(3, 6));
         KokkosBlas::serial_axpy(1., N_tilde, Ouu_12);
-        KokkosBatched::SerialGemm<
-            KokkosBatched::Trans::NoTranspose, KokkosBatched::Trans::NoTranspose,
-            KokkosBatched::Algo::Gemm::Default>::invoke(1., C11, x0pupSS, -1., Ouu_12);
+        Gemm::invoke(1., C11, x0pupSS, -1., Ouu_12);
         auto Ouu_22 = Kokkos::subview(Ouu, Kokkos::make_pair(3, 6), Kokkos::make_pair(3, 6));
         KokkosBlas::serial_axpy(1., M_tilde, Ouu_22);
-        KokkosBatched::SerialGemm<
-            KokkosBatched::Trans::NoTranspose, KokkosBatched::Trans::NoTranspose,
-            KokkosBatched::Algo::Gemm::Default>::invoke(1., C21, x0pupSS, -1., Ouu_22);
+        Gemm::invoke(1., C21, x0pupSS, -1., Ouu_22);
     }
 };
 

--- a/src/restruct_poc/system/calculate_Ouu.hpp
+++ b/src/restruct_poc/system/calculate_Ouu.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <KokkosBatched_Gemm_Decl.hpp>
+#include <KokkosBlas.hpp>
 #include <KokkosBlas1_set.hpp>
 #include <Kokkos_Core.hpp>
 

--- a/src/restruct_poc/system/calculate_Puu.hpp
+++ b/src/restruct_poc/system/calculate_Puu.hpp
@@ -9,6 +9,10 @@
 namespace openturbine {
 
 struct CalculatePuu {
+    using NoTranspose = KokkosBatched::Trans::NoTranspose;
+    using Transpose = KokkosBatched::Trans::Transpose;
+    using Default = KokkosBatched::Algo::Gemm::Default;
+    using GemmTN = KokkosBatched::SerialGemm<Transpose, NoTranspose, Default>;
     View_Nx6x6::const_type qp_Cuu_;
     View_Nx3x3::const_type x0pupSS_;
     View_Nx3x3::const_type N_tilde_;
@@ -26,13 +30,9 @@ struct CalculatePuu {
         KokkosBlas::SerialSet::invoke(0., Puu);
         auto Puu_21 = Kokkos::subview(Puu, Kokkos::make_pair(3, 6), Kokkos::make_pair(0, 3));
         KokkosBlas::serial_axpy(1., N_tilde, Puu_21);
-        KokkosBatched::SerialGemm<
-            KokkosBatched::Trans::Transpose, KokkosBatched::Trans::NoTranspose,
-            KokkosBatched::Algo::Gemm::Default>::invoke(1., x0pupSS, C11, 1., Puu_21);
+        GemmTN::invoke(1., x0pupSS, C11, 1., Puu_21);
         auto Puu_22 = Kokkos::subview(Puu, Kokkos::make_pair(3, 6), Kokkos::make_pair(3, 6));
-        KokkosBatched::SerialGemm<
-            KokkosBatched::Trans::Transpose, KokkosBatched::Trans::NoTranspose,
-            KokkosBatched::Algo::Gemm::Default>::invoke(1., x0pupSS, C12, 0., Puu_22);
+        GemmTN::invoke(1., x0pupSS, C12, 0., Puu_22);
     }
 };
 

--- a/src/restruct_poc/system/calculate_Puu.hpp
+++ b/src/restruct_poc/system/calculate_Puu.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <KokkosBatched_Gemm_Decl.hpp>
+#include <KokkosBlas.hpp>
 #include <KokkosBlas1_set.hpp>
 #include <Kokkos_Core.hpp>
 

--- a/src/restruct_poc/system/calculate_Quu.hpp
+++ b/src/restruct_poc/system/calculate_Quu.hpp
@@ -9,6 +9,11 @@
 namespace openturbine {
 
 struct CalculateQuu {
+    using NoTranspose = KokkosBatched::Trans::NoTranspose;
+    using Transpose = KokkosBatched::Trans::Transpose;
+    using Default = KokkosBatched::Algo::Gemm::Default;
+    using GemmNN = KokkosBatched::SerialGemm<NoTranspose, NoTranspose, Default>;
+    using GemmTN = KokkosBatched::SerialGemm<Transpose, NoTranspose, Default>;
     View_Nx6x6::const_type qp_Cuu_;
     View_Nx3x3::const_type x0pupSS_;
     View_Nx3x3::const_type N_tilde_;
@@ -20,19 +25,15 @@ struct CalculateQuu {
         auto x0pupSS = Kokkos::subview(x0pupSS_, i_qp, Kokkos::ALL, Kokkos::ALL);
         auto N_tilde = Kokkos::subview(N_tilde_, i_qp, Kokkos::ALL, Kokkos::ALL);
         auto m1 = Kokkos::Array<double, 9>{};
-        auto M1 = Kokkos::View<double[3][3], Kokkos::MemoryTraits<Kokkos::Unmanaged>>(m1.data());
+        auto M1 = Kokkos::View<double[3][3]>(m1.data());
         auto Quu = Kokkos::subview(qp_Quu_, i_qp, Kokkos::ALL, Kokkos::ALL);
 
         auto C11 = Kokkos::subview(Cuu, Kokkos::make_pair(0, 3), Kokkos::make_pair(0, 3));
         KokkosBlas::SerialSet::invoke(0., Quu);
         KokkosBlas::serial_axpy(1., N_tilde, M1);
-        KokkosBatched::SerialGemm<
-            KokkosBatched::Trans::NoTranspose, KokkosBatched::Trans::NoTranspose,
-            KokkosBatched::Algo::Gemm::Default>::invoke(1., C11, x0pupSS, -1., M1);
+        GemmNN::invoke(1., C11, x0pupSS, -1., M1);
         auto Quu_22 = Kokkos::subview(Quu, Kokkos::make_pair(3, 6), Kokkos::make_pair(3, 6));
-        KokkosBatched::SerialGemm<
-            KokkosBatched::Trans::Transpose, KokkosBatched::Trans::NoTranspose,
-            KokkosBatched::Algo::Gemm::Default>::invoke(1., x0pupSS, M1, 0., Quu_22);
+        GemmTN::invoke(1., x0pupSS, M1, 0., Quu_22);
     }
 };
 

--- a/src/restruct_poc/system/calculate_Quu.hpp
+++ b/src/restruct_poc/system/calculate_Quu.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <KokkosBatched_Gemm_Decl.hpp>
+#include <KokkosBlas.hpp>
 #include <KokkosBlas1_set.hpp>
 #include <Kokkos_Core.hpp>
 

--- a/src/restruct_poc/system/calculate_RR0.hpp
+++ b/src/restruct_poc/system/calculate_RR0.hpp
@@ -8,22 +8,19 @@
 namespace openturbine {
 
 struct CalculateRR0 {
-    View_Nx4::const_type qp_r0_;  // quadrature point initial rotation
-    View_Nx4::const_type qp_r_;   // quadrature rotation displacement
-    View_Nx6x6 qp_RR0_;           // quadrature global rotation
+    View_Nx4::const_type qp_r0_;
+    View_Nx4::const_type qp_r_;
+    View_Nx6x6 qp_RR0_;
 
     KOKKOS_FUNCTION void operator()(const int i_qp) const {
         auto RR0_quaternion_data = Kokkos::Array<double, 4>{};
-        auto RR0_quaternion = Kokkos::View<double[4], Kokkos::MemoryTraits<Kokkos::Unmanaged>>(
-            RR0_quaternion_data.data()
-        );
+        auto RR0_quaternion = Kokkos::View<double[4]>(RR0_quaternion_data.data());
         QuaternionCompose(
             Kokkos::subview(qp_r_, i_qp, Kokkos::ALL), Kokkos::subview(qp_r0_, i_qp, Kokkos::ALL),
             RR0_quaternion
         );
         auto RR0_data = Kokkos::Array<double, 9>{};
-        auto RR0 =
-            Kokkos::View<double[3][3], Kokkos::MemoryTraits<Kokkos::Unmanaged>>(RR0_data.data());
+        auto RR0 = Kokkos::View<double[3][3]>(RR0_data.data());
         QuaternionToRotationMatrix(RR0_quaternion, RR0);
         for (int i = 0; i < 3; ++i) {
             for (int j = 0; j < 3; ++j) {

--- a/src/restruct_poc/system/calculate_force_FC.hpp
+++ b/src/restruct_poc/system/calculate_force_FC.hpp
@@ -9,6 +9,9 @@
 namespace openturbine {
 
 struct CalculateForceFC {
+    using NoTranspose = KokkosBlas::Trans::NoTranspose;
+    using Default = KokkosBlas::Algo::Gemv::Default;
+    using Gemv = KokkosBlas::SerialGemv<NoTranspose, Default>;
     View_Nx6x6::const_type qp_Cuu_;
     View_Nx6::const_type qp_strain_;
     View_Nx6 qp_FC_;
@@ -23,8 +26,7 @@ struct CalculateForceFC {
         auto M_tilde = Kokkos::subview(M_tilde_, i_qp, Kokkos::ALL, Kokkos::ALL);
         auto N_tilde = Kokkos::subview(N_tilde_, i_qp, Kokkos::ALL, Kokkos::ALL);
 
-        KokkosBlas::SerialGemv<KokkosBlas::Trans::NoTranspose, KokkosBlas::Algo::Gemv::Default>::
-            invoke(1., Cuu, strain, 0., FC);
+        Gemv::invoke(1., Cuu, strain, 0., FC);
         auto N = Kokkos::subview(FC, Kokkos::make_pair(0, 3));
         auto M = Kokkos::subview(FC, Kokkos::make_pair(3, 6));
         VecTilde(M, M_tilde);

--- a/src/restruct_poc/system/calculate_force_FD.hpp
+++ b/src/restruct_poc/system/calculate_force_FD.hpp
@@ -9,6 +9,9 @@
 namespace openturbine {
 
 struct CalculateForceFD {
+    using Transpose = KokkosBlas::Trans::Transpose;
+    using Default = KokkosBlas::Algo::Gemv::Default;
+    using Gemv = KokkosBlas::SerialGemv<Transpose, Default>;
     View_Nx3x3::const_type x0pupSS_;
     View_Nx6::const_type qp_FC_;
     View_Nx6 qp_FD_;
@@ -23,8 +26,7 @@ struct CalculateForceFD {
         for (int i = 0; i < FD.extent_int(0); ++i) {
             FD(i) = 0.;
         }
-        KokkosBlas::SerialGemv<KokkosBlas::Trans::Transpose, KokkosBlas::Algo::Gemv::Default>::
-            invoke(1., x0pupSS, N, 0., Kokkos::subview(FD, Kokkos::make_pair(3, 6)));
+        Gemv::invoke(1., x0pupSS, N, 0., Kokkos::subview(FD, Kokkos::make_pair(3, 6)));
     }
 };
 

--- a/src/restruct_poc/system/calculate_gravity_force.hpp
+++ b/src/restruct_poc/system/calculate_gravity_force.hpp
@@ -9,6 +9,9 @@
 namespace openturbine {
 
 struct CalculateGravityForce {
+    using NoTranspose = KokkosBlas::Trans::NoTranspose;
+    using Default = KokkosBlas::Algo::Gemv::Default;
+    using Gemv = KokkosBlas::SerialGemv<NoTranspose, Default>;
     View_3::const_type gravity;
     View_Nx6x6::const_type qp_Muu_;
     View_Nx3x3::const_type eta_tilde_;
@@ -23,11 +26,7 @@ struct CalculateGravityForce {
         for (int i = 0; i < 3; ++i) {
             FG(i) = m * gravity(i);
         }
-        KokkosBlas::SerialGemv<KokkosBlas::Trans::NoTranspose, KokkosBlas::Algo::Gemv::Default>::
-            invoke(
-                1., eta_tilde, Kokkos::subview(FG, Kokkos::make_pair(0, 3)), 0.,
-                Kokkos::subview(FG, Kokkos::make_pair(3, 6))
-            );
+        Gemv::invoke(1., eta_tilde, Kokkos::subview(FG, Kokkos::make_pair(0, 3)), 0., Kokkos::subview(FG, Kokkos::make_pair(3, 6)));
     }
 };
 

--- a/src/restruct_poc/system/calculate_gravity_force.hpp
+++ b/src/restruct_poc/system/calculate_gravity_force.hpp
@@ -26,7 +26,10 @@ struct CalculateGravityForce {
         for (int i = 0; i < 3; ++i) {
             FG(i) = m * gravity(i);
         }
-        Gemv::invoke(1., eta_tilde, Kokkos::subview(FG, Kokkos::make_pair(0, 3)), 0., Kokkos::subview(FG, Kokkos::make_pair(3, 6)));
+        Gemv::invoke(
+            1., eta_tilde, Kokkos::subview(FG, Kokkos::make_pair(0, 3)), 0.,
+            Kokkos::subview(FG, Kokkos::make_pair(3, 6))
+        );
     }
 };
 

--- a/src/restruct_poc/system/calculate_gyroscopic_matrix.hpp
+++ b/src/restruct_poc/system/calculate_gyroscopic_matrix.hpp
@@ -11,6 +11,13 @@
 namespace openturbine {
 
 struct CalculateGyroscopicMatrix {
+    using NoTranspose = KokkosBatched::Trans::NoTranspose;
+    using Transpose = KokkosBatched::Trans::Transpose;
+    using GemmDefault = KokkosBatched::Algo::Gemm::Default;
+    using GemvDefault = KokkosBatched::Algo::Gemv::Default;
+    using GemmNN = KokkosBatched::SerialGemm<NoTranspose, NoTranspose, GemmDefault>;
+    using GemmNT = KokkosBatched::SerialGemm<NoTranspose, Transpose, GemmDefault>;
+    using Gemv = KokkosBlas::SerialGemv<NoTranspose, GemvDefault>;
     View_Nx6x6::const_type qp_Muu_;
     View_Nx3::const_type qp_omega_;
     View_Nx3x3::const_type omega_tilde_;
@@ -26,11 +33,11 @@ struct CalculateGyroscopicMatrix {
         auto rho = Kokkos::subview(rho_, i_qp, Kokkos::ALL, Kokkos::ALL);
         auto eta = Kokkos::subview(eta_, i_qp, Kokkos::ALL);
         auto v1 = Kokkos::Array<double, 3>{};
-        auto V1 = Kokkos::View<double[3], Kokkos::MemoryTraits<Kokkos::Unmanaged>>(v1.data());
+        auto V1 = Kokkos::View<double[3]>(v1.data());
         auto v2 = Kokkos::Array<double, 3>{};
-        auto V2 = Kokkos::View<double[3], Kokkos::MemoryTraits<Kokkos::Unmanaged>>(v2.data());
+        auto V2 = Kokkos::View<double[3]>(v2.data());
         auto m1 = Kokkos::Array<double, 9>{};
-        auto M1 = Kokkos::View<double[3][3], Kokkos::MemoryTraits<Kokkos::Unmanaged>>(m1.data());
+        auto M1 = Kokkos::View<double[3][3]>(m1.data());
         auto Guu = Kokkos::subview(qp_Guu_, i_qp, Kokkos::ALL, Kokkos::ALL);
 
         auto m = Muu(0, 0);
@@ -39,8 +46,7 @@ struct CalculateGyroscopicMatrix {
         // omega.tilde() * m * eta.tilde().t() + (omega.tilde() * m * eta).tilde().t()
         auto Guu_12 = Kokkos::subview(Guu, Kokkos::make_pair(0, 3), Kokkos::make_pair(3, 6));
         KokkosBlas::serial_axpy(m, eta, V1);
-        KokkosBlas::SerialGemv<KokkosBlas::Trans::NoTranspose, KokkosBlas::Algo::Gemv::Default>::
-            invoke(1., omega_tilde, V1, 0., V2);
+        Gemv::invoke(1., omega_tilde, V1, 0., V2);
         VecTilde(V2, M1);
         for (int i = 0; i < 3; i++) {
             for (int j = 0; j < 3; j++) {
@@ -49,12 +55,9 @@ struct CalculateGyroscopicMatrix {
         }
 
         VecTilde(V1, M1);
-        KokkosBatched::SerialGemm<
-            KokkosBatched::Trans::NoTranspose, KokkosBatched::Trans::Transpose,
-            KokkosBatched::Algo::Gemm::Default>::invoke(1., omega_tilde, M1, 1., Guu_12);
+        GemmNT::invoke(1., omega_tilde, M1, 1., Guu_12);
         // Guu_22 = omega.tilde() * rho - (rho * omega).tilde()
-        KokkosBlas::SerialGemv<KokkosBlas::Trans::NoTranspose, KokkosBlas::Algo::Gemv::Default>::
-            invoke(1., rho, omega, 0., V1);
+        Gemv::invoke(1., rho, omega, 0., V1);
         VecTilde(V1, M1);
         auto Guu_22 = Kokkos::subview(Guu, Kokkos::make_pair(3, 6), Kokkos::make_pair(3, 6));
         for (int i = 0; i < 3; i++) {
@@ -62,9 +65,7 @@ struct CalculateGyroscopicMatrix {
                 Guu_22(i, j) = M1(i, j);
             }
         }
-        KokkosBatched::SerialGemm<
-            KokkosBatched::Trans::NoTranspose, KokkosBatched::Trans::NoTranspose,
-            KokkosBatched::Algo::Gemm::Default>::invoke(1., omega_tilde, rho, -1., Guu_22);
+        GemmNN::invoke(1., omega_tilde, rho, -1., Guu_22);
     }
 };
 

--- a/src/restruct_poc/system/calculate_inertia_stiffness_matrix.hpp
+++ b/src/restruct_poc/system/calculate_inertia_stiffness_matrix.hpp
@@ -11,6 +11,14 @@
 namespace openturbine {
 
 struct CalculateInertiaStiffnessMatrix {
+    using NoTranspose = KokkosBatched::Trans::NoTranspose;
+    using Transpose = KokkosBatched::Trans::Transpose;
+    using GemmDefault = KokkosBatched::Algo::Gemm::Default;
+    using GemvDefault = KokkosBatched::Algo::Gemv::Default;
+    using GemmNN = KokkosBatched::SerialGemm<NoTranspose, NoTranspose, GemmDefault>;
+    using GemmNT = KokkosBatched::SerialGemm<NoTranspose, Transpose, GemmDefault>;
+    using Gemv = KokkosBlas::SerialGemv<NoTranspose, GemvDefault>;
+
     View_Nx6x6::const_type qp_Muu_;
     View_Nx3::const_type qp_u_ddot_;
     View_Nx3::const_type qp_omega_;
@@ -32,47 +40,33 @@ struct CalculateInertiaStiffnessMatrix {
         auto rho = Kokkos::subview(rho_, i_qp, Kokkos::ALL, Kokkos::ALL);
         auto eta = Kokkos::subview(eta_, i_qp, Kokkos::ALL);
         auto v1 = Kokkos::Array<double, 3>{};
-        auto V1 = Kokkos::View<double[3], Kokkos::MemoryTraits<Kokkos::Unmanaged>>(v1.data());
+        auto V1 = Kokkos::View<double[3]>(v1.data());
         auto m1 = Kokkos::Array<double, 9>{};
-        auto M1 = Kokkos::View<double[3][3], Kokkos::MemoryTraits<Kokkos::Unmanaged>>(m1.data());
+        auto M1 = Kokkos::View<double[3][3]>(m1.data());
         auto m2 = Kokkos::Array<double, 9>{};
-        auto M2 = Kokkos::View<double[3][3], Kokkos::MemoryTraits<Kokkos::Unmanaged>>(m2.data());
+        auto M2 = Kokkos::View<double[3][3]>(m2.data());
         auto Kuu = Kokkos::subview(qp_Kuu_, i_qp, Kokkos::ALL, Kokkos::ALL);
 
         auto m = Muu(0, 0);
 
         KokkosBlas::SerialSet::invoke(0., Kuu);
         KokkosBlas::serial_axpy(1., omega_dot_tilde, M1);
-        KokkosBatched::SerialGemm<
-            KokkosBatched::Trans::NoTranspose, KokkosBatched::Trans::NoTranspose,
-            KokkosBatched::Algo::Gemm::Default>::invoke(1., omega_tilde, omega_tilde, 1., M1);
+        GemmNN::invoke(1., omega_tilde, omega_tilde, 1., M1);
         KokkosBlas::serial_axpy(m, eta, V1);
         VecTilde(V1, M2);
         auto Kuu_12 = Kokkos::subview(Kuu, Kokkos::make_pair(0, 3), Kokkos::make_pair(3, 6));
-        KokkosBatched::SerialGemm<
-            KokkosBatched::Trans::NoTranspose, KokkosBatched::Trans::Transpose,
-            KokkosBatched::Algo::Gemm::Default>::invoke(1., M1, M2, 0., Kuu_12);
+        GemmNT::invoke(1., M1, M2, 0., Kuu_12);
         VecTilde(u_ddot, M1);
         auto Kuu_22 = Kokkos::subview(Kuu, Kokkos::make_pair(3, 6), Kokkos::make_pair(3, 6));
-        KokkosBatched::SerialGemm<
-            KokkosBatched::Trans::NoTranspose, KokkosBatched::Trans::NoTranspose,
-            KokkosBatched::Algo::Gemm::Default>::invoke(1., rho, omega_dot_tilde, 0., Kuu_22);
-        KokkosBatched::SerialGemm<
-            KokkosBatched::Trans::NoTranspose, KokkosBatched::Trans::NoTranspose,
-            KokkosBatched::Algo::Gemm::Default>::invoke(1., M1, M2, 1., Kuu_22);
-        KokkosBlas::SerialGemv<KokkosBlas::Trans::NoTranspose, KokkosBlas::Algo::Gemv::Default>::
-            invoke(1., rho, omega_dot, 0., V1);
+        GemmNN::invoke(1., rho, omega_dot_tilde, 0., Kuu_22);
+        GemmNN::invoke(1., M1, M2, 1., Kuu_22);
+        Gemv::invoke(1., rho, omega_dot, 0., V1);
         VecTilde(V1, M2);
         KokkosBlas::serial_axpy(-1., M2, Kuu_22);
-        KokkosBlas::SerialGemv<KokkosBlas::Trans::NoTranspose, KokkosBlas::Algo::Gemv::Default>::
-            invoke(1., rho, omega, 0., V1);
+        Gemv::invoke(1., rho, omega, 0., V1);
         VecTilde(V1, M1);
-        KokkosBatched::SerialGemm<
-            KokkosBatched::Trans::NoTranspose, KokkosBatched::Trans::NoTranspose,
-            KokkosBatched::Algo::Gemm::Default>::invoke(1., rho, omega_tilde, -1., M1);
-        KokkosBatched::SerialGemm<
-            KokkosBatched::Trans::NoTranspose, KokkosBatched::Trans::NoTranspose,
-            KokkosBatched::Algo::Gemm::Default>::invoke(1., omega_tilde, M1, 1., Kuu_22);
+        GemmNN::invoke(1., rho, omega_tilde, -1., M1);
+        GemmNN::invoke(1., omega_tilde, M1, 1., Kuu_22);
     }
 };
 

--- a/src/restruct_poc/system/calculate_inertial_forces.hpp
+++ b/src/restruct_poc/system/calculate_inertial_forces.hpp
@@ -10,6 +10,11 @@
 namespace openturbine {
 
 struct CalculateInertialForces {
+    using NoTranspose = KokkosBatched::Trans::NoTranspose;
+    using GemmDefault = KokkosBatched::Algo::Gemm::Default;
+    using GemvDefault = KokkosBlas::Algo::Gemv::Default;
+    using Gemm = KokkosBatched::SerialGemm<NoTranspose, NoTranspose, GemmDefault>;
+    using Gemv = KokkosBlas::SerialGemv<NoTranspose, GemvDefault>;
     View_Nx6x6::const_type qp_Muu_;
     View_Nx3::const_type qp_u_ddot_;
     View_Nx3::const_type qp_omega_;
@@ -33,34 +38,26 @@ struct CalculateInertialForces {
         auto rho = Kokkos::subview(rho_, i_qp, Kokkos::ALL, Kokkos::ALL);
         auto eta = Kokkos::subview(eta_, i_qp, Kokkos::ALL);
         auto v1 = Kokkos::Array<double, 3>{};
-        auto V1 = Kokkos::View<double[3], Kokkos::MemoryTraits<Kokkos::Unmanaged>>(v1.data());
+        auto V1 = Kokkos::View<double[3]>(v1.data());
         auto m1 = Kokkos::Array<double, 9>{};
-        auto M1 = Kokkos::View<double[3][3], Kokkos::MemoryTraits<Kokkos::Unmanaged>>(m1.data());
+        auto M1 = Kokkos::View<double[3][3]>(m1.data());
         auto FI = Kokkos::subview(qp_FI_, i_qp, Kokkos::ALL);
 
         auto m = Muu(0, 0);
         VecTilde(omega, omega_tilde);
         VecTilde(omega_dot, omega_dot_tilde);
         auto FI_1 = Kokkos::subview(FI, Kokkos::make_pair(0, 3));
-        KokkosBatched::SerialGemm<
-            KokkosBatched::Trans::NoTranspose, KokkosBatched::Trans::NoTranspose,
-            KokkosBatched::Algo::Gemm::Default>::invoke(m, omega_tilde, omega_tilde, 0., M1);
+        Gemm::invoke(m, omega_tilde, omega_tilde, 0., M1);
         KokkosBlas::serial_axpy(m, omega_dot_tilde, M1);
 
-        KokkosBlas::SerialGemv<KokkosBlas::Trans::NoTranspose, KokkosBlas::Algo::Gemv::Default>::
-            invoke(1., M1, eta, 0., FI_1);
+        Gemv::invoke(1., M1, eta, 0., FI_1);
         KokkosBlas::serial_axpy(m, u_ddot, FI_1);
         auto FI_2 = Kokkos::subview(FI, Kokkos::make_pair(3, 6));
         KokkosBlas::serial_axpy(m, u_ddot, V1);
-        KokkosBlas::SerialGemv<KokkosBlas::Trans::NoTranspose, KokkosBlas::Algo::Gemv::Default>::
-            invoke(1., eta_tilde, V1, 0., FI_2);
-        KokkosBlas::SerialGemv<KokkosBlas::Trans::NoTranspose, KokkosBlas::Algo::Gemv::Default>::
-            invoke(1., rho, omega_dot, 1., FI_2);
-        KokkosBatched::SerialGemm<
-            KokkosBatched::Trans::NoTranspose, KokkosBatched::Trans::NoTranspose,
-            KokkosBatched::Algo::Gemm::Default>::invoke(1., omega_tilde, rho, 0., M1);
-        KokkosBlas::SerialGemv<KokkosBlas::Trans::NoTranspose, KokkosBlas::Algo::Gemv::Default>::
-            invoke(1., M1, omega, 1., FI_2);
+        Gemv::invoke(1., eta_tilde, V1, 0., FI_2);
+        Gemv::invoke(1., rho, omega_dot, 1., FI_2);
+        Gemm::invoke(1., omega_tilde, rho, 0., M1);
+        Gemv::invoke(1., M1, omega, 1., FI_2);
     }
 };
 

--- a/src/restruct_poc/system/calculate_node_forces.hpp
+++ b/src/restruct_poc/system/calculate_node_forces.hpp
@@ -28,11 +28,11 @@ struct CalculateNodeForces_FE {
             const auto weight = qp_weight_(j);
             const auto coeff_c = weight * shape_deriv_(i, j_index);
             const auto coeff_d = weight * qp_jacobian_(j) * shape_interp_(i, j_index);
-            for(int k = 0; k < 6; ++k) {
+            for (int k = 0; k < 6; ++k) {
                 FE[k] += coeff_c * qp_Fc_(j, k) + coeff_d * qp_Fd_(j, k);
             }
         }
-        for(int k = 0; k < 6; ++k) {
+        for (int k = 0; k < 6; ++k) {
             node_FE_(i, k) = FE[k];
         }
     }
@@ -57,11 +57,11 @@ struct CalculateNodeForces_FI_FG {
             const auto j = first_qp + j_index;
             const auto weight = qp_weight_(j);
             const auto coeff_ig = weight * qp_jacobian_(j) * shape_interp_(i, j_index);
-            for(int k = 0; k < 6; ++k) {
+            for (int k = 0; k < 6; ++k) {
                 FIG[k] += coeff_ig * qp_Fig_(j, k);
             }
         }
-        for(int k = 0; k < 6; ++k) {
+        for (int k = 0; k < 6; ++k) {
             node_FIG_(i, k) = FIG[k];
         }
     }
@@ -73,9 +73,9 @@ struct CalculateNodeForces {
     View_N::const_type qp_jacobian_;
     View_NxN::const_type shape_interp_;
     View_NxN::const_type shape_deriv_;
-    View_Nx6::const_type qp_Fc_;                                 
-    View_Nx6::const_type qp_Fd_;                                 
-    View_Nx6::const_type qp_Fi_;                                 
+    View_Nx6::const_type qp_Fc_;
+    View_Nx6::const_type qp_Fd_;
+    View_Nx6::const_type qp_Fi_;
     View_Nx6::const_type qp_Fg_;
     View_Nx6 node_FE_;
     View_Nx6 node_FI_;
@@ -88,9 +88,24 @@ struct CalculateNodeForces {
         const auto first_qp = idx.qp_range.first;
         const auto num_qps = idx.num_qps;
 
-        Kokkos::parallel_for(Kokkos::TeamThreadRange(member, idx.num_nodes), CalculateNodeForces_FE{first_node, first_qp, num_qps, qp_weight_, qp_jacobian_, shape_interp_, shape_deriv_, qp_Fc_, qp_Fd_, node_FE_});
-        Kokkos::parallel_for(Kokkos::TeamThreadRange(member, idx.num_nodes), CalculateNodeForces_FI_FG{first_node, first_qp, num_qps, qp_weight_, qp_jacobian_, shape_interp_, shape_deriv_, qp_Fi_, node_FI_});
-        Kokkos::parallel_for(Kokkos::TeamThreadRange(member, idx.num_nodes), CalculateNodeForces_FI_FG{first_node, first_qp, num_qps, qp_weight_, qp_jacobian_, shape_interp_, shape_deriv_, qp_Fg_, node_FG_});
+        Kokkos::parallel_for(
+            Kokkos::TeamThreadRange(member, idx.num_nodes),
+            CalculateNodeForces_FE{
+                first_node, first_qp, num_qps, qp_weight_, qp_jacobian_, shape_interp_, shape_deriv_,
+                qp_Fc_, qp_Fd_, node_FE_}
+        );
+        Kokkos::parallel_for(
+            Kokkos::TeamThreadRange(member, idx.num_nodes),
+            CalculateNodeForces_FI_FG{
+                first_node, first_qp, num_qps, qp_weight_, qp_jacobian_, shape_interp_, shape_deriv_,
+                qp_Fi_, node_FI_}
+        );
+        Kokkos::parallel_for(
+            Kokkos::TeamThreadRange(member, idx.num_nodes),
+            CalculateNodeForces_FI_FG{
+                first_node, first_qp, num_qps, qp_weight_, qp_jacobian_, shape_interp_, shape_deriv_,
+                qp_Fg_, node_FG_}
+        );
     }
 };
 }  // namespace openturbine

--- a/src/restruct_poc/system/calculate_node_forces.hpp
+++ b/src/restruct_poc/system/calculate_node_forces.hpp
@@ -7,6 +7,66 @@
 
 namespace openturbine {
 
+struct CalculateNodeForces_FE {
+    int first_node;
+    int first_qp;
+    int num_qps;
+    View_N::const_type qp_weight_;
+    View_N::const_type qp_jacobian_;
+    View_NxN::const_type shape_interp_;
+    View_NxN::const_type shape_deriv_;
+    View_Nx6::const_type qp_Fc_;
+    View_Nx6::const_type qp_Fd_;
+    View_Nx6 node_FE_;
+
+    KOKKOS_FUNCTION
+    void operator()(int i_index) const {
+        const auto i = first_node + i_index;
+        auto FE = Kokkos::Array<double, 6>{};
+        for (int j_index = 0; j_index < num_qps; ++j_index) {  // QPs
+            const auto j = first_qp + j_index;
+            const auto weight = qp_weight_(j);
+            const auto coeff_c = weight * shape_deriv_(i, j_index);
+            const auto coeff_d = weight * qp_jacobian_(j) * shape_interp_(i, j_index);
+            for(int k = 0; k < 6; ++k) {
+                FE[k] += coeff_c * qp_Fc_(j, k) + coeff_d * qp_Fd_(j, k);
+            }
+        }
+        for(int k = 0; k < 6; ++k) {
+            node_FE_(i, k) = FE[k];
+        }
+    }
+};
+
+struct CalculateNodeForces_FI_FG {
+    int first_node;
+    int first_qp;
+    int num_qps;
+    View_N::const_type qp_weight_;
+    View_N::const_type qp_jacobian_;
+    View_NxN::const_type shape_interp_;
+    View_NxN::const_type shape_deriv_;
+    View_Nx6::const_type qp_Fig_;
+    View_Nx6 node_FIG_;
+
+    KOKKOS_FUNCTION
+    void operator()(int i_index) const {
+        const auto i = first_node + i_index;
+        auto FIG = Kokkos::Array<double, 6>{};
+        for (int j_index = 0; j_index < num_qps; ++j_index) {  // QPs
+            const auto j = first_qp + j_index;
+            const auto weight = qp_weight_(j);
+            const auto coeff_ig = weight * qp_jacobian_(j) * shape_interp_(i, j_index);
+            for(int k = 0; k < 6; ++k) {
+                FIG[k] += coeff_ig * qp_Fig_(j, k);
+            }
+        }
+        for(int k = 0; k < 6; ++k) {
+            node_FIG_(i, k) = FIG[k];
+        }
+    }
+};
+
 struct CalculateNodeForces {
     Kokkos::View<Beams::ElemIndices*>::const_type elem_indices;  // Element indices
     View_N::const_type qp_weight_;                               //
@@ -22,236 +82,15 @@ struct CalculateNodeForces {
     View_Nx6 node_FG_;                                           // Gravity force
 
     KOKKOS_FUNCTION
-    void operator()(const int i_elem) const {
-        auto idx = elem_indices[i_elem];
-
-        for (int i = idx.node_range.first; i < idx.node_range.second; ++i) {
-            for (int j = 0; j < 6; ++j) {
-                node_FE_(i, j) = 0.;
-                node_FG_(i, j) = 0.;
-                node_FI_(i, j) = 0.;
-            }
-        }
-
-        for (int i_index = 0; i_index < idx.num_nodes; ++i_index) {    // Nodes
-            for (int j_index = 0; j_index < idx.num_qps; ++j_index) {  // QPs
-                const auto i = idx.node_range.first + i_index;
-                const auto j = idx.qp_range.first + j_index;
-                const auto weight = qp_weight_(j);
-                const auto coeff_c = weight * shape_deriv_(i, j_index);
-                const auto coeff_d = weight * qp_jacobian_(j) * shape_interp_(i, j_index);
-                const auto coeff_i = coeff_d;
-                const auto coeff_g = coeff_d;
-                for (int k = 0; k < 6; ++k) {  // Components
-                    node_FE_(i, k) += coeff_c * qp_Fc_(j, k) + coeff_d * qp_Fd_(j, k);
-                }
-                for (int k = 0; k < 6; ++k) {  // Components
-                    node_FI_(i, k) += coeff_i * qp_Fi_(j, k);
-                }
-                for (int k = 0; k < 6; ++k) {  // Components
-                    node_FG_(i, k) += coeff_g * qp_Fg_(j, k);
-                }
-            }
-        }
-    }
-
-    KOKKOS_FUNCTION
     void operator()(Kokkos::TeamPolicy<>::member_type member) const {
         const auto idx = elem_indices(member.league_rank());
-        Kokkos::parallel_for(
-            Kokkos::TeamThreadMDRange(member, idx.num_nodes, 6),
-            [=](int i_index, int j) {
-                const auto i = idx.node_range.first + i_index;
-                node_FE_(i, j) = 0.;
-                node_FG_(i, j) = 0.;
-                node_FI_(i, j) = 0.;
-            }
-        );
+        const auto first_node = idx.node_range.first;
+        const auto first_qp = idx.qp_range.first;
+        const auto num_qps = idx.num_qps;
 
-        Kokkos::parallel_for(Kokkos::TeamThreadRange(member, idx.num_nodes), [=](int i_index) {
-            for (int j_index = 0; j_index < idx.num_qps; ++j_index) {  // QPs
-                const auto i = idx.node_range.first + i_index;
-                const auto j = idx.qp_range.first + j_index;
-                const auto weight = qp_weight_(j);
-                const auto coeff_c = weight * shape_deriv_(i, j_index);
-                const auto coeff_d = weight * qp_jacobian_(j) * shape_interp_(i, j_index);
-                const auto coeff_i = coeff_d;
-                const auto coeff_g = coeff_d;
-                Kokkos::parallel_for(Kokkos::ThreadVectorRange(member, 6), [=](int k) {
-                    node_FE_(i, k) += coeff_c * qp_Fc_(j, k) + coeff_d * qp_Fd_(j, k);
-                });
-                Kokkos::parallel_for(Kokkos::ThreadVectorRange(member, 6), [=](int k) {
-                    node_FI_(i, k) += coeff_i * qp_Fi_(j, k);
-                });
-                Kokkos::parallel_for(Kokkos::ThreadVectorRange(member, 6), [=](int k) {
-                    node_FG_(i, k) += coeff_g * qp_Fg_(j, k);
-                });
-            }
-        });
-    }
-
-    KOKKOS_FUNCTION
-    void operator()(const int i_elem, const int i_index) const {
-        const auto idx = elem_indices(i_elem);
-        const auto i = idx.node_range.first + i_index;
-
-        if (i_index >= idx.num_nodes) {
-            return;
-        }
-
-        auto local_FE = Kokkos::Array<double, 6>{};
-        auto local_FI = Kokkos::Array<double, 6>{};
-        auto local_FG = Kokkos::Array<double, 6>{};
-
-        for (int j_index = 0; j_index < idx.num_qps; ++j_index) {
-            const auto j = idx.qp_range.first + j_index;
-            const auto weight = qp_weight_(j);
-            const auto coeff_c = weight * shape_deriv_(i, j_index);
-            const auto coeff_d = weight * qp_jacobian_(j) * shape_interp_(i, j_index);
-            const auto coeff_i = coeff_d;
-            const auto coeff_g = coeff_d;
-            for (int k = 0; k < 6; ++k) {
-                local_FE[k] += coeff_c * qp_Fc_(j, k) + coeff_d * qp_Fd_(j, k);
-                local_FI[k] += coeff_i * qp_Fi_(j, k);
-                local_FG[k] += coeff_g * qp_Fg_(j, k);
-            }
-        }
-
-        for (int k = 0; k < 6; ++k) {
-            node_FE_(i, k) = local_FE[k];
-            node_FI_(i, k) = local_FI[k];
-            node_FG_(i, k) = local_FG[k];
-        }
-    }
-
-    KOKKOS_FUNCTION
-    void operator()(const int i_elem, const int i_index, const int k) const {
-        const auto idx = elem_indices(i_elem);
-        const auto i = idx.node_range.first + i_index;
-
-        if (i_index >= idx.num_nodes || k >= 6) {
-            return;
-        }
-
-        auto local_FE = 0.;
-        auto local_FI = 0.;
-        auto local_FG = 0.;
-
-        for (int j_index = 0; j_index < idx.num_qps; ++j_index) {
-            const auto j = idx.qp_range.first + j_index;
-            const auto weight = qp_weight_(j);
-            const auto coeff_c = weight * shape_deriv_(i, j_index);
-            const auto coeff_d = weight * qp_jacobian_(j) * shape_interp_(i, j_index);
-            const auto coeff_i = coeff_d;
-            const auto coeff_g = coeff_d;
-            local_FE += coeff_c * qp_Fc_(j, k) + coeff_d * qp_Fd_(j, k);
-            local_FI += coeff_i * qp_Fi_(j, k);
-            local_FG += coeff_g * qp_Fg_(j, k);
-        }
-
-        node_FE_(i, k) = local_FE;
-        node_FI_(i, k) = local_FI;
-        node_FG_(i, k) = local_FG;
-    }
-};
-
-struct CalculateNodeForces_FE {
-    Kokkos::View<Beams::ElemIndices*>::const_type elem_indices;  // Element indices
-    View_N::const_type qp_weight_;                               //
-    View_N::const_type qp_jacobian_;                             // Jacobians
-    View_NxN::const_type shape_interp_;                          // Num Nodes x Num Quadrature points
-    View_NxN::const_type shape_deriv_;                           // Num Nodes x Num Quadrature points
-    View_Nx6::const_type qp_Fc_;                                 //
-    View_Nx6::const_type qp_Fd_;                                 //
-    View_Nx6 node_FE_;                                           // Elastic force
-
-    KOKKOS_FUNCTION
-    void operator()(const int i_elem, const int i_index) const {
-        const auto idx = elem_indices(i_elem);
-        const auto i = idx.node_range.first + i_index;
-
-        if (i_index >= idx.num_nodes) {
-            return;
-        }
-
-        auto local_FE = Kokkos::Array<double, 6>{};
-        for (int j_index = 0; j_index < idx.num_qps; ++j_index) {
-            const auto j = idx.qp_range.first + j_index;
-            const auto weight = qp_weight_(j);
-            const auto coeff_c = weight * shape_deriv_(i, j_index);
-            const auto coeff_d = weight * qp_jacobian_(j) * shape_interp_(i, j_index);
-            for (int k = 0; k < 6; ++k) {
-                local_FE[k] += coeff_c * qp_Fc_(j, k) + coeff_d * qp_Fd_(j, k);
-            }
-        }
-        for (int k = 0; k < 6; ++k) {
-            node_FE_(i, k) = local_FE[k];
-        }
-    }
-};
-
-struct CalculateNodeForces_FI {
-    Kokkos::View<Beams::ElemIndices*>::const_type elem_indices;  // Element indices
-    View_N::const_type qp_weight_;                               //
-    View_N::const_type qp_jacobian_;                             // Jacobians
-    View_NxN::const_type shape_interp_;                          // Num Nodes x Num Quadrature points
-    View_NxN::const_type shape_deriv_;                           // Num Nodes x Num Quadrature points
-    View_Nx6::const_type qp_Fi_;                                 //
-    View_Nx6 node_FI_;                                           // Elastic force
-
-    KOKKOS_FUNCTION
-    void operator()(const int i_elem, const int i_index) const {
-        const auto idx = elem_indices(i_elem);
-        const auto i = idx.node_range.first + i_index;
-
-        if (i_index >= idx.num_nodes) {
-            return;
-        }
-
-        auto local_FI = Kokkos::Array<double, 6>{};
-        for (int j_index = 0; j_index < idx.num_qps; ++j_index) {
-            const auto j = idx.qp_range.first + j_index;
-            const auto weight = qp_weight_(j);
-            const auto coeff_i = weight * qp_jacobian_(j) * shape_interp_(i, j_index);
-            for (int k = 0; k < 6; ++k) {
-                local_FI[k] += coeff_i * qp_Fi_(j, k);
-            }
-        }
-        for (int k = 0; k < 6; ++k) {
-            node_FI_(i, k) = local_FI[k];
-        }
-    }
-};
-
-struct CalculateNodeForces_FG {
-    Kokkos::View<Beams::ElemIndices*>::const_type elem_indices;  // Element indices
-    View_N::const_type qp_weight_;                               //
-    View_N::const_type qp_jacobian_;                             // Jacobians
-    View_NxN::const_type shape_interp_;                          // Num Nodes x Num Quadrature points
-    View_NxN::const_type shape_deriv_;                           // Num Nodes x Num Quadrature points
-    View_Nx6::const_type qp_Fg_;                                 //
-    View_Nx6 node_FG_;                                           // Elastic force
-
-    KOKKOS_FUNCTION
-    void operator()(const int i_elem, const int i_index) const {
-        const auto idx = elem_indices(i_elem);
-        const auto i = idx.node_range.first + i_index;
-        if (i_index >= idx.num_nodes) {
-            return;
-        }
-
-        auto local_FG = Kokkos::Array<double, 6>{};
-        for (int j_index = 0; j_index < idx.num_qps; ++j_index) {
-            const auto j = idx.qp_range.first + j_index;
-            const auto weight = qp_weight_(j);
-            const auto coeff_g = weight * qp_jacobian_(j) * shape_interp_(i, j_index);
-            for (int k = 0; k < 6; ++k) {
-                local_FG[k] += coeff_g * qp_Fg_(j, k);
-            }
-        }
-        for (int k = 0; k < 6; ++k) {
-            node_FG_(i, k) = local_FG[k];
-        }
+        Kokkos::parallel_for(Kokkos::TeamThreadRange(member, idx.num_nodes), CalculateNodeForces_FE{first_node, first_qp, num_qps, qp_weight_, qp_jacobian_, shape_interp_, shape_deriv_, qp_Fc_, qp_Fd_, node_FE_});
+        Kokkos::parallel_for(Kokkos::TeamThreadRange(member, idx.num_nodes), CalculateNodeForces_FI_FG{first_node, first_qp, num_qps, qp_weight_, qp_jacobian_, shape_interp_, shape_deriv_, qp_Fi_, node_FI_});
+        Kokkos::parallel_for(Kokkos::TeamThreadRange(member, idx.num_nodes), CalculateNodeForces_FI_FG{first_node, first_qp, num_qps, qp_weight_, qp_jacobian_, shape_interp_, shape_deriv_, qp_Fg_, node_FG_});
     }
 };
 }  // namespace openturbine

--- a/src/restruct_poc/system/calculate_node_forces.hpp
+++ b/src/restruct_poc/system/calculate_node_forces.hpp
@@ -68,18 +68,18 @@ struct CalculateNodeForces_FI_FG {
 };
 
 struct CalculateNodeForces {
-    Kokkos::View<Beams::ElemIndices*>::const_type elem_indices;  // Element indices
-    View_N::const_type qp_weight_;                               //
-    View_N::const_type qp_jacobian_;                             // Jacobians
-    View_NxN::const_type shape_interp_;                          // Num Nodes x Num Quadrature points
-    View_NxN::const_type shape_deriv_;                           // Num Nodes x Num Quadrature points
-    View_Nx6::const_type qp_Fc_;                                 //
-    View_Nx6::const_type qp_Fd_;                                 //
-    View_Nx6::const_type qp_Fi_;                                 //
-    View_Nx6::const_type qp_Fg_;                                 //
-    View_Nx6 node_FE_;                                           // Elastic force
-    View_Nx6 node_FI_;                                           // Inertial force
-    View_Nx6 node_FG_;                                           // Gravity force
+    Kokkos::View<Beams::ElemIndices*>::const_type elem_indices;
+    View_N::const_type qp_weight_;
+    View_N::const_type qp_jacobian_;
+    View_NxN::const_type shape_interp_;
+    View_NxN::const_type shape_deriv_;
+    View_Nx6::const_type qp_Fc_;                                 
+    View_Nx6::const_type qp_Fd_;                                 
+    View_Nx6::const_type qp_Fi_;                                 
+    View_Nx6::const_type qp_Fg_;
+    View_Nx6 node_FE_;
+    View_Nx6 node_FI_;
+    View_Nx6 node_FG_;
 
     KOKKOS_FUNCTION
     void operator()(Kokkos::TeamPolicy<>::member_type member) const {

--- a/src/restruct_poc/system/calculate_strain.hpp
+++ b/src/restruct_poc/system/calculate_strain.hpp
@@ -16,7 +16,7 @@ struct CalculateStrain {
     View_Nx3::const_type qp_x0_prime_;
     View_Nx3::const_type qp_u_prime_;
     View_Nx4::const_type qp_r_;
-    View_Nx4::const_type qp_r_prime_; 
+    View_Nx4::const_type qp_r_prime_;
     View_Nx6 qp_strain_;
 
     KOKKOS_FUNCTION

--- a/src/restruct_poc/system/calculate_strain.hpp
+++ b/src/restruct_poc/system/calculate_strain.hpp
@@ -10,45 +10,43 @@
 namespace openturbine {
 
 struct CalculateStrain {
-    View_Nx3::const_type qp_x0_prime_;  //
-    View_Nx3::const_type qp_u_prime_;   //
-    View_Nx4::const_type qp_r_;         //
-    View_Nx4::const_type qp_r_prime_;   //
-    View_Nx6 qp_strain_;                //
+    using NoTranspose = KokkosBlas::Trans::NoTranspose;
+    using Default = KokkosBlas::Algo::Gemv::Default;
+    using Gemv = KokkosBlas::SerialGemv<NoTranspose, Default>;
+    View_Nx3::const_type qp_x0_prime_;
+    View_Nx3::const_type qp_u_prime_;
+    View_Nx4::const_type qp_r_;
+    View_Nx4::const_type qp_r_prime_; 
+    View_Nx6 qp_strain_;
 
     KOKKOS_FUNCTION
     void operator()(const int i_qp) const {
         auto x0_prime_data = Kokkos::Array<double, 3>{
             qp_x0_prime_(i_qp, 0), qp_x0_prime_(i_qp, 1), qp_x0_prime_(i_qp, 2)};
-        auto x0_prime =
-            Kokkos::View<double[3], Kokkos::MemoryTraits<Kokkos::Unmanaged>>(x0_prime_data.data());
+        auto x0_prime = Kokkos::View<double[3]>(x0_prime_data.data());
         auto u_prime_data = Kokkos::Array<double, 3>{
             qp_u_prime_(i_qp, 0), qp_u_prime_(i_qp, 1), qp_u_prime_(i_qp, 2)};
-        auto u_prime =
-            Kokkos::View<double[3], Kokkos::MemoryTraits<Kokkos::Unmanaged>>(u_prime_data.data());
+        auto u_prime = Kokkos::View<double[3]>(u_prime_data.data());
         auto R_data =
             Kokkos::Array<double, 4>{qp_r_(i_qp, 0), qp_r_(i_qp, 1), qp_r_(i_qp, 2), qp_r_(i_qp, 3)};
-        auto R = Kokkos::View<double[4], Kokkos::MemoryTraits<Kokkos::Unmanaged>>(R_data.data());
+        auto R = Kokkos::View<double[4]>(R_data.data());
 
         auto R_x0_prime_data = Kokkos::Array<double, 3>{};
-        auto R_x0_prime =
-            Kokkos::View<double[3], Kokkos::MemoryTraits<Kokkos::Unmanaged>>(R_x0_prime_data.data());
+        auto R_x0_prime = Kokkos::View<double[3]>(R_x0_prime_data.data());
 
         RotateVectorByQuaternion(R, x0_prime, R_x0_prime);
         KokkosBlas::serial_axpy(-1., u_prime, R_x0_prime);
         KokkosBlas::serial_axpy(-1., x0_prime, R_x0_prime);
 
         auto E_data = Kokkos::Array<double, 12>{};
-        auto E = Kokkos::View<double[3][4], Kokkos::MemoryTraits<Kokkos::Unmanaged>>(E_data.data());
+        auto E = Kokkos::View<double[3][4]>(E_data.data());
         QuaternionDerivative(R, E);
         auto R_prime_data = Kokkos::Array<double, 4>{
             qp_r_prime_(i_qp, 0), qp_r_prime_(i_qp, 1), qp_r_prime_(i_qp, 2), qp_r_prime_(i_qp, 3)};
-        auto R_prime =
-            Kokkos::View<double[4], Kokkos::MemoryTraits<Kokkos::Unmanaged>>(R_prime_data.data());
+        auto R_prime = Kokkos::View<double[4]>(R_prime_data.data());
         auto e2_data = Kokkos::Array<double, 3>{};
-        auto e2 = Kokkos::View<double[4], Kokkos::MemoryTraits<Kokkos::Unmanaged>>{e2_data.data()};
-        KokkosBlas::SerialGemv<KokkosBlas::Trans::NoTranspose, KokkosBlas::Algo::Gemv::Default>::
-            invoke(2., E, R_prime, 0., e2);
+        auto e2 = Kokkos::View<double[4]>{e2_data.data()};
+        Gemv::invoke(2., E, R_prime, 0., e2);
 
         qp_strain_(i_qp, 0) = -R_x0_prime(0);
         qp_strain_(i_qp, 1) = -R_x0_prime(1);

--- a/src/restruct_poc/system/calculate_temporary_variables.hpp
+++ b/src/restruct_poc/system/calculate_temporary_variables.hpp
@@ -16,16 +16,13 @@ struct CalculateTemporaryVariables {
     void operator()(int i_qp) const {
         auto x0pup_data = Kokkos::Array<double, 3>{
             qp_x0_prime_(i_qp, 0), qp_x0_prime_(i_qp, 1), qp_x0_prime_(i_qp, 2)};
-        auto x0pup =
-            Kokkos::View<double[3], Kokkos::MemoryTraits<Kokkos::Unmanaged>>{x0pup_data.data()};
+        auto x0pup = Kokkos::View<double[3]>{x0pup_data.data()};
         auto u_prime_data = Kokkos::Array<double, 3>{
             qp_u_prime_(i_qp, 0), qp_u_prime_(i_qp, 1), qp_u_prime_(i_qp, 2)};
-        auto u_prime =
-            Kokkos::View<double[3], Kokkos::MemoryTraits<Kokkos::Unmanaged>>{u_prime_data.data()};
+        auto u_prime = Kokkos::View<double[3]>{u_prime_data.data()};
         KokkosBlas::serial_axpy(1., u_prime, x0pup);
         auto tmp_data = Kokkos::Array<double, 9>{};
-        auto tmp =
-            Kokkos::View<double[3][3], Kokkos::MemoryTraits<Kokkos::Unmanaged>>{tmp_data.data()};
+        auto tmp = Kokkos::View<double[3][3]>{tmp_data.data()};
         VecTilde(x0pup, tmp);
         for (int i = 0; i < 3; ++i) {
             for (int j = 0; j < 3; ++j) {

--- a/src/restruct_poc/system/calculate_temporary_variables.hpp
+++ b/src/restruct_poc/system/calculate_temporary_variables.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
-#include <Kokkos_Core.hpp>
 #include <KokkosBlas.hpp>
+#include <Kokkos_Core.hpp>
 
 #include "src/restruct_poc/math/vector_operations.hpp"
 #include "src/restruct_poc/types.hpp"

--- a/src/restruct_poc/system/calculate_temporary_variables.hpp
+++ b/src/restruct_poc/system/calculate_temporary_variables.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <Kokkos_Core.hpp>
+#include <KokkosBlas.hpp>
 
 #include "src/restruct_poc/math/vector_operations.hpp"
 #include "src/restruct_poc/types.hpp"

--- a/src/restruct_poc/system/rotate_section_matrix.hpp
+++ b/src/restruct_poc/system/rotate_section_matrix.hpp
@@ -9,9 +9,14 @@
 namespace openturbine {
 
 struct RotateSectionMatrix {
-    View_Nx6x6::const_type qp_RR0_;    //
-    View_Nx6x6::const_type qp_Cstar_;  //
-    View_Nx6x6 qp_Cuu_;                //
+    using NoTranspose = KokkosBatched::Trans::NoTranspose;
+    using Transpose = KokkosBatched::Trans::Transpose;
+    using Default = KokkosBatched::Algo::Gemm::Default;
+    using GemmNN = KokkosBatched::SerialGemm<NoTranspose, NoTranspose, Default>;
+    using GemmNT = KokkosBatched::SerialGemm<NoTranspose, Transpose, Default>;
+    View_Nx6x6::const_type qp_RR0_;
+    View_Nx6x6::const_type qp_Cstar_;
+    View_Nx6x6 qp_Cuu_;
 
     KOKKOS_FUNCTION
     void operator()(const int i_qp) const {
@@ -19,14 +24,9 @@ struct RotateSectionMatrix {
         auto Cstar = Kokkos::subview(qp_Cstar_, i_qp, Kokkos::ALL, Kokkos::ALL);
         auto Cuu = Kokkos::subview(qp_Cuu_, i_qp, Kokkos::ALL, Kokkos::ALL);
         auto ctmp_data = Kokkos::Array<double, 36>{};
-        auto Ctmp =
-            Kokkos::View<double[6][6], Kokkos::MemoryTraits<Kokkos::Unmanaged>>(ctmp_data.data());
-        KokkosBatched::SerialGemm<
-            KokkosBatched::Trans::NoTranspose, KokkosBatched::Trans::NoTranspose,
-            KokkosBatched::Algo::Gemm::Default>::invoke(1., RR0, Cstar, 0., Ctmp);
-        KokkosBatched::SerialGemm<
-            KokkosBatched::Trans::NoTranspose, KokkosBatched::Trans::Transpose,
-            KokkosBatched::Algo::Gemm::Default>::invoke(1., Ctmp, RR0, 0., Cuu);
+        auto Ctmp = Kokkos::View<double[6][6]>(ctmp_data.data());
+        GemmNN::invoke(1., RR0, Cstar, 0., Ctmp);
+        GemmNT::invoke(1., Ctmp, RR0, 0., Cuu);
     }
 };
 

--- a/src/restruct_poc/system/update_node_state.hpp
+++ b/src/restruct_poc/system/update_node_state.hpp
@@ -29,16 +29,6 @@ struct UpdateNodeState {
             node_u_ddot(i, k) = A(j, k);
         }
     }
-
-    KOKKOS_FUNCTION
-    void operator()(const int i, const int k) const {
-        auto j = node_state_indices(i);
-        node_u(i, k) = Q(j, k);
-        if (k < kLieAlgebraComponents) {
-            node_u_dot(i, k) = V(j, k);
-            node_u_ddot(i, k) = A(j, k);
-        }
-    }
 };
 
 }  // namespace openturbine

--- a/src/restruct_poc/system/update_state.hpp
+++ b/src/restruct_poc/system/update_state.hpp
@@ -134,8 +134,7 @@ inline void UpdateState(Beams& beams, View_Nx7 Q, View_Nx6 V, View_Nx6 A) {
     );
 
     Kokkos::parallel_for(
-        "CalculateNodeForces",
-        Kokkos::MDRangePolicy{{0, 0, 0}, {beams.num_elems, beams.max_elem_nodes, 6}},
+        "CalculateNodeForces", range_policy,
         CalculateNodeForces{
             beams.elem_indices, beams.qp_weight, beams.qp_jacobian, beams.shape_interp,
             beams.shape_deriv, beams.qp_Fc, beams.qp_Fd, beams.qp_Fi, beams.qp_Fg, beams.node_FE,

--- a/src/restruct_poc/system/update_state.hpp
+++ b/src/restruct_poc/system/update_state.hpp
@@ -29,7 +29,7 @@ namespace openturbine {
 inline void UpdateState(Beams& beams, View_Nx7 Q, View_Nx6 V, View_Nx6 A) {
     auto region = Kokkos::Profiling::ScopedRegion("Update State");
     Kokkos::parallel_for(
-        "UpdateNodeState", Kokkos::MDRangePolicy{{0, 0}, {beams.num_nodes, kLieGroupComponents}},
+        "UpdateNodeState", beams.num_nodes,
         UpdateNodeState{
             beams.node_state_indices,
             beams.node_u,
@@ -40,6 +40,7 @@ inline void UpdateState(Beams& beams, View_Nx7 Q, View_Nx6 V, View_Nx6 A) {
             A,
         }
     );
+    
     auto range_policy = Kokkos::TeamPolicy<>(beams.num_elems, Kokkos::AUTO());
     Kokkos::parallel_for(
         "InterpolateToQuadraturePoints", range_policy,

--- a/src/restruct_poc/system/update_state.hpp
+++ b/src/restruct_poc/system/update_state.hpp
@@ -40,7 +40,7 @@ inline void UpdateState(Beams& beams, View_Nx7 Q, View_Nx6 V, View_Nx6 A) {
             A,
         }
     );
-    
+
     auto range_policy = Kokkos::TeamPolicy<>(beams.num_elems, Kokkos::AUTO());
     Kokkos::parallel_for(
         "InterpolateToQuadraturePoints", range_policy,

--- a/tests/unit_tests/restruct_poc/CMakeLists.txt
+++ b/tests/unit_tests/restruct_poc/CMakeLists.txt
@@ -23,6 +23,7 @@ target_sources(
     system/test_rotate_section_matrix.cpp
     system/test_calculate_strain.cpp
     system/test_calculate_mass_matrix_components.cpp
+    system/test_calculate_temporary_variables.cpp
 )
 
 if(OTURB_ENABLE_VTK)

--- a/tests/unit_tests/restruct_poc/CMakeLists.txt
+++ b/tests/unit_tests/restruct_poc/CMakeLists.txt
@@ -20,6 +20,7 @@ target_sources(
     system/test_integrate_residual_vector.cpp
     system/test_update_node_state.cpp
     system/test_calculate_RR0.cpp
+    system/test_rotate_section_matrix.cpp
 )
 
 if(OTURB_ENABLE_VTK)

--- a/tests/unit_tests/restruct_poc/CMakeLists.txt
+++ b/tests/unit_tests/restruct_poc/CMakeLists.txt
@@ -27,6 +27,7 @@ target_sources(
     system/test_calculate_force_FC.cpp
     system/test_calculate_force_FD.cpp
     system/test_calculate_inertial_forces.cpp
+    system/test_calculate_gravity_force.cpp
 )
 
 if(OTURB_ENABLE_VTK)

--- a/tests/unit_tests/restruct_poc/CMakeLists.txt
+++ b/tests/unit_tests/restruct_poc/CMakeLists.txt
@@ -29,6 +29,7 @@ target_sources(
     system/test_calculate_inertial_forces.cpp
     system/test_calculate_gravity_force.cpp
     system/test_calculate_Ouu.cpp
+    system/test_calculate_Puu.cpp
 )
 
 if(OTURB_ENABLE_VTK)

--- a/tests/unit_tests/restruct_poc/CMakeLists.txt
+++ b/tests/unit_tests/restruct_poc/CMakeLists.txt
@@ -22,6 +22,7 @@ target_sources(
     system/test_calculate_RR0.cpp
     system/test_rotate_section_matrix.cpp
     system/test_calculate_strain.cpp
+    system/test_calculate_mass_matrix_components.cpp
 )
 
 if(OTURB_ENABLE_VTK)

--- a/tests/unit_tests/restruct_poc/CMakeLists.txt
+++ b/tests/unit_tests/restruct_poc/CMakeLists.txt
@@ -30,6 +30,7 @@ target_sources(
     system/test_calculate_gravity_force.cpp
     system/test_calculate_Ouu.cpp
     system/test_calculate_Puu.cpp
+    system/test_calculate_Quu.cpp
 )
 
 if(OTURB_ENABLE_VTK)

--- a/tests/unit_tests/restruct_poc/CMakeLists.txt
+++ b/tests/unit_tests/restruct_poc/CMakeLists.txt
@@ -31,6 +31,7 @@ target_sources(
     system/test_calculate_Ouu.cpp
     system/test_calculate_Puu.cpp
     system/test_calculate_Quu.cpp
+    system/test_calculate_gyroscopic_matrix.cpp
 )
 
 if(OTURB_ENABLE_VTK)

--- a/tests/unit_tests/restruct_poc/CMakeLists.txt
+++ b/tests/unit_tests/restruct_poc/CMakeLists.txt
@@ -26,6 +26,7 @@ target_sources(
     system/test_calculate_temporary_variables.cpp
     system/test_calculate_force_FC.cpp
     system/test_calculate_force_FD.cpp
+    system/test_calculate_inertial_forces.cpp
 )
 
 if(OTURB_ENABLE_VTK)

--- a/tests/unit_tests/restruct_poc/CMakeLists.txt
+++ b/tests/unit_tests/restruct_poc/CMakeLists.txt
@@ -25,6 +25,7 @@ target_sources(
     system/test_calculate_mass_matrix_components.cpp
     system/test_calculate_temporary_variables.cpp
     system/test_calculate_force_FC.cpp
+    system/test_calculate_force_FD.cpp
 )
 
 if(OTURB_ENABLE_VTK)

--- a/tests/unit_tests/restruct_poc/CMakeLists.txt
+++ b/tests/unit_tests/restruct_poc/CMakeLists.txt
@@ -28,6 +28,7 @@ target_sources(
     system/test_calculate_force_FD.cpp
     system/test_calculate_inertial_forces.cpp
     system/test_calculate_gravity_force.cpp
+    system/test_calculate_Ouu.cpp
 )
 
 if(OTURB_ENABLE_VTK)

--- a/tests/unit_tests/restruct_poc/CMakeLists.txt
+++ b/tests/unit_tests/restruct_poc/CMakeLists.txt
@@ -21,6 +21,7 @@ target_sources(
     system/test_update_node_state.cpp
     system/test_calculate_RR0.cpp
     system/test_rotate_section_matrix.cpp
+    system/test_calculate_strain.cpp
 )
 
 if(OTURB_ENABLE_VTK)

--- a/tests/unit_tests/restruct_poc/CMakeLists.txt
+++ b/tests/unit_tests/restruct_poc/CMakeLists.txt
@@ -19,6 +19,7 @@ target_sources(
     system/test_integrate_inertia_matrix.cpp
     system/test_integrate_residual_vector.cpp
     system/test_update_node_state.cpp
+    system/test_calculate_RR0.cpp
 )
 
 if(OTURB_ENABLE_VTK)

--- a/tests/unit_tests/restruct_poc/CMakeLists.txt
+++ b/tests/unit_tests/restruct_poc/CMakeLists.txt
@@ -24,6 +24,7 @@ target_sources(
     system/test_calculate_strain.cpp
     system/test_calculate_mass_matrix_components.cpp
     system/test_calculate_temporary_variables.cpp
+    system/test_calculate_force_FC.cpp
 )
 
 if(OTURB_ENABLE_VTK)

--- a/tests/unit_tests/restruct_poc/CMakeLists.txt
+++ b/tests/unit_tests/restruct_poc/CMakeLists.txt
@@ -32,6 +32,7 @@ target_sources(
     system/test_calculate_Puu.cpp
     system/test_calculate_Quu.cpp
     system/test_calculate_gyroscopic_matrix.cpp
+    system/test_calculate_inertia_stiffness_matrix.cpp
 )
 
 if(OTURB_ENABLE_VTK)

--- a/tests/unit_tests/restruct_poc/CMakeLists.txt
+++ b/tests/unit_tests/restruct_poc/CMakeLists.txt
@@ -18,6 +18,7 @@ target_sources(
     system/test_integrate_stiffness_matrix.cpp
     system/test_integrate_inertia_matrix.cpp
     system/test_integrate_residual_vector.cpp
+    system/test_update_node_state.cpp
 )
 
 if(OTURB_ENABLE_VTK)

--- a/tests/unit_tests/restruct_poc/CMakeLists.txt
+++ b/tests/unit_tests/restruct_poc/CMakeLists.txt
@@ -33,6 +33,7 @@ target_sources(
     system/test_calculate_Quu.cpp
     system/test_calculate_gyroscopic_matrix.cpp
     system/test_calculate_inertia_stiffness_matrix.cpp
+    system/test_calculate_node_forces.cpp
 )
 
 if(OTURB_ENABLE_VTK)

--- a/tests/unit_tests/restruct_poc/system/test_calculate_Ouu.cpp
+++ b/tests/unit_tests/restruct_poc/system/test_calculate_Ouu.cpp
@@ -8,12 +8,9 @@ namespace openturbine::restruct_poc::tests {
 
 TEST(CalculateOuuTests, OneNode) {
     auto Cuu = Kokkos::View<double[1][6][6]>("Cuu");
-    auto Cuu_data = std::array<double, 36>{1., 2., 3., 4., 5., 6., 
-                                           7., 8., 9., 10., 11., 12., 
-                                           13., 14., 15., 16., 17., 18., 
-                                           19., 20., 21., 22., 23., 24., 
-                                           25., 26., 27., 28., 29., 30., 
-                                           31., 32., 33., 34., 35., 36.};
+    auto Cuu_data = std::array<double, 36>{
+        1.,  2.,  3.,  4.,  5.,  6.,  7.,  8.,  9.,  10., 11., 12., 13., 14., 15., 16., 17., 18.,
+        19., 20., 21., 22., 23., 24., 25., 26., 27., 28., 29., 30., 31., 32., 33., 34., 35., 36.};
     auto Cuu_host = Kokkos::View<double[1][6][6], Kokkos::HostSpace>(Cuu_data.data());
     auto Cuu_mirror = Kokkos::create_mirror(Cuu);
     Kokkos::deep_copy(Cuu_mirror, Cuu_host);
@@ -44,18 +41,16 @@ TEST(CalculateOuuTests, OneNode) {
 
     Kokkos::parallel_for("CalculateOuu", 1, CalculateOuu{Cuu, x0pupSS, M_tilde, N_tilde, Ouu});
 
-    auto Ouu_exact_data = std::array<double, 36>{0., 0., 0., 191., 196., 201., 
-                                                 0., 0., 0., 908., 931., 954., 
-                                                 0., 0., 0., 1625., 1666., 1707., 
-                                                 0., 0., 0., 2360., 2419., 2478.,  
-                                                 0., 0., 0., 3077., 3154., 3231.,
-                                                 0., 0., 0., 3794., 3889., 3984.};
+    auto Ouu_exact_data =
+        std::array<double, 36>{0., 0., 0., 191.,  196.,  201.,  0., 0., 0., 908.,  931.,  954.,
+                               0., 0., 0., 1625., 1666., 1707., 0., 0., 0., 2360., 2419., 2478.,
+                               0., 0., 0., 3077., 3154., 3231., 0., 0., 0., 3794., 3889., 3984.};
     auto Ouu_exact = Kokkos::View<double[1][6][6], Kokkos::HostSpace>(Ouu_exact_data.data());
 
     auto Ouu_mirror = Kokkos::create_mirror(Ouu);
     Kokkos::deep_copy(Ouu_mirror, Ouu);
-    for(int i = 0; i < 6; ++i) {
-        for(int j = 0; j < 6; ++j) {
+    for (int i = 0; i < 6; ++i) {
+        for (int j = 0; j < 6; ++j) {
             EXPECT_EQ(Ouu_mirror(0, i, j), Ouu_exact(0, i, j));
         }
     }

--- a/tests/unit_tests/restruct_poc/system/test_calculate_Ouu.cpp
+++ b/tests/unit_tests/restruct_poc/system/test_calculate_Ouu.cpp
@@ -1,0 +1,64 @@
+#include <Kokkos_Core.hpp>
+#include <gtest/gtest.h>
+
+#include "src/restruct_poc/system/calculate_Ouu.hpp"
+#include "src/restruct_poc/types.hpp"
+
+namespace openturbine::restruct_poc::tests {
+
+TEST(CalculateOuuTests, OneNode) {
+    auto Cuu = Kokkos::View<double[1][6][6]>("Cuu");
+    auto Cuu_data = std::array<double, 36>{1., 2., 3., 4., 5., 6., 
+                                           7., 8., 9., 10., 11., 12., 
+                                           13., 14., 15., 16., 17., 18., 
+                                           19., 20., 21., 22., 23., 24., 
+                                           25., 26., 27., 28., 29., 30., 
+                                           31., 32., 33., 34., 35., 36.};
+    auto Cuu_host = Kokkos::View<double[1][6][6], Kokkos::HostSpace>(Cuu_data.data());
+    auto Cuu_mirror = Kokkos::create_mirror(Cuu);
+    Kokkos::deep_copy(Cuu_mirror, Cuu_host);
+    Kokkos::deep_copy(Cuu, Cuu_mirror);
+
+    auto x0pupSS = Kokkos::View<double[1][3][3]>("x0pupSS");
+    auto x0pupSS_data = std::array<double, 9>{37., 38., 39., 40., 41., 42., 43., 44., 45.};
+    auto x0pupSS_host = Kokkos::View<double[1][3][3], Kokkos::HostSpace>(x0pupSS_data.data());
+    auto x0pupSS_mirror = Kokkos::create_mirror(x0pupSS);
+    Kokkos::deep_copy(x0pupSS_mirror, x0pupSS_host);
+    Kokkos::deep_copy(x0pupSS, x0pupSS_mirror);
+
+    auto M_tilde = Kokkos::View<double[1][3][3]>("M_tilde");
+    auto M_tilde_data = std::array<double, 9>{46., 47., 48., 49., 50., 51., 52., 53., 54.};
+    auto M_tilde_host = Kokkos::View<double[1][3][3], Kokkos::HostSpace>(M_tilde_data.data());
+    auto M_tilde_mirror = Kokkos::create_mirror(M_tilde);
+    Kokkos::deep_copy(M_tilde_mirror, M_tilde_host);
+    Kokkos::deep_copy(M_tilde, M_tilde_mirror);
+
+    auto N_tilde = Kokkos::View<double[1][3][3]>("N_tilde");
+    auto N_tilde_data = std::array<double, 9>{55., 56., 57., 58., 59., 60., 61., 62., 63.};
+    auto N_tilde_host = Kokkos::View<double[1][3][3], Kokkos::HostSpace>(N_tilde_data.data());
+    auto N_tilde_mirror = Kokkos::create_mirror(N_tilde);
+    Kokkos::deep_copy(N_tilde_mirror, N_tilde_host);
+    Kokkos::deep_copy(N_tilde, N_tilde_mirror);
+
+    auto Ouu = Kokkos::View<double[1][6][6]>("Ouu");
+
+    Kokkos::parallel_for("CalculateOuu", 1, CalculateOuu{Cuu, x0pupSS, M_tilde, N_tilde, Ouu});
+
+    auto Ouu_exact_data = std::array<double, 36>{0., 0., 0., 191., 196., 201., 
+                                                 0., 0., 0., 908., 931., 954., 
+                                                 0., 0., 0., 1625., 1666., 1707., 
+                                                 0., 0., 0., 2360., 2419., 2478.,  
+                                                 0., 0., 0., 3077., 3154., 3231.,
+                                                 0., 0., 0., 3794., 3889., 3984.};
+    auto Ouu_exact = Kokkos::View<double[1][6][6], Kokkos::HostSpace>(Ouu_exact_data.data());
+
+    auto Ouu_mirror = Kokkos::create_mirror(Ouu);
+    Kokkos::deep_copy(Ouu_mirror, Ouu);
+    for(int i = 0; i < 6; ++i) {
+        for(int j = 0; j < 6; ++j) {
+            EXPECT_EQ(Ouu_mirror(0, i, j), Ouu_exact(0, i, j));
+        }
+    }
+}
+
+}  // namespace openturbine::restruct_poc::tests

--- a/tests/unit_tests/restruct_poc/system/test_calculate_Puu.cpp
+++ b/tests/unit_tests/restruct_poc/system/test_calculate_Puu.cpp
@@ -1,0 +1,64 @@
+#include <Kokkos_Core.hpp>
+#include <gtest/gtest.h>
+
+#include "src/restruct_poc/system/calculate_Puu.hpp"
+#include "src/restruct_poc/types.hpp"
+
+namespace openturbine::restruct_poc::tests {
+
+TEST(CalculatePuuTests, OneNode) {
+    auto Cuu = Kokkos::View<double[1][6][6]>("Cuu");
+    auto Cuu_data = std::array<double, 36>{1., 2., 3., 4., 5., 6., 
+                                           7., 8., 9., 10., 11., 12., 
+                                           13., 14., 15., 16., 17., 18., 
+                                           19., 20., 21., 22., 23., 24., 
+                                           25., 26., 27., 28., 29., 30., 
+                                           31., 32., 33., 34., 35., 36.};
+    auto Cuu_host = Kokkos::View<double[1][6][6], Kokkos::HostSpace>(Cuu_data.data());
+    auto Cuu_mirror = Kokkos::create_mirror(Cuu);
+    Kokkos::deep_copy(Cuu_mirror, Cuu_host);
+    Kokkos::deep_copy(Cuu, Cuu_mirror);
+
+    auto x0pupSS = Kokkos::View<double[1][3][3]>("x0pupSS");
+    auto x0pupSS_data = std::array<double, 9>{37., 38., 39., 40., 41., 42., 43., 44., 45.};
+    auto x0pupSS_host = Kokkos::View<double[1][3][3], Kokkos::HostSpace>(x0pupSS_data.data());
+    auto x0pupSS_mirror = Kokkos::create_mirror(x0pupSS);
+    Kokkos::deep_copy(x0pupSS_mirror, x0pupSS_host);
+    Kokkos::deep_copy(x0pupSS, x0pupSS_mirror);
+
+    auto M_tilde = Kokkos::View<double[1][3][3]>("M_tilde");
+    auto M_tilde_data = std::array<double, 9>{46., 47., 48., 49., 50., 51., 52., 53., 54.};
+    auto M_tilde_host = Kokkos::View<double[1][3][3], Kokkos::HostSpace>(M_tilde_data.data());
+    auto M_tilde_mirror = Kokkos::create_mirror(M_tilde);
+    Kokkos::deep_copy(M_tilde_mirror, M_tilde_host);
+    Kokkos::deep_copy(M_tilde, M_tilde_mirror);
+
+    auto N_tilde = Kokkos::View<double[1][3][3]>("N_tilde");
+    auto N_tilde_data = std::array<double, 9>{55., 56., 57., 58., 59., 60., 61., 62., 63.};
+    auto N_tilde_host = Kokkos::View<double[1][3][3], Kokkos::HostSpace>(N_tilde_data.data());
+    auto N_tilde_mirror = Kokkos::create_mirror(N_tilde);
+    Kokkos::deep_copy(N_tilde_mirror, N_tilde_host);
+    Kokkos::deep_copy(N_tilde, N_tilde_mirror);
+
+    auto Puu = Kokkos::View<double[1][6][6]>("Puu");
+
+    Kokkos::parallel_for("CalculatePuu", 1, CalculatePuu{Cuu, x0pupSS, N_tilde, Puu});
+
+    auto Puu_exact_data = std::array<double, 36>{0., 0., 0., 0., 0., 0., 
+                                                 0., 0., 0., 0., 0., 0., 
+                                                 0., 0., 0., 0., 0., 0., 
+                                                 931., 1052., 1173., 1236., 1356., 1476.,  
+                                                 955., 1079., 1203., 1266., 1389., 1512.,
+                                                 979., 1106., 1233., 1296., 1422., 1548.};
+    auto Puu_exact = Kokkos::View<double[1][6][6], Kokkos::HostSpace>(Puu_exact_data.data());
+
+    auto Puu_mirror = Kokkos::create_mirror(Puu);
+    Kokkos::deep_copy(Puu_mirror, Puu);
+    for(int i = 0; i < 6; ++i) {
+        for(int j = 0; j < 6; ++j) {
+            EXPECT_EQ(Puu_mirror(0, i, j), Puu_exact(0, i, j));
+        }
+    }
+}
+
+}  // namespace openturbine::restruct_poc::tests

--- a/tests/unit_tests/restruct_poc/system/test_calculate_Puu.cpp
+++ b/tests/unit_tests/restruct_poc/system/test_calculate_Puu.cpp
@@ -8,12 +8,9 @@ namespace openturbine::restruct_poc::tests {
 
 TEST(CalculatePuuTests, OneNode) {
     auto Cuu = Kokkos::View<double[1][6][6]>("Cuu");
-    auto Cuu_data = std::array<double, 36>{1., 2., 3., 4., 5., 6., 
-                                           7., 8., 9., 10., 11., 12., 
-                                           13., 14., 15., 16., 17., 18., 
-                                           19., 20., 21., 22., 23., 24., 
-                                           25., 26., 27., 28., 29., 30., 
-                                           31., 32., 33., 34., 35., 36.};
+    auto Cuu_data = std::array<double, 36>{
+        1.,  2.,  3.,  4.,  5.,  6.,  7.,  8.,  9.,  10., 11., 12., 13., 14., 15., 16., 17., 18.,
+        19., 20., 21., 22., 23., 24., 25., 26., 27., 28., 29., 30., 31., 32., 33., 34., 35., 36.};
     auto Cuu_host = Kokkos::View<double[1][6][6], Kokkos::HostSpace>(Cuu_data.data());
     auto Cuu_mirror = Kokkos::create_mirror(Cuu);
     Kokkos::deep_copy(Cuu_mirror, Cuu_host);
@@ -44,18 +41,16 @@ TEST(CalculatePuuTests, OneNode) {
 
     Kokkos::parallel_for("CalculatePuu", 1, CalculatePuu{Cuu, x0pupSS, N_tilde, Puu});
 
-    auto Puu_exact_data = std::array<double, 36>{0., 0., 0., 0., 0., 0., 
-                                                 0., 0., 0., 0., 0., 0., 
-                                                 0., 0., 0., 0., 0., 0., 
-                                                 931., 1052., 1173., 1236., 1356., 1476.,  
-                                                 955., 1079., 1203., 1266., 1389., 1512.,
-                                                 979., 1106., 1233., 1296., 1422., 1548.};
+    auto Puu_exact_data = std::array<double, 36>{
+        0.,   0.,    0.,    0.,    0.,    0.,    0.,   0.,    0.,    0.,    0.,    0.,
+        0.,   0.,    0.,    0.,    0.,    0.,    931., 1052., 1173., 1236., 1356., 1476.,
+        955., 1079., 1203., 1266., 1389., 1512., 979., 1106., 1233., 1296., 1422., 1548.};
     auto Puu_exact = Kokkos::View<double[1][6][6], Kokkos::HostSpace>(Puu_exact_data.data());
 
     auto Puu_mirror = Kokkos::create_mirror(Puu);
     Kokkos::deep_copy(Puu_mirror, Puu);
-    for(int i = 0; i < 6; ++i) {
-        for(int j = 0; j < 6; ++j) {
+    for (int i = 0; i < 6; ++i) {
+        for (int j = 0; j < 6; ++j) {
             EXPECT_EQ(Puu_mirror(0, i, j), Puu_exact(0, i, j));
         }
     }

--- a/tests/unit_tests/restruct_poc/system/test_calculate_Quu.cpp
+++ b/tests/unit_tests/restruct_poc/system/test_calculate_Quu.cpp
@@ -8,12 +8,9 @@ namespace openturbine::restruct_poc::tests {
 
 TEST(CalculateQuuTests, OneNode) {
     auto Cuu = Kokkos::View<double[1][6][6]>("Cuu");
-    auto Cuu_data = std::array<double, 36>{1., 2., 3., 4., 5., 6., 
-                                           7., 8., 9., 10., 11., 12., 
-                                           13., 14., 15., 16., 17., 18., 
-                                           19., 20., 21., 22., 23., 24., 
-                                           25., 26., 27., 28., 29., 30., 
-                                           31., 32., 33., 34., 35., 36.};
+    auto Cuu_data = std::array<double, 36>{
+        1.,  2.,  3.,  4.,  5.,  6.,  7.,  8.,  9.,  10., 11., 12., 13., 14., 15., 16., 17., 18.,
+        19., 20., 21., 22., 23., 24., 25., 26., 27., 28., 29., 30., 31., 32., 33., 34., 35., 36.};
     auto Cuu_host = Kokkos::View<double[1][6][6], Kokkos::HostSpace>(Cuu_data.data());
     auto Cuu_mirror = Kokkos::create_mirror(Cuu);
     Kokkos::deep_copy(Cuu_mirror, Cuu_host);
@@ -44,18 +41,16 @@ TEST(CalculateQuuTests, OneNode) {
 
     Kokkos::parallel_for("CalculateQuu", 1, CalculateQuu{Cuu, x0pupSS, N_tilde, Quu});
 
-    auto Quu_exact_data = std::array<double, 36>{0., 0., 0., 0., 0., 0., 
-                                                 0., 0., 0., 0., 0., 0., 
-                                                 0., 0., 0., 0., 0., 0., 
-                                                 0., 0., 0., 113262., 116130., 118998.,  
-                                                 0., 0., 0., 115986., 118923., 121860.,
-                                                 0., 0., 0., 118710., 121716., 124722.};
+    auto Quu_exact_data = std::array<double, 36>{
+        0., 0., 0., 0.,      0.,      0.,      0., 0., 0., 0.,      0.,      0.,
+        0., 0., 0., 0.,      0.,      0.,      0., 0., 0., 113262., 116130., 118998.,
+        0., 0., 0., 115986., 118923., 121860., 0., 0., 0., 118710., 121716., 124722.};
     auto Quu_exact = Kokkos::View<double[1][6][6], Kokkos::HostSpace>(Quu_exact_data.data());
 
     auto Quu_mirror = Kokkos::create_mirror(Quu);
     Kokkos::deep_copy(Quu_mirror, Quu);
-    for(int i = 0; i < 6; ++i) {
-        for(int j = 0; j < 6; ++j) {
+    for (int i = 0; i < 6; ++i) {
+        for (int j = 0; j < 6; ++j) {
             EXPECT_EQ(Quu_mirror(0, i, j), Quu_exact(0, i, j));
         }
     }

--- a/tests/unit_tests/restruct_poc/system/test_calculate_Quu.cpp
+++ b/tests/unit_tests/restruct_poc/system/test_calculate_Quu.cpp
@@ -1,0 +1,64 @@
+#include <Kokkos_Core.hpp>
+#include <gtest/gtest.h>
+
+#include "src/restruct_poc/system/calculate_Quu.hpp"
+#include "src/restruct_poc/types.hpp"
+
+namespace openturbine::restruct_poc::tests {
+
+TEST(CalculateQuuTests, OneNode) {
+    auto Cuu = Kokkos::View<double[1][6][6]>("Cuu");
+    auto Cuu_data = std::array<double, 36>{1., 2., 3., 4., 5., 6., 
+                                           7., 8., 9., 10., 11., 12., 
+                                           13., 14., 15., 16., 17., 18., 
+                                           19., 20., 21., 22., 23., 24., 
+                                           25., 26., 27., 28., 29., 30., 
+                                           31., 32., 33., 34., 35., 36.};
+    auto Cuu_host = Kokkos::View<double[1][6][6], Kokkos::HostSpace>(Cuu_data.data());
+    auto Cuu_mirror = Kokkos::create_mirror(Cuu);
+    Kokkos::deep_copy(Cuu_mirror, Cuu_host);
+    Kokkos::deep_copy(Cuu, Cuu_mirror);
+
+    auto x0pupSS = Kokkos::View<double[1][3][3]>("x0pupSS");
+    auto x0pupSS_data = std::array<double, 9>{37., 38., 39., 40., 41., 42., 43., 44., 45.};
+    auto x0pupSS_host = Kokkos::View<double[1][3][3], Kokkos::HostSpace>(x0pupSS_data.data());
+    auto x0pupSS_mirror = Kokkos::create_mirror(x0pupSS);
+    Kokkos::deep_copy(x0pupSS_mirror, x0pupSS_host);
+    Kokkos::deep_copy(x0pupSS, x0pupSS_mirror);
+
+    auto M_tilde = Kokkos::View<double[1][3][3]>("M_tilde");
+    auto M_tilde_data = std::array<double, 9>{46., 47., 48., 49., 50., 51., 52., 53., 54.};
+    auto M_tilde_host = Kokkos::View<double[1][3][3], Kokkos::HostSpace>(M_tilde_data.data());
+    auto M_tilde_mirror = Kokkos::create_mirror(M_tilde);
+    Kokkos::deep_copy(M_tilde_mirror, M_tilde_host);
+    Kokkos::deep_copy(M_tilde, M_tilde_mirror);
+
+    auto N_tilde = Kokkos::View<double[1][3][3]>("N_tilde");
+    auto N_tilde_data = std::array<double, 9>{55., 56., 57., 58., 59., 60., 61., 62., 63.};
+    auto N_tilde_host = Kokkos::View<double[1][3][3], Kokkos::HostSpace>(N_tilde_data.data());
+    auto N_tilde_mirror = Kokkos::create_mirror(N_tilde);
+    Kokkos::deep_copy(N_tilde_mirror, N_tilde_host);
+    Kokkos::deep_copy(N_tilde, N_tilde_mirror);
+
+    auto Quu = Kokkos::View<double[1][6][6]>("Quu");
+
+    Kokkos::parallel_for("CalculateQuu", 1, CalculateQuu{Cuu, x0pupSS, N_tilde, Quu});
+
+    auto Quu_exact_data = std::array<double, 36>{0., 0., 0., 0., 0., 0., 
+                                                 0., 0., 0., 0., 0., 0., 
+                                                 0., 0., 0., 0., 0., 0., 
+                                                 0., 0., 0., 113262., 116130., 118998.,  
+                                                 0., 0., 0., 115986., 118923., 121860.,
+                                                 0., 0., 0., 118710., 121716., 124722.};
+    auto Quu_exact = Kokkos::View<double[1][6][6], Kokkos::HostSpace>(Quu_exact_data.data());
+
+    auto Quu_mirror = Kokkos::create_mirror(Quu);
+    Kokkos::deep_copy(Quu_mirror, Quu);
+    for(int i = 0; i < 6; ++i) {
+        for(int j = 0; j < 6; ++j) {
+            EXPECT_EQ(Quu_mirror(0, i, j), Quu_exact(0, i, j));
+        }
+    }
+}
+
+}  // namespace openturbine::restruct_poc::tests

--- a/tests/unit_tests/restruct_poc/system/test_calculate_RR0.cpp
+++ b/tests/unit_tests/restruct_poc/system/test_calculate_RR0.cpp
@@ -1,0 +1,93 @@
+#include <Kokkos_Core.hpp>
+#include <gtest/gtest.h>
+
+#include "src/restruct_poc/system/calculate_RR0.hpp"
+#include "src/restruct_poc/types.hpp"
+
+namespace openturbine::restruct_poc::tests {
+
+TEST(CalculateRR0Tests, OneNode) {
+    auto r0 = Kokkos::View<double[1][4]>("r0");
+    auto r0_host_data = std::array<double, 4>{1., 2., 3., 4.};
+    auto r0_host = Kokkos::View<double[1][4], Kokkos::HostSpace>(r0_host_data.data());
+    auto r0_mirror = Kokkos::create_mirror(r0);
+    Kokkos::deep_copy(r0_mirror, r0_host);
+    Kokkos::deep_copy(r0, r0_mirror);
+
+    auto r = Kokkos::View<double[1][4]>("r");
+    auto r_host_data = std::array<double, 4>{5., 6., 7., 8.};
+    auto r_host = Kokkos::View<double[1][4], Kokkos::HostSpace>(r_host_data.data());
+    auto r_mirror = Kokkos::create_mirror(r);
+    Kokkos::deep_copy(r_mirror, r_host);
+    Kokkos::deep_copy(r, r_mirror);
+
+    auto rr0 = Kokkos::View<double[1][6][6]>("rr0");
+
+    Kokkos::parallel_for("CalculateRR0", 1, CalculateRR0{r0, r, rr0});
+
+    auto expected_rr0_data = std::array<double, 36>{2780., 4400., -400., 0., 0., 0., 
+                                                    -3280., 2372., 3296., 0., 0., 0., 
+                                                    2960., -1504., 4028., 0., 0., 0.,
+                                                    0., 0., 0., 2780., 4400., -400.,
+                                                    0., 0., 0., -3280., 2372., 3296.,
+                                                    0., 0., 0., 2960., -1504., 4028.};
+    auto expected_rr0 = Kokkos::View<double[1][6][6], Kokkos::HostSpace>(expected_rr0_data.data());
+
+    auto rr0_mirror = Kokkos::create_mirror(rr0);
+    Kokkos::deep_copy(rr0_mirror, rr0);
+    for(int i = 0; i < 6; ++i) {
+        for(int j = 0; j < 6; ++j) {
+            EXPECT_EQ(rr0_mirror(0, i, j), expected_rr0(0, i, j));
+        }
+    }
+}
+
+TEST(CalculateRR0Tests, TwoNodes) {
+    auto r0 = Kokkos::View<double[2][4]>("r0");
+    auto r0_host_data = std::array<double, 8>{1., 2., 3., 4., 5., 6., 7., 8.};
+    auto r0_host = Kokkos::View<double[2][4], Kokkos::HostSpace>(r0_host_data.data());
+    auto r0_mirror = Kokkos::create_mirror(r0);
+    Kokkos::deep_copy(r0_mirror, r0_host);
+    Kokkos::deep_copy(r0, r0_mirror);
+
+    auto r = Kokkos::View<double[2][4]>("r");
+    auto r_host_data = std::array<double, 8>{5., 6., 7., 8., 9., 10., 11., 12.};
+    auto r_host = Kokkos::View<double[2][4], Kokkos::HostSpace>(r_host_data.data());
+    auto r_mirror = Kokkos::create_mirror(r);
+    Kokkos::deep_copy(r_mirror, r_host);
+    Kokkos::deep_copy(r, r_mirror);
+
+    auto rr0 = Kokkos::View<double[2][6][6]>("rr0");
+
+    Kokkos::parallel_for("CalculateRR0", 2, CalculateRR0{r0, r, rr0});
+
+    auto expected_rr0_data = std::array<double, 72>{2780., 4400., -400., 0., 0., 0., 
+                                                    -3280., 2372., 3296., 0., 0., 0., 
+                                                    2960., -1504., 4028., 0., 0., 0.,
+                                                    0., 0., 0., 2780., 4400., -400.,
+                                                    0., 0., 0., -3280., 2372., 3296.,
+                                                    0., 0., 0., 2960., -1504., 4028.,
+
+                                                    16412., 74896., -11984., 0., 0., 0., 
+                                                    -27376., 17284., 70528., 0., 0., 0., 
+                                                    70736., -10688., 30076., 0., 0., 0.,
+                                                    0., 0., 0., 16412., 74896., -11984.,
+                                                    0., 0., 0., -27376., 17284., 70528.,
+                                                    0., 0., 0., 70736., -10688., 30076.};
+    auto expected_rr0 = Kokkos::View<double[2][6][6], Kokkos::HostSpace>(expected_rr0_data.data());
+
+    auto rr0_mirror = Kokkos::create_mirror(rr0);
+    Kokkos::deep_copy(rr0_mirror, rr0);
+    for(int i = 0; i < 6; ++i) {
+        for(int j = 0; j < 6; ++j) {
+            EXPECT_EQ(rr0_mirror(0, i, j), expected_rr0(0, i, j));
+        }
+    }
+    for(int i = 0; i < 6; ++i) {
+        for(int j = 0; j < 6; ++j) {
+            EXPECT_EQ(rr0_mirror(1, i, j), expected_rr0(1, i, j));
+        }
+    }
+}
+
+}  // namespace openturbine::restruct_poc::tests

--- a/tests/unit_tests/restruct_poc/system/test_calculate_RR0.cpp
+++ b/tests/unit_tests/restruct_poc/system/test_calculate_RR0.cpp
@@ -25,18 +25,16 @@ TEST(CalculateRR0Tests, OneNode) {
 
     Kokkos::parallel_for("CalculateRR0", 1, CalculateRR0{r0, r, rr0});
 
-    auto expected_rr0_data = std::array<double, 36>{2780., 4400., -400., 0., 0., 0., 
-                                                    -3280., 2372., 3296., 0., 0., 0., 
-                                                    2960., -1504., 4028., 0., 0., 0.,
-                                                    0., 0., 0., 2780., 4400., -400.,
-                                                    0., 0., 0., -3280., 2372., 3296.,
-                                                    0., 0., 0., 2960., -1504., 4028.};
+    auto expected_rr0_data = std::array<double, 36>{
+        2780., 4400.,  -400., 0.,     0.,    0.,    -3280., 2372., 3296., 0.,    0.,     0.,
+        2960., -1504., 4028., 0.,     0.,    0.,    0.,     0.,    0.,    2780., 4400.,  -400.,
+        0.,    0.,     0.,    -3280., 2372., 3296., 0.,     0.,    0.,    2960., -1504., 4028.};
     auto expected_rr0 = Kokkos::View<double[1][6][6], Kokkos::HostSpace>(expected_rr0_data.data());
 
     auto rr0_mirror = Kokkos::create_mirror(rr0);
     Kokkos::deep_copy(rr0_mirror, rr0);
-    for(int i = 0; i < 6; ++i) {
-        for(int j = 0; j < 6; ++j) {
+    for (int i = 0; i < 6; ++i) {
+        for (int j = 0; j < 6; ++j) {
             EXPECT_EQ(rr0_mirror(0, i, j), expected_rr0(0, i, j));
         }
     }
@@ -61,30 +59,27 @@ TEST(CalculateRR0Tests, TwoNodes) {
 
     Kokkos::parallel_for("CalculateRR0", 2, CalculateRR0{r0, r, rr0});
 
-    auto expected_rr0_data = std::array<double, 72>{2780., 4400., -400., 0., 0., 0., 
-                                                    -3280., 2372., 3296., 0., 0., 0., 
-                                                    2960., -1504., 4028., 0., 0., 0.,
-                                                    0., 0., 0., 2780., 4400., -400.,
-                                                    0., 0., 0., -3280., 2372., 3296.,
-                                                    0., 0., 0., 2960., -1504., 4028.,
+    auto expected_rr0_data = std::array<double, 72>{
+        2780.,   4400.,  -400.,   0.,     0.,      0.,      -3280.,  2372.,   3296.,
+        0.,      0.,     0.,      2960.,  -1504.,  4028.,   0.,      0.,      0.,
+        0.,      0.,     0.,      2780.,  4400.,   -400.,   0.,      0.,      0.,
+        -3280.,  2372.,  3296.,   0.,     0.,      0.,      2960.,   -1504.,  4028.,
 
-                                                    16412., 74896., -11984., 0., 0., 0., 
-                                                    -27376., 17284., 70528., 0., 0., 0., 
-                                                    70736., -10688., 30076., 0., 0., 0.,
-                                                    0., 0., 0., 16412., 74896., -11984.,
-                                                    0., 0., 0., -27376., 17284., 70528.,
-                                                    0., 0., 0., 70736., -10688., 30076.};
+        16412.,  74896., -11984., 0.,     0.,      0.,      -27376., 17284.,  70528.,
+        0.,      0.,     0.,      70736., -10688., 30076.,  0.,      0.,      0.,
+        0.,      0.,     0.,      16412., 74896.,  -11984., 0.,      0.,      0.,
+        -27376., 17284., 70528.,  0.,     0.,      0.,      70736.,  -10688., 30076.};
     auto expected_rr0 = Kokkos::View<double[2][6][6], Kokkos::HostSpace>(expected_rr0_data.data());
 
     auto rr0_mirror = Kokkos::create_mirror(rr0);
     Kokkos::deep_copy(rr0_mirror, rr0);
-    for(int i = 0; i < 6; ++i) {
-        for(int j = 0; j < 6; ++j) {
+    for (int i = 0; i < 6; ++i) {
+        for (int j = 0; j < 6; ++j) {
             EXPECT_EQ(rr0_mirror(0, i, j), expected_rr0(0, i, j));
         }
     }
-    for(int i = 0; i < 6; ++i) {
-        for(int j = 0; j < 6; ++j) {
+    for (int i = 0; i < 6; ++i) {
+        for (int j = 0; j < 6; ++j) {
             EXPECT_EQ(rr0_mirror(1, i, j), expected_rr0(1, i, j));
         }
     }

--- a/tests/unit_tests/restruct_poc/system/test_calculate_force_FC.cpp
+++ b/tests/unit_tests/restruct_poc/system/test_calculate_force_FC.cpp
@@ -8,12 +8,10 @@ namespace openturbine::restruct_poc::tests {
 
 TEST(CalculateForceFCTests, OneNode) {
     auto Cuu = Kokkos::View<double[1][6][6]>("Cuu");
-    auto Cuu_data = std::array<double, 36>{ 1.,  2.,  3.,  4.,  5.,  6.,
-                                            7.,  8.,  9., 10., 11., 12.,
-                                           13., 14., 15., 16., 17., 18.,
-                                           19., 20., 21., 22., 23., 24.,
-                                           25., 26., 27., 28., 29., 30.,
-                                           31., 32., 33., 34., 35., 36.,};
+    auto Cuu_data = std::array<double, 36>{
+        1.,  2.,  3.,  4.,  5.,  6.,  7.,  8.,  9.,  10., 11., 12., 13., 14., 15., 16., 17., 18.,
+        19., 20., 21., 22., 23., 24., 25., 26., 27., 28., 29., 30., 31., 32., 33., 34., 35., 36.,
+    };
     auto Cuu_host = Kokkos::View<double[1][6][6], Kokkos::HostSpace>(Cuu_data.data());
     auto Cuu_mirror = Kokkos::create_mirror(Cuu);
     Kokkos::deep_copy(Cuu_mirror, Cuu_host);
@@ -37,32 +35,30 @@ TEST(CalculateForceFCTests, OneNode) {
 
     auto FC_mirror = Kokkos::create_mirror(FC);
     Kokkos::deep_copy(FC_mirror, FC);
-    for(int i = 0; i < 6; ++i) {
+    for (int i = 0; i < 6; ++i) {
         EXPECT_EQ(FC_mirror(0, i), FC_exact(0, i));
     }
 
-    auto M_tilde_exact_data = std::array<double, 9>{0., -7957., 6535., 
-                                                    7957., 0., -5113., 
-                                                    -6535., 5113., 0.};
+    auto M_tilde_exact_data =
+        std::array<double, 9>{0., -7957., 6535., 7957., 0., -5113., -6535., 5113., 0.};
     auto M_tilde_exact = Kokkos::View<double[1][3][3], Kokkos::HostSpace>(M_tilde_exact_data.data());
 
     auto M_tilde_mirror = Kokkos::create_mirror(M_tilde);
     Kokkos::deep_copy(M_tilde_mirror, M_tilde);
-    for(int i = 0; i < 3; ++i) {
-        for(int j = 0; j < 3; ++j) {
+    for (int i = 0; i < 3; ++i) {
+        for (int j = 0; j < 3; ++j) {
             EXPECT_EQ(M_tilde_mirror(0, i, j), M_tilde_exact(0, i, j));
         }
     }
 
-    auto N_tilde_exact_data = std::array<double, 9>{0., -3691., 2269., 
-                                                    3691., 0., -847.,
-                                                    -2269., 847., 0.};
+    auto N_tilde_exact_data =
+        std::array<double, 9>{0., -3691., 2269., 3691., 0., -847., -2269., 847., 0.};
     auto N_tilde_exact = Kokkos::View<double[1][3][3], Kokkos::HostSpace>(N_tilde_exact_data.data());
 
     auto N_tilde_mirror = Kokkos::create_mirror(N_tilde);
     Kokkos::deep_copy(N_tilde_mirror, N_tilde);
-    for(int i = 0; i < 3; ++i) {
-        for(int j = 0; j < 3; ++j) {
+    for (int i = 0; i < 3; ++i) {
+        for (int j = 0; j < 3; ++j) {
             EXPECT_EQ(N_tilde_mirror(0, i, j), N_tilde_exact(0, i, j));
         }
     }

--- a/tests/unit_tests/restruct_poc/system/test_calculate_force_FC.cpp
+++ b/tests/unit_tests/restruct_poc/system/test_calculate_force_FC.cpp
@@ -1,0 +1,71 @@
+#include <Kokkos_Core.hpp>
+#include <gtest/gtest.h>
+
+#include "src/restruct_poc/system/calculate_force_FC.hpp"
+#include "src/restruct_poc/types.hpp"
+
+namespace openturbine::restruct_poc::tests {
+
+TEST(CalculateForceFCTests, OneNode) {
+    auto Cuu = Kokkos::View<double[1][6][6]>("Cuu");
+    auto Cuu_data = std::array<double, 36>{ 1.,  2.,  3.,  4.,  5.,  6.,
+                                            7.,  8.,  9., 10., 11., 12.,
+                                           13., 14., 15., 16., 17., 18.,
+                                           19., 20., 21., 22., 23., 24.,
+                                           25., 26., 27., 28., 29., 30.,
+                                           31., 32., 33., 34., 35., 36.,};
+    auto Cuu_host = Kokkos::View<double[1][6][6], Kokkos::HostSpace>(Cuu_data.data());
+    auto Cuu_mirror = Kokkos::create_mirror(Cuu);
+    Kokkos::deep_copy(Cuu_mirror, Cuu_host);
+    Kokkos::deep_copy(Cuu, Cuu_mirror);
+
+    auto strain = Kokkos::View<double[1][6]>("strain");
+    auto strain_data = std::array<double, 6>{37., 38., 39., 40., 41., 42.};
+    auto strain_host = Kokkos::View<double[1][6], Kokkos::HostSpace>(strain_data.data());
+    auto strain_mirror = Kokkos::create_mirror(strain);
+    Kokkos::deep_copy(strain_mirror, strain_host);
+    Kokkos::deep_copy(strain, strain_mirror);
+
+    auto FC = Kokkos::View<double[1][6]>("FC");
+    auto M_tilde = Kokkos::View<double[1][3][3]>("M_tilde");
+    auto N_tilde = Kokkos::View<double[1][3][3]>("N_tilde");
+
+    Kokkos::parallel_for("CalculateForceFC", 1, CalculateForceFC{Cuu, strain, FC, M_tilde, N_tilde});
+
+    auto FC_exact_data = std::array<double, 6>{847., 2269., 3691., 5113., 6535., 7957.};
+    auto FC_exact = Kokkos::View<double[1][6], Kokkos::HostSpace>(FC_exact_data.data());
+
+    auto FC_mirror = Kokkos::create_mirror(FC);
+    Kokkos::deep_copy(FC_mirror, FC);
+    for(int i = 0; i < 6; ++i) {
+        EXPECT_EQ(FC_mirror(0, i), FC_exact(0, i));
+    }
+
+    auto M_tilde_exact_data = std::array<double, 9>{0., -7957., 6535., 
+                                                    7957., 0., -5113., 
+                                                    -6535., 5113., 0.};
+    auto M_tilde_exact = Kokkos::View<double[1][3][3], Kokkos::HostSpace>(M_tilde_exact_data.data());
+
+    auto M_tilde_mirror = Kokkos::create_mirror(M_tilde);
+    Kokkos::deep_copy(M_tilde_mirror, M_tilde);
+    for(int i = 0; i < 3; ++i) {
+        for(int j = 0; j < 3; ++j) {
+            EXPECT_EQ(M_tilde_mirror(0, i, j), M_tilde_exact(0, i, j));
+        }
+    }
+
+    auto N_tilde_exact_data = std::array<double, 9>{0., -3691., 2269., 
+                                                    3691., 0., -847.,
+                                                    -2269., 847., 0.};
+    auto N_tilde_exact = Kokkos::View<double[1][3][3], Kokkos::HostSpace>(N_tilde_exact_data.data());
+
+    auto N_tilde_mirror = Kokkos::create_mirror(N_tilde);
+    Kokkos::deep_copy(N_tilde_mirror, N_tilde);
+    for(int i = 0; i < 3; ++i) {
+        for(int j = 0; j < 3; ++j) {
+            EXPECT_EQ(N_tilde_mirror(0, i, j), N_tilde_exact(0, i, j));
+        }
+    }
+}
+
+}  // namespace openturbine::restruct_poc::tests

--- a/tests/unit_tests/restruct_poc/system/test_calculate_force_FD.cpp
+++ b/tests/unit_tests/restruct_poc/system/test_calculate_force_FD.cpp
@@ -8,9 +8,7 @@ namespace openturbine::restruct_poc::tests {
 
 TEST(CalculateForceFDTests, OneNode) {
     auto x0pupSS = Kokkos::View<double[1][3][3]>("x0pupSS");
-    auto x0pupSS_data = std::array<double, 9>{ 1.,  2.,  3.,  
-                                               4.,  5.,  6.,
-                                               7.,  8.,  9.};
+    auto x0pupSS_data = std::array<double, 9>{1., 2., 3., 4., 5., 6., 7., 8., 9.};
     auto x0pupSS_host = Kokkos::View<double[1][3][3], Kokkos::HostSpace>(x0pupSS_data.data());
     auto x0pupSS_mirror = Kokkos::create_mirror(x0pupSS);
     Kokkos::deep_copy(x0pupSS_mirror, x0pupSS_host);
@@ -32,7 +30,7 @@ TEST(CalculateForceFDTests, OneNode) {
 
     auto FD_mirror = Kokkos::create_mirror(FD);
     Kokkos::deep_copy(FD_mirror, FD);
-    for(int i = 0; i < 6; ++i) {
+    for (int i = 0; i < 6; ++i) {
         EXPECT_EQ(FD_mirror(0, i), FD_exact(0, i));
     }
 }

--- a/tests/unit_tests/restruct_poc/system/test_calculate_force_FD.cpp
+++ b/tests/unit_tests/restruct_poc/system/test_calculate_force_FD.cpp
@@ -1,0 +1,40 @@
+#include <Kokkos_Core.hpp>
+#include <gtest/gtest.h>
+
+#include "src/restruct_poc/system/calculate_force_FD.hpp"
+#include "src/restruct_poc/types.hpp"
+
+namespace openturbine::restruct_poc::tests {
+
+TEST(CalculateForceFDTests, OneNode) {
+    auto x0pupSS = Kokkos::View<double[1][3][3]>("x0pupSS");
+    auto x0pupSS_data = std::array<double, 9>{ 1.,  2.,  3.,  
+                                               4.,  5.,  6.,
+                                               7.,  8.,  9.};
+    auto x0pupSS_host = Kokkos::View<double[1][3][3], Kokkos::HostSpace>(x0pupSS_data.data());
+    auto x0pupSS_mirror = Kokkos::create_mirror(x0pupSS);
+    Kokkos::deep_copy(x0pupSS_mirror, x0pupSS_host);
+    Kokkos::deep_copy(x0pupSS, x0pupSS_mirror);
+
+    auto FC = Kokkos::View<double[1][6]>("FC");
+    auto FC_data = std::array<double, 6>{10., 11., 12., 13., 14., 15.};
+    auto FC_host = Kokkos::View<double[1][6], Kokkos::HostSpace>(FC_data.data());
+    auto FC_mirror = Kokkos::create_mirror(FC);
+    Kokkos::deep_copy(FC_mirror, FC_host);
+    Kokkos::deep_copy(FC, FC_mirror);
+
+    auto FD = Kokkos::View<double[1][6]>("FD");
+
+    Kokkos::parallel_for("CalculateForceFD", 1, CalculateForceFD{x0pupSS, FC, FD});
+
+    auto FD_exact_data = std::array<double, 6>{0., 0., 0., 138., 171., 204.};
+    auto FD_exact = Kokkos::View<double[1][6], Kokkos::HostSpace>(FD_exact_data.data());
+
+    auto FD_mirror = Kokkos::create_mirror(FD);
+    Kokkos::deep_copy(FD_mirror, FD);
+    for(int i = 0; i < 6; ++i) {
+        EXPECT_EQ(FD_mirror(0, i), FD_exact(0, i));
+    }
+}
+
+}  // namespace openturbine::restruct_poc::tests

--- a/tests/unit_tests/restruct_poc/system/test_calculate_gravity_force.cpp
+++ b/tests/unit_tests/restruct_poc/system/test_calculate_gravity_force.cpp
@@ -1,0 +1,50 @@
+#include <Kokkos_Core.hpp>
+#include <gtest/gtest.h>
+
+#include "src/restruct_poc/system/calculate_gravity_force.hpp"
+#include "src/restruct_poc/types.hpp"
+
+namespace openturbine::restruct_poc::tests {
+
+TEST(CalculateGravityForceTests, OneNode) {
+    auto Muu = Kokkos::View<double[1][6][6]>("Muu");
+    auto Muu_data = std::array<double, 36>{1., 2., 3., 4., 5., 6., 
+                                           7., 8., 9., 10., 11., 12., 
+                                           13., 14., 15., 16., 17., 18., 
+                                           19., 20., 21., 22., 23., 24., 
+                                           25., 26., 27., 28., 29., 30., 
+                                           31., 32., 33., 34., 35., 36.};
+    auto Muu_host = Kokkos::View<double[1][6][6], Kokkos::HostSpace>(Muu_data.data());
+    auto Muu_mirror = Kokkos::create_mirror(Muu);
+    Kokkos::deep_copy(Muu_mirror, Muu_host);
+    Kokkos::deep_copy(Muu, Muu_mirror);
+
+    auto eta_tilde = Kokkos::View<double[1][3][3]>("eta_tilde");
+    auto eta_tilde_data = std::array<double, 9>{37., 38., 39., 40., 41., 42., 43., 44., 45.};
+    auto eta_tilde_host = Kokkos::View<double[1][3][3], Kokkos::HostSpace>(eta_tilde_data.data());
+    auto eta_tilde_mirror = Kokkos::create_mirror(eta_tilde);
+    Kokkos::deep_copy(eta_tilde_mirror, eta_tilde_host);
+    Kokkos::deep_copy(eta_tilde, eta_tilde_mirror);
+
+    auto gravity = Kokkos::View<double[3]>("gravity");
+    auto gravity_data = std::array<double, 3>{46., 47., 48.};
+    auto gravity_host = Kokkos::View<double[3], Kokkos::HostSpace>(gravity_data.data());
+    auto gravity_mirror = Kokkos::create_mirror(gravity);
+    Kokkos::deep_copy(gravity_mirror, gravity_host);
+    Kokkos::deep_copy(gravity, gravity_mirror);
+
+    auto FG = Kokkos::View<double[1][6]>("FG");
+
+    Kokkos::parallel_for("CalculateGravityForce", 1, CalculateGravityForce{gravity, Muu, eta_tilde, FG});
+
+    auto FG_exact_data = std::array<double, 6>{46., 47., 48., 5360., 5783., 6206.};
+    auto FG_exact = Kokkos::View<double[1][6], Kokkos::HostSpace>(FG_exact_data.data());
+
+    auto FG_mirror = Kokkos::create_mirror(FG);
+    Kokkos::deep_copy(FG_mirror, FG);
+    for(int i = 0; i < 6; ++i) {
+        EXPECT_EQ(FG_mirror(0, i), FG_exact(0, i));
+    }
+}
+
+}  // namespace openturbine::restruct_poc::tests

--- a/tests/unit_tests/restruct_poc/system/test_calculate_gravity_force.cpp
+++ b/tests/unit_tests/restruct_poc/system/test_calculate_gravity_force.cpp
@@ -8,12 +8,9 @@ namespace openturbine::restruct_poc::tests {
 
 TEST(CalculateGravityForceTests, OneNode) {
     auto Muu = Kokkos::View<double[1][6][6]>("Muu");
-    auto Muu_data = std::array<double, 36>{1., 2., 3., 4., 5., 6., 
-                                           7., 8., 9., 10., 11., 12., 
-                                           13., 14., 15., 16., 17., 18., 
-                                           19., 20., 21., 22., 23., 24., 
-                                           25., 26., 27., 28., 29., 30., 
-                                           31., 32., 33., 34., 35., 36.};
+    auto Muu_data = std::array<double, 36>{
+        1.,  2.,  3.,  4.,  5.,  6.,  7.,  8.,  9.,  10., 11., 12., 13., 14., 15., 16., 17., 18.,
+        19., 20., 21., 22., 23., 24., 25., 26., 27., 28., 29., 30., 31., 32., 33., 34., 35., 36.};
     auto Muu_host = Kokkos::View<double[1][6][6], Kokkos::HostSpace>(Muu_data.data());
     auto Muu_mirror = Kokkos::create_mirror(Muu);
     Kokkos::deep_copy(Muu_mirror, Muu_host);
@@ -35,14 +32,16 @@ TEST(CalculateGravityForceTests, OneNode) {
 
     auto FG = Kokkos::View<double[1][6]>("FG");
 
-    Kokkos::parallel_for("CalculateGravityForce", 1, CalculateGravityForce{gravity, Muu, eta_tilde, FG});
+    Kokkos::parallel_for(
+        "CalculateGravityForce", 1, CalculateGravityForce{gravity, Muu, eta_tilde, FG}
+    );
 
     auto FG_exact_data = std::array<double, 6>{46., 47., 48., 5360., 5783., 6206.};
     auto FG_exact = Kokkos::View<double[1][6], Kokkos::HostSpace>(FG_exact_data.data());
 
     auto FG_mirror = Kokkos::create_mirror(FG);
     Kokkos::deep_copy(FG_mirror, FG);
-    for(int i = 0; i < 6; ++i) {
+    for (int i = 0; i < 6; ++i) {
         EXPECT_EQ(FG_mirror(0, i), FG_exact(0, i));
     }
 }

--- a/tests/unit_tests/restruct_poc/system/test_calculate_gyroscopic_matrix.cpp
+++ b/tests/unit_tests/restruct_poc/system/test_calculate_gyroscopic_matrix.cpp
@@ -1,0 +1,71 @@
+#include <Kokkos_Core.hpp>
+#include <gtest/gtest.h>
+
+#include "src/restruct_poc/system/calculate_gyroscopic_matrix.hpp"
+#include "src/restruct_poc/types.hpp"
+
+namespace openturbine::restruct_poc::tests {
+
+TEST(CalculateGyroscopicMatrixTests, OneNode) {
+    auto Muu = Kokkos::View<double[1][6][6]>("Muu");
+    auto Muu_data = std::array<double, 36>{1., 2., 3., 4., 5., 6., 
+                                           7., 8., 9., 10., 11., 12., 
+                                           13., 14., 15., 16., 17., 18., 
+                                           19., 20., 21., 22., 23., 24., 
+                                           25., 26., 27., 28., 29., 30., 
+                                           31., 32., 33., 34., 35., 36.};
+    auto Muu_host = Kokkos::View<double[1][6][6], Kokkos::HostSpace>(Muu_data.data());
+    auto Muu_mirror = Kokkos::create_mirror(Muu);
+    Kokkos::deep_copy(Muu_mirror, Muu_host);
+    Kokkos::deep_copy(Muu, Muu_mirror);
+
+    auto omega = Kokkos::View<double[1][3]>("omega");
+    auto omega_data = std::array<double, 3>{40., 41., 42.};
+    auto omega_host = Kokkos::View<double[1][3], Kokkos::HostSpace>(omega_data.data());
+    auto omega_mirror = Kokkos::create_mirror(omega);
+    Kokkos::deep_copy(omega_mirror, omega_host);
+    Kokkos::deep_copy(omega, omega_mirror);
+
+    auto omega_tilde = Kokkos::View<double[1][3][3]>("omega_tilde");
+    auto omega_tilde_data = std::array<double, 9>{46., 47., 48., 49., 50., 51., 52., 53., 54.};
+    auto omega_tilde_host = Kokkos::View<double[1][3][3], Kokkos::HostSpace>(omega_tilde_data.data());
+    auto omega_tilde_mirror = Kokkos::create_mirror(omega_tilde);
+    Kokkos::deep_copy(omega_tilde_mirror, omega_tilde_host);
+    Kokkos::deep_copy(omega_tilde, omega_tilde_mirror);
+
+    auto rho = Kokkos::View<double[1][3][3]>("rho");
+    auto rho_data = std::array<double, 9>{55., 56., 57., 58., 59., 60., 61., 62., 63.};
+    auto rho_host = Kokkos::View<double[1][3][3], Kokkos::HostSpace>(rho_data.data());
+    auto rho_mirror = Kokkos::create_mirror(rho);
+    Kokkos::deep_copy(rho_mirror, rho_host);
+    Kokkos::deep_copy(rho, rho_mirror);
+
+    auto eta = Kokkos::View<double[1][3]>("eta");
+    auto eta_data = std::array<double, 3>{64., 65., 66.};
+    auto eta_host = Kokkos::View<double[1][3], Kokkos::HostSpace>(eta_data.data());
+    auto eta_mirror = Kokkos::create_mirror(eta);
+    Kokkos::deep_copy(eta_mirror, eta_host);
+    Kokkos::deep_copy(eta, eta_mirror);
+
+    auto Guu = Kokkos::View<double[1][6][6]>("Guu");
+
+    Kokkos::parallel_for("CalculateGyroscopicMatrix", 1, CalculateGyroscopicMatrix{Muu, omega, omega_tilde, rho, eta, Guu});
+
+    auto Guu_exact_data = std::array<double, 36>{0., 0., 0., 18., 10301., -9734.,
+                                                 0., 0., 0., -10322., -30., 9182.,
+                                                 0., 0., 0., 9764., -9191., 12.,
+                                                 0., 0., 0., 8184., 15953., 1207.,
+                                                 0., 0., 0., 1078., 8856., 15896.,
+                                                 0., 0., 0., 16487., 2497., 9546.};
+    auto Guu_exact = Kokkos::View<double[1][6][6], Kokkos::HostSpace>(Guu_exact_data.data());
+
+    auto Guu_mirror = Kokkos::create_mirror(Guu);
+    Kokkos::deep_copy(Guu_mirror, Guu);
+    for(int i = 0; i < 6; ++i) {
+        for(int j = 0; j < 6; ++j) {
+            EXPECT_EQ(Guu_mirror(0, i, j), Guu_exact(0, i, j));
+        }
+    }
+}
+
+}  // namespace openturbine::restruct_poc::tests

--- a/tests/unit_tests/restruct_poc/system/test_calculate_gyroscopic_matrix.cpp
+++ b/tests/unit_tests/restruct_poc/system/test_calculate_gyroscopic_matrix.cpp
@@ -8,12 +8,9 @@ namespace openturbine::restruct_poc::tests {
 
 TEST(CalculateGyroscopicMatrixTests, OneNode) {
     auto Muu = Kokkos::View<double[1][6][6]>("Muu");
-    auto Muu_data = std::array<double, 36>{1., 2., 3., 4., 5., 6., 
-                                           7., 8., 9., 10., 11., 12., 
-                                           13., 14., 15., 16., 17., 18., 
-                                           19., 20., 21., 22., 23., 24., 
-                                           25., 26., 27., 28., 29., 30., 
-                                           31., 32., 33., 34., 35., 36.};
+    auto Muu_data = std::array<double, 36>{
+        1.,  2.,  3.,  4.,  5.,  6.,  7.,  8.,  9.,  10., 11., 12., 13., 14., 15., 16., 17., 18.,
+        19., 20., 21., 22., 23., 24., 25., 26., 27., 28., 29., 30., 31., 32., 33., 34., 35., 36.};
     auto Muu_host = Kokkos::View<double[1][6][6], Kokkos::HostSpace>(Muu_data.data());
     auto Muu_mirror = Kokkos::create_mirror(Muu);
     Kokkos::deep_copy(Muu_mirror, Muu_host);
@@ -28,7 +25,8 @@ TEST(CalculateGyroscopicMatrixTests, OneNode) {
 
     auto omega_tilde = Kokkos::View<double[1][3][3]>("omega_tilde");
     auto omega_tilde_data = std::array<double, 9>{46., 47., 48., 49., 50., 51., 52., 53., 54.};
-    auto omega_tilde_host = Kokkos::View<double[1][3][3], Kokkos::HostSpace>(omega_tilde_data.data());
+    auto omega_tilde_host =
+        Kokkos::View<double[1][3][3], Kokkos::HostSpace>(omega_tilde_data.data());
     auto omega_tilde_mirror = Kokkos::create_mirror(omega_tilde);
     Kokkos::deep_copy(omega_tilde_mirror, omega_tilde_host);
     Kokkos::deep_copy(omega_tilde, omega_tilde_mirror);
@@ -49,20 +47,21 @@ TEST(CalculateGyroscopicMatrixTests, OneNode) {
 
     auto Guu = Kokkos::View<double[1][6][6]>("Guu");
 
-    Kokkos::parallel_for("CalculateGyroscopicMatrix", 1, CalculateGyroscopicMatrix{Muu, omega, omega_tilde, rho, eta, Guu});
+    Kokkos::parallel_for(
+        "CalculateGyroscopicMatrix", 1,
+        CalculateGyroscopicMatrix{Muu, omega, omega_tilde, rho, eta, Guu}
+    );
 
-    auto Guu_exact_data = std::array<double, 36>{0., 0., 0., 18., 10301., -9734.,
-                                                 0., 0., 0., -10322., -30., 9182.,
-                                                 0., 0., 0., 9764., -9191., 12.,
-                                                 0., 0., 0., 8184., 15953., 1207.,
-                                                 0., 0., 0., 1078., 8856., 15896.,
-                                                 0., 0., 0., 16487., 2497., 9546.};
+    auto Guu_exact_data = std::array<double, 36>{
+        0., 0., 0., 18.,   10301., -9734., 0., 0., 0., -10322., -30.,   9182.,
+        0., 0., 0., 9764., -9191., 12.,    0., 0., 0., 8184.,   15953., 1207.,
+        0., 0., 0., 1078., 8856.,  15896., 0., 0., 0., 16487.,  2497.,  9546.};
     auto Guu_exact = Kokkos::View<double[1][6][6], Kokkos::HostSpace>(Guu_exact_data.data());
 
     auto Guu_mirror = Kokkos::create_mirror(Guu);
     Kokkos::deep_copy(Guu_mirror, Guu);
-    for(int i = 0; i < 6; ++i) {
-        for(int j = 0; j < 6; ++j) {
+    for (int i = 0; i < 6; ++i) {
+        for (int j = 0; j < 6; ++j) {
             EXPECT_EQ(Guu_mirror(0, i, j), Guu_exact(0, i, j));
         }
     }

--- a/tests/unit_tests/restruct_poc/system/test_calculate_inertia_stiffness_matrix.cpp
+++ b/tests/unit_tests/restruct_poc/system/test_calculate_inertia_stiffness_matrix.cpp
@@ -1,12 +1,12 @@
 #include <Kokkos_Core.hpp>
 #include <gtest/gtest.h>
 
-#include "src/restruct_poc/system/calculate_inertial_forces.hpp"
+#include "src/restruct_poc/system/calculate_inertia_stiffness_matrix.hpp"
 #include "src/restruct_poc/types.hpp"
 
 namespace openturbine::restruct_poc::tests {
 
-TEST(CalculateInertialForcesTests, OneNode) {
+TEST(CalculateInertiaStiffnessMatrixTests, OneNode) {
     auto Muu = Kokkos::View<double[1][6][6]>("Muu");
     auto Muu_data = std::array<double, 36>{1., 2., 3., 4., 5., 6., 
                                            7., 8., 9., 10., 11., 12., 
@@ -47,59 +47,52 @@ TEST(CalculateInertialForcesTests, OneNode) {
     Kokkos::deep_copy(eta_tilde_mirror, eta_tilde_host);
     Kokkos::deep_copy(eta_tilde, eta_tilde_mirror);
 
+    auto omega_tilde = Kokkos::View<double[1][3][3]>("omega_tilde");
+    auto omega_tilde_data = std::array<double, 9>{46., 47., 48., 49., 50., 51., 52., 53., 54.};
+    auto omega_tilde_host = Kokkos::View<double[1][3][3], Kokkos::HostSpace>(omega_tilde_data.data());
+    auto omega_tilde_mirror = Kokkos::create_mirror(omega_tilde);
+    Kokkos::deep_copy(omega_tilde_mirror, omega_tilde_host);
+    Kokkos::deep_copy(omega_tilde, omega_tilde_mirror);
+
+    auto omega_dot_tilde = Kokkos::View<double[1][3][3]>("omega_dot_tilde");
+    auto omega_dot_tilde_data = std::array<double, 9>{55., 56., 57., 58., 59., 60., 61., 62., 63.};
+    auto omega_dot_tilde_host = Kokkos::View<double[1][3][3], Kokkos::HostSpace>(omega_dot_tilde_data.data());
+    auto omega_dot_tilde_mirror = Kokkos::create_mirror(omega_dot_tilde);
+    Kokkos::deep_copy(omega_dot_tilde_mirror, omega_dot_tilde_host);
+    Kokkos::deep_copy(omega_dot_tilde, omega_dot_tilde_mirror);
+
     auto rho = Kokkos::View<double[1][3][3]>("rho");
-    auto rho_data = std::array<double, 9>{55., 56., 57., 58., 59., 60., 61., 62., 63.};
+    auto rho_data = std::array<double, 9>{64., 65., 66., 67., 68., 69., 70., 71., 72.};
     auto rho_host = Kokkos::View<double[1][3][3], Kokkos::HostSpace>(rho_data.data());
     auto rho_mirror = Kokkos::create_mirror(rho);
     Kokkos::deep_copy(rho_mirror, rho_host);
     Kokkos::deep_copy(rho, rho_mirror);
 
     auto eta = Kokkos::View<double[1][3]>("eta");
-    auto eta_data = std::array<double, 3>{64., 65., 66.};
+    auto eta_data = std::array<double, 3>{73., 74., 75.};
     auto eta_host = Kokkos::View<double[1][3], Kokkos::HostSpace>(eta_data.data());
     auto eta_mirror = Kokkos::create_mirror(eta);
     Kokkos::deep_copy(eta_mirror, eta_host);
     Kokkos::deep_copy(eta, eta_mirror);
 
-    auto omega_tilde = Kokkos::View<double[1][3][3]>("omega_tilde");
-    auto omega_dot_tilde = Kokkos::View<double[1][3][3]>("omega_dot_tilde");
-    auto FI = Kokkos::View<double[1][6]>("FI");
+    auto Kuu = Kokkos::View<double[1][6][6]>("Kuu");
 
-    Kokkos::parallel_for("CalculateInertialForces", 1, CalculateInertialForces{Muu, u_ddot, omega, omega_dot, eta_tilde, omega_tilde, omega_dot_tilde, rho, eta, FI});
+    Kokkos::parallel_for("CalculateInertiaStiffnessMatrix", 1, CalculateInertiaStiffnessMatrix{Muu, u_ddot, omega, omega_dot, omega_tilde, omega_dot_tilde, rho, eta, Kuu});
 
-    auto omega_tilde_exact_data = std::array<double, 9>{0., -42., 41.,
-                                                         42., 0., -40.,
-                                                         -41., 40., 0.};
-    auto omega_tilde_exact = Kokkos::View<double[1][3][3], Kokkos::HostSpace>(omega_tilde_exact_data.data());
+    auto Kuu_exact_data = std::array<double, 36>{0., 0., 0., 3396., -6792., 3396.,
+                                                 0., 0., 0., 3609., -7218., 3609.,
+                                                 0., 0., 0., 3822., -7644., 3822.,
+                                                 0., 0., 0., 1407766., 1481559., 1465326.,
+                                                 0., 0., 0., 1496300., 1558384., 1576048.,
+                                                 0., 0., 0., 1604122., 1652877., 1652190.};
+    auto Kuu_exact = Kokkos::View<double[1][6][6], Kokkos::HostSpace>(Kuu_exact_data.data());
 
-    auto omega_tilde_mirror = Kokkos::create_mirror(omega_tilde);
-    Kokkos::deep_copy(omega_tilde_mirror, omega_tilde);
-    for(int i = 0; i < 3; ++i) {
-        for(int j = 0; j < 3; ++j) {
-            EXPECT_EQ(omega_tilde_mirror(0, i, j), omega_tilde_exact(0, i, j));
-        }
-    }
-
-    auto omega_dot_tilde_exact_data = std::array<double, 9>{0., -45., 44.,
-                                                             45., 0., -43.,
-                                                             -44., 43., 0.};
-    auto omega_dot_tilde_exact = Kokkos::View<double[1][3][3], Kokkos::HostSpace>(omega_dot_tilde_exact_data.data());
-
-    auto omega_dot_tilde_mirror = Kokkos::create_mirror(omega_dot_tilde);
-    Kokkos::deep_copy(omega_dot_tilde_mirror, omega_dot_tilde);
-    for(int i = 0; i < 3; ++i) {
-        for(int j = 0; j < 3; ++j) {
-            EXPECT_EQ(omega_dot_tilde_mirror(0, i, j), omega_dot_tilde_exact(0, i, j));
-        }
-    }
-
-    auto FI_exact_data = std::array<double, 6>{-2984., 32., 2922., 20624., -2248., 22100.};
-    auto FI_exact = Kokkos::View<double[1][6], Kokkos::HostSpace>(FI_exact_data.data());
-
-    auto FI_mirror = Kokkos::create_mirror(FI);
-    Kokkos::deep_copy(FI_mirror, FI);
+    auto Kuu_mirror = Kokkos::create_mirror(Kuu);
+    Kokkos::deep_copy(Kuu_mirror, Kuu);
     for(int i = 0; i < 6; ++i) {
-        EXPECT_EQ(FI_mirror(0, i), FI_exact(0, i));
+        for(int j = 0; j < 6; ++j) {
+            EXPECT_EQ(Kuu_mirror(0, i, j), Kuu_exact(0, i, j));
+        }
     }
 }
 

--- a/tests/unit_tests/restruct_poc/system/test_calculate_inertia_stiffness_matrix.cpp
+++ b/tests/unit_tests/restruct_poc/system/test_calculate_inertia_stiffness_matrix.cpp
@@ -8,12 +8,9 @@ namespace openturbine::restruct_poc::tests {
 
 TEST(CalculateInertiaStiffnessMatrixTests, OneNode) {
     auto Muu = Kokkos::View<double[1][6][6]>("Muu");
-    auto Muu_data = std::array<double, 36>{1., 2., 3., 4., 5., 6., 
-                                           7., 8., 9., 10., 11., 12., 
-                                           13., 14., 15., 16., 17., 18., 
-                                           19., 20., 21., 22., 23., 24., 
-                                           25., 26., 27., 28., 29., 30., 
-                                           31., 32., 33., 34., 35., 36.};
+    auto Muu_data = std::array<double, 36>{
+        1.,  2.,  3.,  4.,  5.,  6.,  7.,  8.,  9.,  10., 11., 12., 13., 14., 15., 16., 17., 18.,
+        19., 20., 21., 22., 23., 24., 25., 26., 27., 28., 29., 30., 31., 32., 33., 34., 35., 36.};
     auto Muu_host = Kokkos::View<double[1][6][6], Kokkos::HostSpace>(Muu_data.data());
     auto Muu_mirror = Kokkos::create_mirror(Muu);
     Kokkos::deep_copy(Muu_mirror, Muu_host);
@@ -49,14 +46,16 @@ TEST(CalculateInertiaStiffnessMatrixTests, OneNode) {
 
     auto omega_tilde = Kokkos::View<double[1][3][3]>("omega_tilde");
     auto omega_tilde_data = std::array<double, 9>{46., 47., 48., 49., 50., 51., 52., 53., 54.};
-    auto omega_tilde_host = Kokkos::View<double[1][3][3], Kokkos::HostSpace>(omega_tilde_data.data());
+    auto omega_tilde_host =
+        Kokkos::View<double[1][3][3], Kokkos::HostSpace>(omega_tilde_data.data());
     auto omega_tilde_mirror = Kokkos::create_mirror(omega_tilde);
     Kokkos::deep_copy(omega_tilde_mirror, omega_tilde_host);
     Kokkos::deep_copy(omega_tilde, omega_tilde_mirror);
 
     auto omega_dot_tilde = Kokkos::View<double[1][3][3]>("omega_dot_tilde");
     auto omega_dot_tilde_data = std::array<double, 9>{55., 56., 57., 58., 59., 60., 61., 62., 63.};
-    auto omega_dot_tilde_host = Kokkos::View<double[1][3][3], Kokkos::HostSpace>(omega_dot_tilde_data.data());
+    auto omega_dot_tilde_host =
+        Kokkos::View<double[1][3][3], Kokkos::HostSpace>(omega_dot_tilde_data.data());
     auto omega_dot_tilde_mirror = Kokkos::create_mirror(omega_dot_tilde);
     Kokkos::deep_copy(omega_dot_tilde_mirror, omega_dot_tilde_host);
     Kokkos::deep_copy(omega_dot_tilde, omega_dot_tilde_mirror);
@@ -77,20 +76,22 @@ TEST(CalculateInertiaStiffnessMatrixTests, OneNode) {
 
     auto Kuu = Kokkos::View<double[1][6][6]>("Kuu");
 
-    Kokkos::parallel_for("CalculateInertiaStiffnessMatrix", 1, CalculateInertiaStiffnessMatrix{Muu, u_ddot, omega, omega_dot, omega_tilde, omega_dot_tilde, rho, eta, Kuu});
+    Kokkos::parallel_for(
+        "CalculateInertiaStiffnessMatrix", 1,
+        CalculateInertiaStiffnessMatrix{
+            Muu, u_ddot, omega, omega_dot, omega_tilde, omega_dot_tilde, rho, eta, Kuu}
+    );
 
-    auto Kuu_exact_data = std::array<double, 36>{0., 0., 0., 3396., -6792., 3396.,
-                                                 0., 0., 0., 3609., -7218., 3609.,
-                                                 0., 0., 0., 3822., -7644., 3822.,
-                                                 0., 0., 0., 1407766., 1481559., 1465326.,
-                                                 0., 0., 0., 1496300., 1558384., 1576048.,
-                                                 0., 0., 0., 1604122., 1652877., 1652190.};
+    auto Kuu_exact_data = std::array<double, 36>{
+        0., 0., 0., 3396.,    -6792.,   3396.,    0., 0., 0., 3609.,    -7218.,   3609.,
+        0., 0., 0., 3822.,    -7644.,   3822.,    0., 0., 0., 1407766., 1481559., 1465326.,
+        0., 0., 0., 1496300., 1558384., 1576048., 0., 0., 0., 1604122., 1652877., 1652190.};
     auto Kuu_exact = Kokkos::View<double[1][6][6], Kokkos::HostSpace>(Kuu_exact_data.data());
 
     auto Kuu_mirror = Kokkos::create_mirror(Kuu);
     Kokkos::deep_copy(Kuu_mirror, Kuu);
-    for(int i = 0; i < 6; ++i) {
-        for(int j = 0; j < 6; ++j) {
+    for (int i = 0; i < 6; ++i) {
+        for (int j = 0; j < 6; ++j) {
             EXPECT_EQ(Kuu_mirror(0, i, j), Kuu_exact(0, i, j));
         }
     }

--- a/tests/unit_tests/restruct_poc/system/test_calculate_inertial_forces.cpp
+++ b/tests/unit_tests/restruct_poc/system/test_calculate_inertial_forces.cpp
@@ -8,12 +8,9 @@ namespace openturbine::restruct_poc::tests {
 
 TEST(CalculateInertialForcesTests, OneNode) {
     auto Muu = Kokkos::View<double[1][6][6]>("Muu");
-    auto Muu_data = std::array<double, 36>{1., 2., 3., 4., 5., 6., 
-                                           7., 8., 9., 10., 11., 12., 
-                                           13., 14., 15., 16., 17., 18., 
-                                           19., 20., 21., 22., 23., 24., 
-                                           25., 26., 27., 28., 29., 30., 
-                                           31., 32., 33., 34., 35., 36.};
+    auto Muu_data = std::array<double, 36>{
+        1.,  2.,  3.,  4.,  5.,  6.,  7.,  8.,  9.,  10., 11., 12., 13., 14., 15., 16., 17., 18.,
+        19., 20., 21., 22., 23., 24., 25., 26., 27., 28., 29., 30., 31., 32., 33., 34., 35., 36.};
     auto Muu_host = Kokkos::View<double[1][6][6], Kokkos::HostSpace>(Muu_data.data());
     auto Muu_mirror = Kokkos::create_mirror(Muu);
     Kokkos::deep_copy(Muu_mirror, Muu_host);
@@ -65,30 +62,33 @@ TEST(CalculateInertialForcesTests, OneNode) {
     auto omega_dot_tilde = Kokkos::View<double[1][3][3]>("omega_dot_tilde");
     auto FI = Kokkos::View<double[1][6]>("FI");
 
-    Kokkos::parallel_for("CalculateInertialForces", 1, CalculateInertialForces{Muu, u_ddot, omega, omega_dot, eta_tilde, omega_tilde, omega_dot_tilde, rho, eta, FI});
+    Kokkos::parallel_for(
+        "CalculateInertialForces", 1,
+        CalculateInertialForces{
+            Muu, u_ddot, omega, omega_dot, eta_tilde, omega_tilde, omega_dot_tilde, rho, eta, FI}
+    );
 
-    auto omega_tilde_exact_data = std::array<double, 9>{0., -42., 41.,
-                                                         42., 0., -40.,
-                                                         -41., 40., 0.};
-    auto omega_tilde_exact = Kokkos::View<double[1][3][3], Kokkos::HostSpace>(omega_tilde_exact_data.data());
+    auto omega_tilde_exact_data = std::array<double, 9>{0., -42., 41., 42., 0., -40., -41., 40., 0.};
+    auto omega_tilde_exact =
+        Kokkos::View<double[1][3][3], Kokkos::HostSpace>(omega_tilde_exact_data.data());
 
     auto omega_tilde_mirror = Kokkos::create_mirror(omega_tilde);
     Kokkos::deep_copy(omega_tilde_mirror, omega_tilde);
-    for(int i = 0; i < 3; ++i) {
-        for(int j = 0; j < 3; ++j) {
+    for (int i = 0; i < 3; ++i) {
+        for (int j = 0; j < 3; ++j) {
             EXPECT_EQ(omega_tilde_mirror(0, i, j), omega_tilde_exact(0, i, j));
         }
     }
 
-    auto omega_dot_tilde_exact_data = std::array<double, 9>{0., -45., 44.,
-                                                             45., 0., -43.,
-                                                             -44., 43., 0.};
-    auto omega_dot_tilde_exact = Kokkos::View<double[1][3][3], Kokkos::HostSpace>(omega_dot_tilde_exact_data.data());
+    auto omega_dot_tilde_exact_data =
+        std::array<double, 9>{0., -45., 44., 45., 0., -43., -44., 43., 0.};
+    auto omega_dot_tilde_exact =
+        Kokkos::View<double[1][3][3], Kokkos::HostSpace>(omega_dot_tilde_exact_data.data());
 
     auto omega_dot_tilde_mirror = Kokkos::create_mirror(omega_dot_tilde);
     Kokkos::deep_copy(omega_dot_tilde_mirror, omega_dot_tilde);
-    for(int i = 0; i < 3; ++i) {
-        for(int j = 0; j < 3; ++j) {
+    for (int i = 0; i < 3; ++i) {
+        for (int j = 0; j < 3; ++j) {
             EXPECT_EQ(omega_dot_tilde_mirror(0, i, j), omega_dot_tilde_exact(0, i, j));
         }
     }
@@ -98,7 +98,7 @@ TEST(CalculateInertialForcesTests, OneNode) {
 
     auto FI_mirror = Kokkos::create_mirror(FI);
     Kokkos::deep_copy(FI_mirror, FI);
-    for(int i = 0; i < 6; ++i) {
+    for (int i = 0; i < 6; ++i) {
         EXPECT_EQ(FI_mirror(0, i), FI_exact(0, i));
     }
 }

--- a/tests/unit_tests/restruct_poc/system/test_calculate_inertial_forces.cpp
+++ b/tests/unit_tests/restruct_poc/system/test_calculate_inertial_forces.cpp
@@ -1,0 +1,106 @@
+#include <Kokkos_Core.hpp>
+#include <gtest/gtest.h>
+
+#include "src/restruct_poc/system/calculate_inertial_forces.hpp"
+#include "src/restruct_poc/types.hpp"
+
+namespace openturbine::restruct_poc::tests {
+
+TEST(CalculateInertialForcesTests, OneNode) {
+    auto Muu = Kokkos::View<double[1][6][6]>("Muu");
+    auto Muu_data = std::array<double, 36>{1., 2., 3., 4., 5., 6., 
+                                           7., 8., 9., 10., 11., 12., 
+                                           13., 14., 15., 16., 17., 18., 
+                                           19., 20., 21., 22., 23., 24., 
+                                           25., 26., 27., 28., 29., 30., 
+                                           31., 32., 33., 34., 35., 36.};
+    auto Muu_host = Kokkos::View<double[1][6][6], Kokkos::HostSpace>(Muu_data.data());
+    auto Muu_mirror = Kokkos::create_mirror(Muu);
+    Kokkos::deep_copy(Muu_mirror, Muu_host);
+    Kokkos::deep_copy(Muu, Muu_mirror);
+
+    auto u_ddot = Kokkos::View<double[1][3]>("u_ddot");
+    auto u_ddot_data = std::array<double, 3>{37., 38., 39.};
+    auto u_ddot_host = Kokkos::View<double[1][3], Kokkos::HostSpace>(u_ddot_data.data());
+    auto u_ddot_mirror = Kokkos::create_mirror(u_ddot);
+    Kokkos::deep_copy(u_ddot_mirror, u_ddot_host);
+    Kokkos::deep_copy(u_ddot, u_ddot_mirror);
+
+    auto omega = Kokkos::View<double[1][3]>("omega");
+    auto omega_data = std::array<double, 3>{40., 41., 42.};
+    auto omega_host = Kokkos::View<double[1][3], Kokkos::HostSpace>(omega_data.data());
+    auto omega_mirror = Kokkos::create_mirror(omega);
+    Kokkos::deep_copy(omega_mirror, omega_host);
+    Kokkos::deep_copy(omega, omega_mirror);
+
+    auto omega_dot = Kokkos::View<double[1][3]>("omega_dot");
+    auto omega_dot_data = std::array<double, 3>{43., 44., 45.};
+    auto omega_dot_host = Kokkos::View<double[1][3], Kokkos::HostSpace>(omega_dot_data.data());
+    auto omega_dot_mirror = Kokkos::create_mirror(omega_dot);
+    Kokkos::deep_copy(omega_dot_mirror, omega_dot_host);
+    Kokkos::deep_copy(omega_dot, omega_dot_mirror);
+
+    auto eta_tilde = Kokkos::View<double[1][3][3]>("eta_tilde");
+    auto eta_tilde_data = std::array<double, 9>{46., 47., 48., 49., 50., 51., 52., 53., 54.};
+    auto eta_tilde_host = Kokkos::View<double[1][3][3], Kokkos::HostSpace>(eta_tilde_data.data());
+    auto eta_tilde_mirror = Kokkos::create_mirror(eta_tilde);
+    Kokkos::deep_copy(eta_tilde_mirror, eta_tilde_host);
+    Kokkos::deep_copy(eta_tilde, eta_tilde_mirror);
+
+    auto rho = Kokkos::View<double[1][3][3]>("rho");
+    auto rho_data = std::array<double, 9>{55., 56., 57., 58., 59., 60., 61., 62., 63.};
+    auto rho_host = Kokkos::View<double[1][3][3], Kokkos::HostSpace>(rho_data.data());
+    auto rho_mirror = Kokkos::create_mirror(rho);
+    Kokkos::deep_copy(rho_mirror, rho_host);
+    Kokkos::deep_copy(rho, rho_mirror);
+
+    auto eta = Kokkos::View<double[1][3]>("eta");
+    auto eta_data = std::array<double, 3>{64., 65., 66.};
+    auto eta_host = Kokkos::View<double[1][3], Kokkos::HostSpace>(eta_data.data());
+    auto eta_mirror = Kokkos::create_mirror(eta);
+    Kokkos::deep_copy(eta_mirror, eta_host);
+    Kokkos::deep_copy(eta, eta_mirror);
+
+    auto omega_tilde = Kokkos::View<double[1][3][3]>("omega_tilde");
+    auto omega_dot_tilde = Kokkos::View<double[1][3][3]>("omega_dot_tilde");
+    auto FI = Kokkos::View<double[1][6]>("FI");
+
+    Kokkos::parallel_for("CalculateForceFI", 1, CalculateInertialForces{Muu, u_ddot, omega, omega_dot, eta_tilde, omega_tilde, omega_dot_tilde, rho, eta, FI});
+
+    auto omega_tilde_exact_data = std::array<double, 9>{0., -42., 41.,
+                                                         42., 0., -40.,
+                                                         -41., 40., 0.};
+    auto omega_tilde_exact = Kokkos::View<double[1][3][3], Kokkos::HostSpace>(omega_tilde_exact_data.data());
+
+    auto omega_tilde_mirror = Kokkos::create_mirror(omega_tilde);
+    Kokkos::deep_copy(omega_tilde_mirror, omega_tilde);
+    for(int i = 0; i < 3; ++i) {
+        for(int j = 0; j < 3; ++j) {
+            EXPECT_EQ(omega_tilde_mirror(0, i, j), omega_tilde_exact(0, i, j));
+        }
+    }
+
+    auto omega_dot_tilde_exact_data = std::array<double, 9>{0., -45., 44.,
+                                                             45., 0., -43.,
+                                                             -44., 43., 0.};
+    auto omega_dot_tilde_exact = Kokkos::View<double[1][3][3], Kokkos::HostSpace>(omega_dot_tilde_exact_data.data());
+
+    auto omega_dot_tilde_mirror = Kokkos::create_mirror(omega_dot_tilde);
+    Kokkos::deep_copy(omega_dot_tilde_mirror, omega_dot_tilde);
+    for(int i = 0; i < 3; ++i) {
+        for(int j = 0; j < 3; ++j) {
+            EXPECT_EQ(omega_dot_tilde_mirror(0, i, j), omega_dot_tilde_exact(0, i, j));
+        }
+    }
+
+    auto FI_exact_data = std::array<double, 6>{-2984., 32., 2922., 20624., -2248., 22100.};
+    auto FI_exact = Kokkos::View<double[1][6], Kokkos::HostSpace>(FI_exact_data.data());
+
+    auto FI_mirror = Kokkos::create_mirror(FI);
+    Kokkos::deep_copy(FI_mirror, FI);
+    for(int i = 0; i < 6; ++i) {
+        EXPECT_EQ(FI_mirror(0, i), FI_exact(0, i));
+    }
+}
+
+}  // namespace openturbine::restruct_poc::tests

--- a/tests/unit_tests/restruct_poc/system/test_calculate_mass_matrix_components.cpp
+++ b/tests/unit_tests/restruct_poc/system/test_calculate_mass_matrix_components.cpp
@@ -8,12 +8,9 @@ namespace openturbine::restruct_poc::tests {
 
 TEST(CalculateMassMatrixComponentsTests, OneQuadPoint) {
     auto Muu = Kokkos::View<double[1][6][6]>("Muu");
-    auto Muu_data = std::array<double, 36>{ 1.,  2.,  3.,  4.,  5.,  6.,
-                                            7.,  8.,  9., 10., 11., 12.,
-                                           13., 14., 15., 16., 17., 18.,
-                                           19., 20., 21., 22., 23., 24.,
-                                           25., 26., 27., 28., 29., 30.,
-                                           31., 32., 33., 34., 35., 36.};
+    auto Muu_data = std::array<double, 36>{
+        1.,  2.,  3.,  4.,  5.,  6.,  7.,  8.,  9.,  10., 11., 12., 13., 14., 15., 16., 17., 18.,
+        19., 20., 21., 22., 23., 24., 25., 26., 27., 28., 29., 30., 31., 32., 33., 34., 35., 36.};
     auto Muu_host = Kokkos::View<double[1][6][6], Kokkos::HostSpace>(Muu_data.data());
     auto Muu_mirror = Kokkos::create_mirror(Muu);
     Kokkos::deep_copy(Muu_mirror, Muu_host);
@@ -23,39 +20,38 @@ TEST(CalculateMassMatrixComponentsTests, OneQuadPoint) {
     auto rho = Kokkos::View<double[1][3][3]>("rho");
     auto eta_tilde = Kokkos::View<double[1][3][3]>("eta_tilde");
 
-    Kokkos::parallel_for("CalculateMassMatrixComponents", 1, CalculateMassMatrixComponents{Muu, eta, rho, eta_tilde});
+    Kokkos::parallel_for(
+        "CalculateMassMatrixComponents", 1, CalculateMassMatrixComponents{Muu, eta, rho, eta_tilde}
+    );
 
     auto eta_exact_data = std::array<double, 3>{32., -31., 25.};
     auto eta_exact = Kokkos::View<double[1][3], Kokkos::HostSpace>(eta_exact_data.data());
 
     auto eta_mirror = Kokkos::create_mirror(eta);
     Kokkos::deep_copy(eta_mirror, eta);
-    for(int i = 0; i < 3; ++i) {
+    for (int i = 0; i < 3; ++i) {
         EXPECT_EQ(eta_mirror(0, i), eta_exact(0, i));
     }
 
-    auto rho_exact_data = std::array<double, 9>{22., 23., 24.,
-                                                28., 29., 30.,
-                                                34., 35., 36.};
+    auto rho_exact_data = std::array<double, 9>{22., 23., 24., 28., 29., 30., 34., 35., 36.};
     auto rho_exact = Kokkos::View<double[1][3][3], Kokkos::HostSpace>(rho_exact_data.data());
 
     auto rho_mirror = Kokkos::create_mirror(rho);
     Kokkos::deep_copy(rho_mirror, rho);
-    for(int i = 0; i < 3; ++i) {
-        for(int j = 0; j < 3; ++j) {
+    for (int i = 0; i < 3; ++i) {
+        for (int j = 0; j < 3; ++j) {
             EXPECT_EQ(rho_mirror(0, i, j), rho_exact(0, i, j));
         }
     }
 
-    auto eta_tilde_exact_data = std::array<double, 9>{ 0., -25., -31.,
-                                                      25.,   0., -32.,
-                                                      31.,  32.,   0.};
-    auto eta_tilde_exact = Kokkos::View<double[1][3][3], Kokkos::HostSpace>(eta_tilde_exact_data.data());
+    auto eta_tilde_exact_data = std::array<double, 9>{0., -25., -31., 25., 0., -32., 31., 32., 0.};
+    auto eta_tilde_exact =
+        Kokkos::View<double[1][3][3], Kokkos::HostSpace>(eta_tilde_exact_data.data());
 
     auto eta_tilde_mirror = Kokkos::create_mirror(eta_tilde);
     Kokkos::deep_copy(eta_tilde_mirror, eta_tilde);
-    for(int i = 0; i < 3; ++i) {
-        for(int j = 0; j < 3; ++j) {
+    for (int i = 0; i < 3; ++i) {
+        for (int j = 0; j < 3; ++j) {
             EXPECT_EQ(eta_tilde_mirror(0, i, j), eta_tilde_exact(0, i, j));
         }
     }

--- a/tests/unit_tests/restruct_poc/system/test_calculate_mass_matrix_components.cpp
+++ b/tests/unit_tests/restruct_poc/system/test_calculate_mass_matrix_components.cpp
@@ -1,0 +1,64 @@
+#include <Kokkos_Core.hpp>
+#include <gtest/gtest.h>
+
+#include "src/restruct_poc/system/calculate_mass_matrix_components.hpp"
+#include "src/restruct_poc/types.hpp"
+
+namespace openturbine::restruct_poc::tests {
+
+TEST(CalculateMassMatrixComponentsTests, OneQuadPoint) {
+    auto Muu = Kokkos::View<double[1][6][6]>("Muu");
+    auto Muu_data = std::array<double, 36>{ 1.,  2.,  3.,  4.,  5.,  6.,
+                                            7.,  8.,  9., 10., 11., 12.,
+                                           13., 14., 15., 16., 17., 18.,
+                                           19., 20., 21., 22., 23., 24.,
+                                           25., 26., 27., 28., 29., 30.,
+                                           31., 32., 33., 34., 35., 36.};
+    auto Muu_host = Kokkos::View<double[1][6][6], Kokkos::HostSpace>(Muu_data.data());
+    auto Muu_mirror = Kokkos::create_mirror(Muu);
+    Kokkos::deep_copy(Muu_mirror, Muu_host);
+    Kokkos::deep_copy(Muu, Muu_mirror);
+
+    auto eta = Kokkos::View<double[1][3]>("eta");
+    auto rho = Kokkos::View<double[1][3][3]>("rho");
+    auto eta_tilde = Kokkos::View<double[1][3][3]>("eta_tilde");
+
+    Kokkos::parallel_for("CalculateMassMatrixComponents", 1, CalculateMassMatrixComponents{Muu, eta, rho, eta_tilde});
+
+    auto eta_exact_data = std::array<double, 3>{32., -31., 25.};
+    auto eta_exact = Kokkos::View<double[1][3], Kokkos::HostSpace>(eta_exact_data.data());
+
+    auto eta_mirror = Kokkos::create_mirror(eta);
+    Kokkos::deep_copy(eta_mirror, eta);
+    for(int i = 0; i < 3; ++i) {
+        EXPECT_EQ(eta_mirror(0, i), eta_exact(0, i));
+    }
+
+    auto rho_exact_data = std::array<double, 9>{22., 23., 24.,
+                                                28., 29., 30.,
+                                                34., 35., 36.};
+    auto rho_exact = Kokkos::View<double[1][3][3], Kokkos::HostSpace>(rho_exact_data.data());
+
+    auto rho_mirror = Kokkos::create_mirror(rho);
+    Kokkos::deep_copy(rho_mirror, rho);
+    for(int i = 0; i < 3; ++i) {
+        for(int j = 0; j < 3; ++j) {
+            EXPECT_EQ(rho_mirror(0, i, j), rho_exact(0, i, j));
+        }
+    }
+
+    auto eta_tilde_exact_data = std::array<double, 9>{ 0., -25., -31.,
+                                                      25.,   0., -32.,
+                                                      31.,  32.,   0.};
+    auto eta_tilde_exact = Kokkos::View<double[1][3][3], Kokkos::HostSpace>(eta_tilde_exact_data.data());
+
+    auto eta_tilde_mirror = Kokkos::create_mirror(eta_tilde);
+    Kokkos::deep_copy(eta_tilde_mirror, eta_tilde);
+    for(int i = 0; i < 3; ++i) {
+        for(int j = 0; j < 3; ++j) {
+            EXPECT_EQ(eta_tilde_mirror(0, i, j), eta_tilde_exact(0, i, j));
+        }
+    }
+}
+
+}  // namespace openturbine::restruct_poc::tests

--- a/tests/unit_tests/restruct_poc/system/test_calculate_node_forces.cpp
+++ b/tests/unit_tests/restruct_poc/system/test_calculate_node_forces.cpp
@@ -28,14 +28,16 @@ TEST(CalculateNodeForcesTests, FE_OneNodeOneQP) {
 
     auto shape_interp = Kokkos::View<double[num_nodes][num_qps]>("shape_interp");
     auto shape_interp_data = std::array<double, 1>{4.};
-    auto shape_interp_host = Kokkos::View<double[num_nodes][num_qps], Kokkos::HostSpace>(shape_interp_data.data());
+    auto shape_interp_host =
+        Kokkos::View<double[num_nodes][num_qps], Kokkos::HostSpace>(shape_interp_data.data());
     auto shape_interp_mirror = Kokkos::create_mirror(shape_interp);
     Kokkos::deep_copy(shape_interp_mirror, shape_interp_host);
     Kokkos::deep_copy(shape_interp, shape_interp_mirror);
 
     auto shape_deriv = Kokkos::View<double[num_nodes][num_qps]>("shape_deriv");
     auto shape_deriv_data = std::array<double, 1>{5.};
-    auto shape_deriv_host = Kokkos::View<double[num_nodes][num_qps], Kokkos::HostSpace>(shape_deriv_data.data());
+    auto shape_deriv_host =
+        Kokkos::View<double[num_nodes][num_qps], Kokkos::HostSpace>(shape_deriv_data.data());
     auto shape_deriv_mirror = Kokkos::create_mirror(shape_deriv);
     Kokkos::deep_copy(shape_deriv_mirror, shape_deriv_host);
     Kokkos::deep_copy(shape_deriv, shape_deriv_mirror);
@@ -56,15 +58,19 @@ TEST(CalculateNodeForcesTests, FE_OneNodeOneQP) {
 
     auto FE = Kokkos::View<double[num_nodes][6]>("FE");
 
-    Kokkos::parallel_for("CalculateNodeForces_FE", num_nodes, CalculateNodeForces_FE{first_node, first_qp, num_qps, weight, jacobian, shape_interp, shape_deriv, Fc, Fd, FE});
+    Kokkos::parallel_for(
+        "CalculateNodeForces_FE", num_nodes,
+        CalculateNodeForces_FE{
+            first_node, first_qp, num_qps, weight, jacobian, shape_interp, shape_deriv, Fc, Fd, FE}
+    );
 
     auto FE_exact_data = std::array<double, 6>{178., 212., 246., 280., 314., 348.};
     auto FE_exact = Kokkos::View<double[num_nodes][6], Kokkos::HostSpace>(FE_exact_data.data());
-    
+
     auto FE_mirror = Kokkos::create_mirror(FE);
     Kokkos::deep_copy(FE_mirror, FE);
-    
-    for(int i = 0; i < 6; ++i) {
+
+    for (int i = 0; i < 6; ++i) {
         EXPECT_EQ(FE_mirror(0, i), FE_exact(0, i));
     }
 }
@@ -91,14 +97,16 @@ TEST(CalculateNodeForcesTests, FE_TwoNodesTwoQPs) {
 
     auto shape_interp = Kokkos::View<double[num_nodes][num_qps]>("shape_interp");
     auto shape_interp_data = std::array<double, 4>{6., 7., 8., 9.};
-    auto shape_interp_host = Kokkos::View<double[num_nodes][num_qps], Kokkos::HostSpace>(shape_interp_data.data());
+    auto shape_interp_host =
+        Kokkos::View<double[num_nodes][num_qps], Kokkos::HostSpace>(shape_interp_data.data());
     auto shape_interp_mirror = Kokkos::create_mirror(shape_interp);
     Kokkos::deep_copy(shape_interp_mirror, shape_interp_host);
     Kokkos::deep_copy(shape_interp, shape_interp_mirror);
 
     auto shape_deriv = Kokkos::View<double[num_nodes][num_qps]>("shape_deriv");
     auto shape_deriv_data = std::array<double, 4>{10., 11., 12., 13.};
-    auto shape_deriv_host = Kokkos::View<double[num_nodes][num_qps], Kokkos::HostSpace>(shape_deriv_data.data());
+    auto shape_deriv_host =
+        Kokkos::View<double[num_nodes][num_qps], Kokkos::HostSpace>(shape_deriv_data.data());
     auto shape_deriv_mirror = Kokkos::create_mirror(shape_deriv);
     Kokkos::deep_copy(shape_deriv_mirror, shape_deriv_host);
     Kokkos::deep_copy(shape_deriv, shape_deriv_mirror);
@@ -111,7 +119,8 @@ TEST(CalculateNodeForcesTests, FE_TwoNodesTwoQPs) {
     Kokkos::deep_copy(Fc, Fc_mirror);
 
     auto Fd = Kokkos::View<double[num_qps][6]>("Fd");
-    auto Fd_data = std::array<double, 12>{13., 14., 15., 16., 17., 18., 19., 20., 21., 22., 23., 24.};
+    auto Fd_data =
+        std::array<double, 12>{13., 14., 15., 16., 17., 18., 19., 20., 21., 22., 23., 24.};
     auto Fd_host = Kokkos::View<double[num_qps][6], Kokkos::HostSpace>(Fd_data.data());
     auto Fd_mirror = Kokkos::create_mirror(Fd);
     Kokkos::deep_copy(Fd_mirror, Fd_host);
@@ -119,19 +128,24 @@ TEST(CalculateNodeForcesTests, FE_TwoNodesTwoQPs) {
 
     auto FE = Kokkos::View<double[num_nodes][6]>("FE");
 
-    Kokkos::parallel_for("CalculateNodeForces_FE", num_nodes, CalculateNodeForces_FE{first_node, first_qp, num_qps, weight, jacobian, shape_interp, shape_deriv, Fc, Fd, FE});
+    Kokkos::parallel_for(
+        "CalculateNodeForces_FE", num_nodes,
+        CalculateNodeForces_FE{
+            first_node, first_qp, num_qps, weight, jacobian, shape_interp, shape_deriv, Fc, Fd, FE}
+    );
 
-    auto FE_exact_data = std::array<double, 12>{2870., 3076., 3282., 3488., 3694., 3900., 3694., 3956., 4218., 4480., 4742., 5004.};
+    auto FE_exact_data = std::array<double, 12>{2870., 3076., 3282., 3488., 3694., 3900.,
+                                                3694., 3956., 4218., 4480., 4742., 5004.};
     auto FE_exact = Kokkos::View<double[num_nodes][6], Kokkos::HostSpace>(FE_exact_data.data());
-    
+
     auto FE_mirror = Kokkos::create_mirror(FE);
     Kokkos::deep_copy(FE_mirror, FE);
-    
-    for(int i = 0; i < 6; ++i) {
+
+    for (int i = 0; i < 6; ++i) {
         EXPECT_EQ(FE_mirror(0, i), FE_exact(0, i));
     }
 
-    for(int i = 0; i < 6; ++i) {
+    for (int i = 0; i < 6; ++i) {
         EXPECT_EQ(FE_mirror(1, i), FE_exact(1, i));
     }
 }
@@ -158,14 +172,16 @@ TEST(CalculateNodeForcesTests, FI_FG_OneNodeOneQP) {
 
     auto shape_interp = Kokkos::View<double[num_nodes][num_qps]>("shape_interp");
     auto shape_interp_data = std::array<double, 1>{4.};
-    auto shape_interp_host = Kokkos::View<double[num_nodes][num_qps], Kokkos::HostSpace>(shape_interp_data.data());
+    auto shape_interp_host =
+        Kokkos::View<double[num_nodes][num_qps], Kokkos::HostSpace>(shape_interp_data.data());
     auto shape_interp_mirror = Kokkos::create_mirror(shape_interp);
     Kokkos::deep_copy(shape_interp_mirror, shape_interp_host);
     Kokkos::deep_copy(shape_interp, shape_interp_mirror);
 
     auto shape_deriv = Kokkos::View<double[num_nodes][num_qps]>("shape_deriv");
     auto shape_deriv_data = std::array<double, 1>{5.};
-    auto shape_deriv_host = Kokkos::View<double[num_nodes][num_qps], Kokkos::HostSpace>(shape_deriv_data.data());
+    auto shape_deriv_host =
+        Kokkos::View<double[num_nodes][num_qps], Kokkos::HostSpace>(shape_deriv_data.data());
     auto shape_deriv_mirror = Kokkos::create_mirror(shape_deriv);
     Kokkos::deep_copy(shape_deriv_mirror, shape_deriv_host);
     Kokkos::deep_copy(shape_deriv, shape_deriv_mirror);
@@ -179,15 +195,19 @@ TEST(CalculateNodeForcesTests, FI_FG_OneNodeOneQP) {
 
     auto FIG = Kokkos::View<double[num_nodes][6]>("FIG");
 
-    Kokkos::parallel_for("CalculateNodeForces_FI_FG", num_nodes, CalculateNodeForces_FI_FG{first_node, first_qp, num_qps, weight, jacobian, shape_interp, shape_deriv, Fig, FIG});
+    Kokkos::parallel_for(
+        "CalculateNodeForces_FI_FG", num_nodes,
+        CalculateNodeForces_FI_FG{
+            first_node, first_qp, num_qps, weight, jacobian, shape_interp, shape_deriv, Fig, FIG}
+    );
 
     auto FIG_exact_data = std::array<double, 6>{24., 48., 72., 96., 120., 144.};
     auto FIG_exact = Kokkos::View<double[num_nodes][6], Kokkos::HostSpace>(FIG_exact_data.data());
-    
+
     auto FIG_mirror = Kokkos::create_mirror(FIG);
     Kokkos::deep_copy(FIG_mirror, FIG);
-    
-    for(int i = 0; i < 6; ++i) {
+
+    for (int i = 0; i < 6; ++i) {
         EXPECT_EQ(FIG_mirror(0, i), FIG_exact(0, i));
     }
 }
@@ -214,14 +234,16 @@ TEST(CalculateNodeForcesTests, FI_FG_TwoNodesTwoQP) {
 
     auto shape_interp = Kokkos::View<double[num_nodes][num_qps]>("shape_interp");
     auto shape_interp_data = std::array<double, 4>{6., 7., 8., 9.};
-    auto shape_interp_host = Kokkos::View<double[num_nodes][num_qps], Kokkos::HostSpace>(shape_interp_data.data());
+    auto shape_interp_host =
+        Kokkos::View<double[num_nodes][num_qps], Kokkos::HostSpace>(shape_interp_data.data());
     auto shape_interp_mirror = Kokkos::create_mirror(shape_interp);
     Kokkos::deep_copy(shape_interp_mirror, shape_interp_host);
     Kokkos::deep_copy(shape_interp, shape_interp_mirror);
 
     auto shape_deriv = Kokkos::View<double[num_nodes][num_qps]>("shape_deriv");
     auto shape_deriv_data = std::array<double, 4>{10., 11., 12., 13.};
-    auto shape_deriv_host = Kokkos::View<double[num_nodes][num_qps], Kokkos::HostSpace>(shape_deriv_data.data());
+    auto shape_deriv_host =
+        Kokkos::View<double[num_nodes][num_qps], Kokkos::HostSpace>(shape_deriv_data.data());
     auto shape_deriv_mirror = Kokkos::create_mirror(shape_deriv);
     Kokkos::deep_copy(shape_deriv_mirror, shape_deriv_host);
     Kokkos::deep_copy(shape_deriv, shape_deriv_mirror);
@@ -235,21 +257,26 @@ TEST(CalculateNodeForcesTests, FI_FG_TwoNodesTwoQP) {
 
     auto FIG = Kokkos::View<double[num_nodes][6]>("FIG");
 
-    Kokkos::parallel_for("CalculateNodeForces_FI_FG", num_nodes, CalculateNodeForces_FI_FG{first_node, first_qp, num_qps, weight, jacobian, shape_interp, shape_deriv, Fig, FIG});
+    Kokkos::parallel_for(
+        "CalculateNodeForces_FI_FG", num_nodes,
+        CalculateNodeForces_FI_FG{
+            first_node, first_qp, num_qps, weight, jacobian, shape_interp, shape_deriv, Fig, FIG}
+    );
 
-    auto FIG_exact_data = std::array<double, 12>{783., 936., 1089., 1242., 1395., 1548., 1009., 1208., 1407., 1606., 1805., 2004.};
+    auto FIG_exact_data = std::array<double, 12>{783.,  936.,  1089., 1242., 1395., 1548.,
+                                                 1009., 1208., 1407., 1606., 1805., 2004.};
     auto FIG_exact = Kokkos::View<double[num_nodes][6], Kokkos::HostSpace>(FIG_exact_data.data());
-    
+
     auto FIG_mirror = Kokkos::create_mirror(FIG);
     Kokkos::deep_copy(FIG_mirror, FIG);
-    
-    for(int i = 0; i < 6; ++i) {
+
+    for (int i = 0; i < 6; ++i) {
         EXPECT_EQ(FIG_mirror(0, i), FIG_exact(0, i));
     }
 
-    for(int i = 0; i < 6; ++i) {
+    for (int i = 0; i < 6; ++i) {
         EXPECT_EQ(FIG_mirror(1, i), FIG_exact(1, i));
     }
 }
 
-}
+}  // namespace openturbine::restruct_poc::tests

--- a/tests/unit_tests/restruct_poc/system/test_calculate_node_forces.cpp
+++ b/tests/unit_tests/restruct_poc/system/test_calculate_node_forces.cpp
@@ -1,0 +1,255 @@
+#include <Kokkos_Core.hpp>
+#include <gtest/gtest.h>
+
+#include "src/restruct_poc/system/calculate_node_forces.hpp"
+#include "src/restruct_poc/types.hpp"
+
+namespace openturbine::restruct_poc::tests {
+
+TEST(CalculateNodeForcesTests, FE_OneNodeOneQP) {
+    constexpr auto first_node = 0;
+    constexpr auto first_qp = 0;
+    constexpr auto num_nodes = 1;
+    constexpr auto num_qps = 1;
+
+    auto weight = Kokkos::View<double[num_qps]>("weight");
+    auto weight_data = std::array<double, 1>{2.};
+    auto weight_host = Kokkos::View<double[num_qps], Kokkos::HostSpace>(weight_data.data());
+    auto weight_mirror = Kokkos::create_mirror(weight);
+    Kokkos::deep_copy(weight_mirror, weight_host);
+    Kokkos::deep_copy(weight, weight_mirror);
+
+    auto jacobian = Kokkos::View<double[num_qps]>("jacobian");
+    auto jacobian_data = std::array<double, 1>{3.};
+    auto jacobian_host = Kokkos::View<double[num_qps], Kokkos::HostSpace>(jacobian_data.data());
+    auto jacobian_mirror = Kokkos::create_mirror(jacobian);
+    Kokkos::deep_copy(jacobian_mirror, jacobian_host);
+    Kokkos::deep_copy(jacobian, jacobian_mirror);
+
+    auto shape_interp = Kokkos::View<double[num_nodes][num_qps]>("shape_interp");
+    auto shape_interp_data = std::array<double, 1>{4.};
+    auto shape_interp_host = Kokkos::View<double[num_nodes][num_qps], Kokkos::HostSpace>(shape_interp_data.data());
+    auto shape_interp_mirror = Kokkos::create_mirror(shape_interp);
+    Kokkos::deep_copy(shape_interp_mirror, shape_interp_host);
+    Kokkos::deep_copy(shape_interp, shape_interp_mirror);
+
+    auto shape_deriv = Kokkos::View<double[num_nodes][num_qps]>("shape_deriv");
+    auto shape_deriv_data = std::array<double, 1>{5.};
+    auto shape_deriv_host = Kokkos::View<double[num_nodes][num_qps], Kokkos::HostSpace>(shape_deriv_data.data());
+    auto shape_deriv_mirror = Kokkos::create_mirror(shape_deriv);
+    Kokkos::deep_copy(shape_deriv_mirror, shape_deriv_host);
+    Kokkos::deep_copy(shape_deriv, shape_deriv_mirror);
+
+    auto Fc = Kokkos::View<double[num_qps][6]>("Fc");
+    auto Fc_data = std::array<double, 6>{1., 2., 3., 4., 5., 6.};
+    auto Fc_host = Kokkos::View<double[num_qps][6], Kokkos::HostSpace>(Fc_data.data());
+    auto Fc_mirror = Kokkos::create_mirror(Fc);
+    Kokkos::deep_copy(Fc_mirror, Fc_host);
+    Kokkos::deep_copy(Fc, Fc_mirror);
+
+    auto Fd = Kokkos::View<double[num_qps][6]>("Fd");
+    auto Fd_data = std::array<double, 6>{7., 8., 9., 10., 11., 12.};
+    auto Fd_host = Kokkos::View<double[num_qps][6], Kokkos::HostSpace>(Fd_data.data());
+    auto Fd_mirror = Kokkos::create_mirror(Fd);
+    Kokkos::deep_copy(Fd_mirror, Fd_host);
+    Kokkos::deep_copy(Fd, Fd_mirror);
+
+    auto FE = Kokkos::View<double[num_nodes][6]>("FE");
+
+    Kokkos::parallel_for("CalculateNodeForces_FE", num_nodes, CalculateNodeForces_FE{first_node, first_qp, num_qps, weight, jacobian, shape_interp, shape_deriv, Fc, Fd, FE});
+
+    auto FE_exact_data = std::array<double, 6>{178., 212., 246., 280., 314., 348.};
+    auto FE_exact = Kokkos::View<double[num_nodes][6], Kokkos::HostSpace>(FE_exact_data.data());
+    
+    auto FE_mirror = Kokkos::create_mirror(FE);
+    Kokkos::deep_copy(FE_mirror, FE);
+    
+    for(int i = 0; i < 6; ++i) {
+        EXPECT_EQ(FE_mirror(0, i), FE_exact(0, i));
+    }
+}
+
+TEST(CalculateNodeForcesTests, FE_TwoNodesTwoQPs) {
+    constexpr auto first_node = 0;
+    constexpr auto first_qp = 0;
+    constexpr auto num_nodes = 2;
+    constexpr auto num_qps = 2;
+
+    auto weight = Kokkos::View<double[num_qps]>("weight");
+    auto weight_data = std::array<double, 2>{2., 3.};
+    auto weight_host = Kokkos::View<double[num_qps], Kokkos::HostSpace>(weight_data.data());
+    auto weight_mirror = Kokkos::create_mirror(weight);
+    Kokkos::deep_copy(weight_mirror, weight_host);
+    Kokkos::deep_copy(weight, weight_mirror);
+
+    auto jacobian = Kokkos::View<double[num_qps]>("jacobian");
+    auto jacobian_data = std::array<double, 2>{4., 5.};
+    auto jacobian_host = Kokkos::View<double[num_qps], Kokkos::HostSpace>(jacobian_data.data());
+    auto jacobian_mirror = Kokkos::create_mirror(jacobian);
+    Kokkos::deep_copy(jacobian_mirror, jacobian_host);
+    Kokkos::deep_copy(jacobian, jacobian_mirror);
+
+    auto shape_interp = Kokkos::View<double[num_nodes][num_qps]>("shape_interp");
+    auto shape_interp_data = std::array<double, 4>{6., 7., 8., 9.};
+    auto shape_interp_host = Kokkos::View<double[num_nodes][num_qps], Kokkos::HostSpace>(shape_interp_data.data());
+    auto shape_interp_mirror = Kokkos::create_mirror(shape_interp);
+    Kokkos::deep_copy(shape_interp_mirror, shape_interp_host);
+    Kokkos::deep_copy(shape_interp, shape_interp_mirror);
+
+    auto shape_deriv = Kokkos::View<double[num_nodes][num_qps]>("shape_deriv");
+    auto shape_deriv_data = std::array<double, 4>{10., 11., 12., 13.};
+    auto shape_deriv_host = Kokkos::View<double[num_nodes][num_qps], Kokkos::HostSpace>(shape_deriv_data.data());
+    auto shape_deriv_mirror = Kokkos::create_mirror(shape_deriv);
+    Kokkos::deep_copy(shape_deriv_mirror, shape_deriv_host);
+    Kokkos::deep_copy(shape_deriv, shape_deriv_mirror);
+
+    auto Fc = Kokkos::View<double[num_qps][6]>("Fc");
+    auto Fc_data = std::array<double, 12>{1., 2., 3., 4., 5., 6., 7., 8., 9., 10., 11., 12.};
+    auto Fc_host = Kokkos::View<double[num_qps][6], Kokkos::HostSpace>(Fc_data.data());
+    auto Fc_mirror = Kokkos::create_mirror(Fc);
+    Kokkos::deep_copy(Fc_mirror, Fc_host);
+    Kokkos::deep_copy(Fc, Fc_mirror);
+
+    auto Fd = Kokkos::View<double[num_qps][6]>("Fd");
+    auto Fd_data = std::array<double, 12>{13., 14., 15., 16., 17., 18., 19., 20., 21., 22., 23., 24.};
+    auto Fd_host = Kokkos::View<double[num_qps][6], Kokkos::HostSpace>(Fd_data.data());
+    auto Fd_mirror = Kokkos::create_mirror(Fd);
+    Kokkos::deep_copy(Fd_mirror, Fd_host);
+    Kokkos::deep_copy(Fd, Fd_mirror);
+
+    auto FE = Kokkos::View<double[num_nodes][6]>("FE");
+
+    Kokkos::parallel_for("CalculateNodeForces_FE", num_nodes, CalculateNodeForces_FE{first_node, first_qp, num_qps, weight, jacobian, shape_interp, shape_deriv, Fc, Fd, FE});
+
+    auto FE_exact_data = std::array<double, 12>{2870., 3076., 3282., 3488., 3694., 3900., 3694., 3956., 4218., 4480., 4742., 5004.};
+    auto FE_exact = Kokkos::View<double[num_nodes][6], Kokkos::HostSpace>(FE_exact_data.data());
+    
+    auto FE_mirror = Kokkos::create_mirror(FE);
+    Kokkos::deep_copy(FE_mirror, FE);
+    
+    for(int i = 0; i < 6; ++i) {
+        EXPECT_EQ(FE_mirror(0, i), FE_exact(0, i));
+    }
+
+    for(int i = 0; i < 6; ++i) {
+        EXPECT_EQ(FE_mirror(1, i), FE_exact(1, i));
+    }
+}
+
+TEST(CalculateNodeForcesTests, FI_FG_OneNodeOneQP) {
+    constexpr auto first_node = 0;
+    constexpr auto first_qp = 0;
+    constexpr auto num_nodes = 1;
+    constexpr auto num_qps = 1;
+
+    auto weight = Kokkos::View<double[num_qps]>("weight");
+    auto weight_data = std::array<double, 1>{2.};
+    auto weight_host = Kokkos::View<double[num_qps], Kokkos::HostSpace>(weight_data.data());
+    auto weight_mirror = Kokkos::create_mirror(weight);
+    Kokkos::deep_copy(weight_mirror, weight_host);
+    Kokkos::deep_copy(weight, weight_mirror);
+
+    auto jacobian = Kokkos::View<double[num_qps]>("jacobian");
+    auto jacobian_data = std::array<double, 1>{3.};
+    auto jacobian_host = Kokkos::View<double[num_qps], Kokkos::HostSpace>(jacobian_data.data());
+    auto jacobian_mirror = Kokkos::create_mirror(jacobian);
+    Kokkos::deep_copy(jacobian_mirror, jacobian_host);
+    Kokkos::deep_copy(jacobian, jacobian_mirror);
+
+    auto shape_interp = Kokkos::View<double[num_nodes][num_qps]>("shape_interp");
+    auto shape_interp_data = std::array<double, 1>{4.};
+    auto shape_interp_host = Kokkos::View<double[num_nodes][num_qps], Kokkos::HostSpace>(shape_interp_data.data());
+    auto shape_interp_mirror = Kokkos::create_mirror(shape_interp);
+    Kokkos::deep_copy(shape_interp_mirror, shape_interp_host);
+    Kokkos::deep_copy(shape_interp, shape_interp_mirror);
+
+    auto shape_deriv = Kokkos::View<double[num_nodes][num_qps]>("shape_deriv");
+    auto shape_deriv_data = std::array<double, 1>{5.};
+    auto shape_deriv_host = Kokkos::View<double[num_nodes][num_qps], Kokkos::HostSpace>(shape_deriv_data.data());
+    auto shape_deriv_mirror = Kokkos::create_mirror(shape_deriv);
+    Kokkos::deep_copy(shape_deriv_mirror, shape_deriv_host);
+    Kokkos::deep_copy(shape_deriv, shape_deriv_mirror);
+
+    auto Fig = Kokkos::View<double[num_qps][6]>("Fig");
+    auto Fig_data = std::array<double, 6>{1., 2., 3., 4., 5., 6.};
+    auto Fig_host = Kokkos::View<double[num_qps][6], Kokkos::HostSpace>(Fig_data.data());
+    auto Fig_mirror = Kokkos::create_mirror(Fig);
+    Kokkos::deep_copy(Fig_mirror, Fig_host);
+    Kokkos::deep_copy(Fig, Fig_mirror);
+
+    auto FIG = Kokkos::View<double[num_nodes][6]>("FIG");
+
+    Kokkos::parallel_for("CalculateNodeForces_FI_FG", num_nodes, CalculateNodeForces_FI_FG{first_node, first_qp, num_qps, weight, jacobian, shape_interp, shape_deriv, Fig, FIG});
+
+    auto FIG_exact_data = std::array<double, 6>{24., 48., 72., 96., 120., 144.};
+    auto FIG_exact = Kokkos::View<double[num_nodes][6], Kokkos::HostSpace>(FIG_exact_data.data());
+    
+    auto FIG_mirror = Kokkos::create_mirror(FIG);
+    Kokkos::deep_copy(FIG_mirror, FIG);
+    
+    for(int i = 0; i < 6; ++i) {
+        EXPECT_EQ(FIG_mirror(0, i), FIG_exact(0, i));
+    }
+}
+
+TEST(CalculateNodeForcesTests, FI_FG_TwoNodesTwoQP) {
+    constexpr auto first_node = 0;
+    constexpr auto first_qp = 0;
+    constexpr auto num_nodes = 2;
+    constexpr auto num_qps = 2;
+
+    auto weight = Kokkos::View<double[num_qps]>("weight");
+    auto weight_data = std::array<double, 2>{2., 3.};
+    auto weight_host = Kokkos::View<double[num_qps], Kokkos::HostSpace>(weight_data.data());
+    auto weight_mirror = Kokkos::create_mirror(weight);
+    Kokkos::deep_copy(weight_mirror, weight_host);
+    Kokkos::deep_copy(weight, weight_mirror);
+
+    auto jacobian = Kokkos::View<double[num_qps]>("jacobian");
+    auto jacobian_data = std::array<double, 2>{4., 5.};
+    auto jacobian_host = Kokkos::View<double[num_qps], Kokkos::HostSpace>(jacobian_data.data());
+    auto jacobian_mirror = Kokkos::create_mirror(jacobian);
+    Kokkos::deep_copy(jacobian_mirror, jacobian_host);
+    Kokkos::deep_copy(jacobian, jacobian_mirror);
+
+    auto shape_interp = Kokkos::View<double[num_nodes][num_qps]>("shape_interp");
+    auto shape_interp_data = std::array<double, 4>{6., 7., 8., 9.};
+    auto shape_interp_host = Kokkos::View<double[num_nodes][num_qps], Kokkos::HostSpace>(shape_interp_data.data());
+    auto shape_interp_mirror = Kokkos::create_mirror(shape_interp);
+    Kokkos::deep_copy(shape_interp_mirror, shape_interp_host);
+    Kokkos::deep_copy(shape_interp, shape_interp_mirror);
+
+    auto shape_deriv = Kokkos::View<double[num_nodes][num_qps]>("shape_deriv");
+    auto shape_deriv_data = std::array<double, 4>{10., 11., 12., 13.};
+    auto shape_deriv_host = Kokkos::View<double[num_nodes][num_qps], Kokkos::HostSpace>(shape_deriv_data.data());
+    auto shape_deriv_mirror = Kokkos::create_mirror(shape_deriv);
+    Kokkos::deep_copy(shape_deriv_mirror, shape_deriv_host);
+    Kokkos::deep_copy(shape_deriv, shape_deriv_mirror);
+
+    auto Fig = Kokkos::View<double[num_qps][6]>("Fig");
+    auto Fig_data = std::array<double, 12>{1., 2., 3., 4., 5., 6., 7., 8., 9., 10., 11., 12.};
+    auto Fig_host = Kokkos::View<double[num_qps][6], Kokkos::HostSpace>(Fig_data.data());
+    auto Fig_mirror = Kokkos::create_mirror(Fig);
+    Kokkos::deep_copy(Fig_mirror, Fig_host);
+    Kokkos::deep_copy(Fig, Fig_mirror);
+
+    auto FIG = Kokkos::View<double[num_nodes][6]>("FIG");
+
+    Kokkos::parallel_for("CalculateNodeForces_FI_FG", num_nodes, CalculateNodeForces_FI_FG{first_node, first_qp, num_qps, weight, jacobian, shape_interp, shape_deriv, Fig, FIG});
+
+    auto FIG_exact_data = std::array<double, 12>{783., 936., 1089., 1242., 1395., 1548., 1009., 1208., 1407., 1606., 1805., 2004.};
+    auto FIG_exact = Kokkos::View<double[num_nodes][6], Kokkos::HostSpace>(FIG_exact_data.data());
+    
+    auto FIG_mirror = Kokkos::create_mirror(FIG);
+    Kokkos::deep_copy(FIG_mirror, FIG);
+    
+    for(int i = 0; i < 6; ++i) {
+        EXPECT_EQ(FIG_mirror(0, i), FIG_exact(0, i));
+    }
+
+    for(int i = 0; i < 6; ++i) {
+        EXPECT_EQ(FIG_mirror(1, i), FIG_exact(1, i));
+    }
+}
+
+}

--- a/tests/unit_tests/restruct_poc/system/test_calculate_strain.cpp
+++ b/tests/unit_tests/restruct_poc/system/test_calculate_strain.cpp
@@ -37,14 +37,16 @@ TEST(CalculateStrainTests, OneNode) {
 
     auto strain = Kokkos::View<double[1][6]>("strain");
 
-    Kokkos::parallel_for("CalculateStrain", 1, CalculateStrain{x0_prime, u_prime, r, r_prime, strain});
+    Kokkos::parallel_for(
+        "CalculateStrain", 1, CalculateStrain{x0_prime, u_prime, r, r_prime, strain}
+    );
 
     auto strain_exact_data = std::array<double, 6>{-793., -413., -621., -16., 0., -32.};
     auto strain_exact = Kokkos::View<double[1][6], Kokkos::HostSpace>(strain_exact_data.data());
-    
+
     auto strain_mirror = Kokkos::create_mirror(strain);
     Kokkos::deep_copy(strain_mirror, strain);
-    for(int i = 0; i < 6; ++i) {
+    for (int i = 0; i < 6; ++i) {
         EXPECT_EQ(strain_mirror(0, i), strain_exact(0, i));
     }
 }

--- a/tests/unit_tests/restruct_poc/system/test_calculate_strain.cpp
+++ b/tests/unit_tests/restruct_poc/system/test_calculate_strain.cpp
@@ -1,0 +1,52 @@
+#include <Kokkos_Core.hpp>
+#include <gtest/gtest.h>
+
+#include "src/restruct_poc/system/calculate_strain.hpp"
+#include "src/restruct_poc/types.hpp"
+
+namespace openturbine::restruct_poc::tests {
+
+TEST(CalculateStrainTests, OneNode) {
+    auto x0_prime = Kokkos::View<double[1][3]>("x0_prime");
+    auto x0_prime_data = std::array<double, 3>{1., 2., 3.};
+    auto x0_prime_host = Kokkos::View<double[1][3], Kokkos::HostSpace>(x0_prime_data.data());
+    auto x0_prime_mirror = Kokkos::create_mirror(x0_prime);
+    Kokkos::deep_copy(x0_prime_mirror, x0_prime_host);
+    Kokkos::deep_copy(x0_prime, x0_prime_mirror);
+
+    auto u_prime = Kokkos::View<double[1][3]>("u_prime");
+    auto u_prime_data = std::array<double, 3>{4., 5., 6.};
+    auto u_prime_host = Kokkos::View<double[1][3], Kokkos::HostSpace>(u_prime_data.data());
+    auto u_prime_mirror = Kokkos::create_mirror(u_prime);
+    Kokkos::deep_copy(u_prime_mirror, u_prime_host);
+    Kokkos::deep_copy(u_prime, u_prime_mirror);
+
+    auto r = Kokkos::View<double[1][4]>("r");
+    auto r_data = std::array<double, 4>{7., 8., 9., 10.};
+    auto r_host = Kokkos::View<double[1][4], Kokkos::HostSpace>(r_data.data());
+    auto r_mirror = Kokkos::create_mirror(r);
+    Kokkos::deep_copy(r_mirror, r_host);
+    Kokkos::deep_copy(r, r_mirror);
+
+    auto r_prime = Kokkos::View<double[1][4]>("r_prime");
+    auto r_prime_data = std::array<double, 4>{11., 12., 13., 14.};
+    auto r_prime_host = Kokkos::View<double[1][4], Kokkos::HostSpace>(r_prime_data.data());
+    auto r_prime_mirror = Kokkos::create_mirror(r_prime);
+    Kokkos::deep_copy(r_prime_mirror, r_prime_host);
+    Kokkos::deep_copy(r_prime, r_prime_mirror);
+
+    auto strain = Kokkos::View<double[1][6]>("strain");
+
+    Kokkos::parallel_for("CalculateStrain", 1, CalculateStrain{x0_prime, u_prime, r, r_prime, strain});
+
+    auto strain_exact_data = std::array<double, 6>{-793., -413., -621., -16., 0., -32.};
+    auto strain_exact = Kokkos::View<double[1][6], Kokkos::HostSpace>(strain_exact_data.data());
+    
+    auto strain_mirror = Kokkos::create_mirror(strain);
+    Kokkos::deep_copy(strain_mirror, strain);
+    for(int i = 0; i < 6; ++i) {
+        EXPECT_EQ(strain_mirror(0, i), strain_exact(0, i));
+    }
+}
+
+}  // namespace openturbine::restruct_poc::tests

--- a/tests/unit_tests/restruct_poc/system/test_calculate_temporary_variables.cpp
+++ b/tests/unit_tests/restruct_poc/system/test_calculate_temporary_variables.cpp
@@ -23,17 +23,17 @@ TEST(CalculateTemporaryVariablesTests, OneNode) {
 
     auto x0pupSS = Kokkos::View<double[1][3][3]>("x0pupSS");
 
-    Kokkos::parallel_for("CalculateTemporaryVariables", 1, CalculateTemporaryVariables{x0_prime, u_prime, x0pupSS});
+    Kokkos::parallel_for(
+        "CalculateTemporaryVariables", 1, CalculateTemporaryVariables{x0_prime, u_prime, x0pupSS}
+    );
 
-    auto x0pupSS_exact_data = std::array<double, 9>{0., -9., 7., 
-                                                    9., 0., -5., 
-                                                   -7., 5., 0.};
+    auto x0pupSS_exact_data = std::array<double, 9>{0., -9., 7., 9., 0., -5., -7., 5., 0.};
     auto x0pupSS_exact = Kokkos::View<double[1][3][3], Kokkos::HostSpace>(x0pupSS_exact_data.data());
-    
+
     auto x0pupSS_mirror = Kokkos::create_mirror(x0pupSS);
     Kokkos::deep_copy(x0pupSS_mirror, x0pupSS);
-    for(int i = 0; i < 3; ++i) {
-        for(int j = 0; j < 3; ++j) {
+    for (int i = 0; i < 3; ++i) {
+        for (int j = 0; j < 3; ++j) {
             EXPECT_EQ(x0pupSS_mirror(0, i, j), x0pupSS_exact(0, i, j));
         }
     }

--- a/tests/unit_tests/restruct_poc/system/test_calculate_temporary_variables.cpp
+++ b/tests/unit_tests/restruct_poc/system/test_calculate_temporary_variables.cpp
@@ -1,0 +1,42 @@
+#include <Kokkos_Core.hpp>
+#include <gtest/gtest.h>
+
+#include "src/restruct_poc/system/calculate_temporary_variables.hpp"
+#include "src/restruct_poc/types.hpp"
+
+namespace openturbine::restruct_poc::tests {
+
+TEST(CalculateTemporaryVariablesTests, OneNode) {
+    auto x0_prime = Kokkos::View<double[1][3]>("x0_prime");
+    auto x0_prime_data = std::array<double, 3>{1., 2., 3.};
+    auto x0_prime_host = Kokkos::View<double[1][3], Kokkos::HostSpace>(x0_prime_data.data());
+    auto x0_prime_mirror = Kokkos::create_mirror(x0_prime);
+    Kokkos::deep_copy(x0_prime_mirror, x0_prime_host);
+    Kokkos::deep_copy(x0_prime, x0_prime_mirror);
+
+    auto u_prime = Kokkos::View<double[1][3]>("u_prime");
+    auto u_prime_data = std::array<double, 3>{4., 5., 6.};
+    auto u_prime_host = Kokkos::View<double[1][3], Kokkos::HostSpace>(u_prime_data.data());
+    auto u_prime_mirror = Kokkos::create_mirror(u_prime);
+    Kokkos::deep_copy(u_prime_mirror, u_prime_host);
+    Kokkos::deep_copy(u_prime, u_prime_mirror);
+
+    auto x0pupSS = Kokkos::View<double[1][3][3]>("x0pupSS");
+
+    Kokkos::parallel_for("CalculateTemporaryVariables", 1, CalculateTemporaryVariables{x0_prime, u_prime, x0pupSS});
+
+    auto x0pupSS_exact_data = std::array<double, 9>{0., -9., 7., 
+                                                    9., 0., -5., 
+                                                   -7., 5., 0.};
+    auto x0pupSS_exact = Kokkos::View<double[1][3][3], Kokkos::HostSpace>(x0pupSS_exact_data.data());
+    
+    auto x0pupSS_mirror = Kokkos::create_mirror(x0pupSS);
+    Kokkos::deep_copy(x0pupSS_mirror, x0pupSS);
+    for(int i = 0; i < 3; ++i) {
+        for(int j = 0; j < 3; ++j) {
+            EXPECT_EQ(x0pupSS_mirror(0, i, j), x0pupSS_exact(0, i, j));
+        }
+    }
+}
+
+}  // namespace openturbine::restruct_poc::tests

--- a/tests/unit_tests/restruct_poc/system/test_rotate_section_matrix.cpp
+++ b/tests/unit_tests/restruct_poc/system/test_rotate_section_matrix.cpp
@@ -1,0 +1,55 @@
+#include <Kokkos_Core.hpp>
+#include <gtest/gtest.h>
+
+#include "src/restruct_poc/system/rotate_section_matrix.hpp"
+#include "src/restruct_poc/types.hpp"
+
+namespace openturbine::restruct_poc::tests {
+
+TEST(RotateSectionMatrixTests, OneNode) {
+    auto rr0 = Kokkos::View<double[1][6][6]>("rr0");
+    auto rr0_data = std::array<double, 36>{1., 2., 3., 0., 0., 0.,
+                                           4., 5., 6., 0., 0., 0.,
+                                           7., 8., 9., 0., 0., 0.,
+                                           0., 0., 0., 1., 2., 3.,
+                                           0., 0., 0., 4., 5., 6.,
+                                           0., 0., 0., 7., 8., 9.};
+    auto rr0_host = Kokkos::View<double[1][6][6], Kokkos::HostSpace>(rr0_data.data());
+    auto rr0_mirror = Kokkos::create_mirror(rr0);
+    Kokkos::deep_copy(rr0_mirror, rr0_host);
+    Kokkos::deep_copy(rr0, rr0_mirror);
+
+    auto Cstar = Kokkos::View<double[1][6][6]>("Cstar");
+    auto Cstar_data = std::array<double, 36>{ 1.,  2.,  3.,  4.,  5.,  6.,
+                                              7.,  8.,  9., 10., 11., 12.,
+                                             13., 14., 15., 16., 17., 18.,
+                                             19., 20., 21., 22., 23., 24.,
+                                             25., 26., 27., 28., 29., 30.,
+                                             31., 32., 33., 34., 35., 36.};
+    auto Cstar_host = Kokkos::View<double[1][6][6], Kokkos::HostSpace>(Cstar_data.data());
+    auto Cstar_mirror = Kokkos::create_mirror(Cstar);
+    Kokkos::deep_copy(Cstar_mirror, Cstar_host);
+    Kokkos::deep_copy(Cstar, Cstar_mirror);
+
+    auto Cuu = Kokkos::View<double[1][6][6]>("Cuu");
+
+    Kokkos::parallel_for("RotateSectionMatrix", 1, RotateSectionMatrix{rr0, Cstar, Cuu});
+
+    auto Cuu_exact_data = std::array<double, 36>{ 372.,  912.,  1452.,  480.,  1182.,  1884.,
+                                                  822., 2010.,  3198., 1092.,  2685.,  4278.,
+                                                 1272., 3108.,  4944., 1704.,  4188.,  6672.,
+                                                 1020., 2532.,  4044., 1128.,  2802.,  4476.,
+                                                 2442., 6060.,  9678., 2712.,  6735., 10758.,
+                                                 3864., 9588., 15312., 4296., 10668., 17040.};
+    auto Cuu_exact = Kokkos::View<double[1][6][6], Kokkos::HostSpace>(Cuu_exact_data.data());
+
+    auto Cuu_mirror = Kokkos::create_mirror(Cuu);
+    Kokkos::deep_copy(Cuu_mirror, Cuu);
+    for(int i = 0; i < 6; ++i) {
+        for(int j = 0; j < 6; ++j) {
+            EXPECT_EQ(Cuu_mirror(0, i, j), Cuu_exact(0, i, j));
+        }
+    }
+}
+
+}  // namespace openturbine::restruct_poc::tests

--- a/tests/unit_tests/restruct_poc/system/test_rotate_section_matrix.cpp
+++ b/tests/unit_tests/restruct_poc/system/test_rotate_section_matrix.cpp
@@ -8,24 +8,18 @@ namespace openturbine::restruct_poc::tests {
 
 TEST(RotateSectionMatrixTests, OneNode) {
     auto rr0 = Kokkos::View<double[1][6][6]>("rr0");
-    auto rr0_data = std::array<double, 36>{1., 2., 3., 0., 0., 0.,
-                                           4., 5., 6., 0., 0., 0.,
-                                           7., 8., 9., 0., 0., 0.,
-                                           0., 0., 0., 1., 2., 3.,
-                                           0., 0., 0., 4., 5., 6.,
-                                           0., 0., 0., 7., 8., 9.};
+    auto rr0_data = std::array<double, 36>{1., 2., 3., 0., 0., 0., 4., 5., 6., 0., 0., 0.,
+                                           7., 8., 9., 0., 0., 0., 0., 0., 0., 1., 2., 3.,
+                                           0., 0., 0., 4., 5., 6., 0., 0., 0., 7., 8., 9.};
     auto rr0_host = Kokkos::View<double[1][6][6], Kokkos::HostSpace>(rr0_data.data());
     auto rr0_mirror = Kokkos::create_mirror(rr0);
     Kokkos::deep_copy(rr0_mirror, rr0_host);
     Kokkos::deep_copy(rr0, rr0_mirror);
 
     auto Cstar = Kokkos::View<double[1][6][6]>("Cstar");
-    auto Cstar_data = std::array<double, 36>{ 1.,  2.,  3.,  4.,  5.,  6.,
-                                              7.,  8.,  9., 10., 11., 12.,
-                                             13., 14., 15., 16., 17., 18.,
-                                             19., 20., 21., 22., 23., 24.,
-                                             25., 26., 27., 28., 29., 30.,
-                                             31., 32., 33., 34., 35., 36.};
+    auto Cstar_data = std::array<double, 36>{
+        1.,  2.,  3.,  4.,  5.,  6.,  7.,  8.,  9.,  10., 11., 12., 13., 14., 15., 16., 17., 18.,
+        19., 20., 21., 22., 23., 24., 25., 26., 27., 28., 29., 30., 31., 32., 33., 34., 35., 36.};
     auto Cstar_host = Kokkos::View<double[1][6][6], Kokkos::HostSpace>(Cstar_data.data());
     auto Cstar_mirror = Kokkos::create_mirror(Cstar);
     Kokkos::deep_copy(Cstar_mirror, Cstar_host);
@@ -35,18 +29,16 @@ TEST(RotateSectionMatrixTests, OneNode) {
 
     Kokkos::parallel_for("RotateSectionMatrix", 1, RotateSectionMatrix{rr0, Cstar, Cuu});
 
-    auto Cuu_exact_data = std::array<double, 36>{ 372.,  912.,  1452.,  480.,  1182.,  1884.,
-                                                  822., 2010.,  3198., 1092.,  2685.,  4278.,
-                                                 1272., 3108.,  4944., 1704.,  4188.,  6672.,
-                                                 1020., 2532.,  4044., 1128.,  2802.,  4476.,
-                                                 2442., 6060.,  9678., 2712.,  6735., 10758.,
-                                                 3864., 9588., 15312., 4296., 10668., 17040.};
+    auto Cuu_exact_data = std::array<double, 36>{
+        372.,  912.,  1452., 480.,  1182., 1884.,  822.,  2010., 3198.,  1092., 2685.,  4278.,
+        1272., 3108., 4944., 1704., 4188., 6672.,  1020., 2532., 4044.,  1128., 2802.,  4476.,
+        2442., 6060., 9678., 2712., 6735., 10758., 3864., 9588., 15312., 4296., 10668., 17040.};
     auto Cuu_exact = Kokkos::View<double[1][6][6], Kokkos::HostSpace>(Cuu_exact_data.data());
 
     auto Cuu_mirror = Kokkos::create_mirror(Cuu);
     Kokkos::deep_copy(Cuu_mirror, Cuu);
-    for(int i = 0; i < 6; ++i) {
-        for(int j = 0; j < 6; ++j) {
+    for (int i = 0; i < 6; ++i) {
+        for (int j = 0; j < 6; ++j) {
             EXPECT_EQ(Cuu_mirror(0, i, j), Cuu_exact(0, i, j));
         }
     }

--- a/tests/unit_tests/restruct_poc/system/test_update_node_state.cpp
+++ b/tests/unit_tests/restruct_poc/system/test_update_node_state.cpp
@@ -1,0 +1,132 @@
+#include <Kokkos_Core.hpp>
+#include <gtest/gtest.h>
+
+#include "src/restruct_poc/system/update_node_state.hpp"
+#include "src/restruct_poc/types.hpp"
+#include "tests/unit_tests/restruct_poc/test_utilities.hpp"
+
+namespace openturbine::restruct_poc::tests {
+
+TEST(UpdateNodeStateStests, TwoNodes_InOrder) {
+    auto indices = Kokkos::View<int[2]>("node_state_indices");
+    auto indices_data = std::array<int, 2>{0, 1};
+    auto indices_host = Kokkos::View<int[2], Kokkos::HostSpace>(indices_data.data());
+    auto indices_mirror = Kokkos::create_mirror(indices);
+    Kokkos::deep_copy(indices_mirror, indices_host);
+    Kokkos::deep_copy(indices, indices_host);
+    
+    auto Q = Kokkos::View<double[2][7]>("Q");
+    auto Q_data = std::array<double, 14>{1., 2., 3., 4., 5., 6., 7., 8., 9., 10., 11., 12., 13., 14.};
+    auto Q_host = Kokkos::View<double[2][7], Kokkos::HostSpace>(Q_data.data());
+    auto Q_mirror = Kokkos::create_mirror(Q);
+    Kokkos::deep_copy(Q_mirror, Q_host);
+    Kokkos::deep_copy(Q, Q_mirror);
+    auto V = Kokkos::View<double[2][6]>("V");
+    auto V_data = std::array<double, 12>{15., 16., 17., 18., 19., 20., 21., 22., 23., 24., 25., 26.};
+    auto V_host = Kokkos::View<double[2][6], Kokkos::HostSpace>(V_data.data());
+    auto V_mirror = Kokkos::create_mirror(V);
+    Kokkos::deep_copy(V_mirror, V_host);
+    Kokkos::deep_copy(V, V_mirror);
+    auto A = Kokkos::View<double[2][6]>("A");
+    auto A_data = std::array<double, 12>{27., 28., 29., 30., 31., 32., 33., 34., 35., 36., 37., 38.};
+    auto A_host = Kokkos::View<double[2][6], Kokkos::HostSpace>(A_data.data());
+    auto A_mirror = Kokkos::create_mirror(A);
+    Kokkos::deep_copy(A_mirror, A_host);
+    Kokkos::deep_copy(A, A_mirror);
+
+    auto node_u = Kokkos::View<double[2][7]>("node_u");
+    auto node_u_dot = Kokkos::View<double[2][6]>("node_u_dot");
+    auto node_u_ddot = Kokkos::View<double[2][6]>("node_u_ddot");
+
+    Kokkos::parallel_for("UpdateNodeState", 2, UpdateNodeState{indices, node_u, node_u_dot, node_u_ddot, Q, V, A});
+
+    auto node_u_mirror = Kokkos::create_mirror(node_u);
+    Kokkos::deep_copy(node_u_mirror, node_u);
+    for(int j = 0; j < 7; ++j) {
+        EXPECT_EQ(node_u_mirror(0, j), Q_host(0, j));
+    }
+    for(int j = 0; j < 7; ++j) {
+        EXPECT_EQ(node_u_mirror(1, j), Q_host(1, j));
+    }
+
+    auto node_u_dot_mirror = Kokkos::create_mirror(node_u_dot);
+    Kokkos::deep_copy(node_u_dot_mirror, node_u_dot);
+    for(int j = 0; j < 6; ++j) {
+        EXPECT_EQ(node_u_dot_mirror(0, j), V_host(0, j));
+    }
+    for(int j = 0; j < 6; ++j) {
+        EXPECT_EQ(node_u_dot_mirror(1, j), V_host(1, j));
+    }
+
+    auto node_u_ddot_mirror = Kokkos::create_mirror(node_u_ddot);
+    Kokkos::deep_copy(node_u_ddot_mirror, node_u_ddot);
+    for(int j = 0; j < 6; ++j) {
+        EXPECT_EQ(node_u_ddot_mirror(0, j), A_host(0, j));
+    }
+    for(int j = 0; j < 6; ++j) {
+        EXPECT_EQ(node_u_ddot_mirror(1, j), A_host(1, j));
+    }
+}
+
+TEST(UpdateNodeStateStests, TwoNodes_OutOfOrder) {
+    auto indices = Kokkos::View<int[2]>("node_state_indices");
+    auto indices_data = std::array<int, 2>{1, 0};
+    auto indices_host = Kokkos::View<int[2], Kokkos::HostSpace>(indices_data.data());
+    auto indices_mirror = Kokkos::create_mirror(indices);
+    Kokkos::deep_copy(indices_mirror, indices_host);
+    Kokkos::deep_copy(indices, indices_host);
+    
+    auto Q = Kokkos::View<double[2][7]>("Q");
+    auto Q_data = std::array<double, 14>{1., 2., 3., 4., 5., 6., 7., 8., 9., 10., 11., 12., 13., 14.};
+    auto Q_host = Kokkos::View<double[2][7], Kokkos::HostSpace>(Q_data.data());
+    auto Q_mirror = Kokkos::create_mirror(Q);
+    Kokkos::deep_copy(Q_mirror, Q_host);
+    Kokkos::deep_copy(Q, Q_mirror);
+    auto V = Kokkos::View<double[2][6]>("V");
+    auto V_data = std::array<double, 12>{15., 16., 17., 18., 19., 20., 21., 22., 23., 24., 25., 26.};
+    auto V_host = Kokkos::View<double[2][6], Kokkos::HostSpace>(V_data.data());
+    auto V_mirror = Kokkos::create_mirror(V);
+    Kokkos::deep_copy(V_mirror, V_host);
+    Kokkos::deep_copy(V, V_mirror);
+    auto A = Kokkos::View<double[2][6]>("A");
+    auto A_data = std::array<double, 12>{27., 28., 29., 30., 31., 32., 33., 34., 35., 36., 37., 38.};
+    auto A_host = Kokkos::View<double[2][6], Kokkos::HostSpace>(A_data.data());
+    auto A_mirror = Kokkos::create_mirror(A);
+    Kokkos::deep_copy(A_mirror, A_host);
+    Kokkos::deep_copy(A, A_mirror);
+
+    auto node_u = Kokkos::View<double[2][7]>("node_u");
+    auto node_u_dot = Kokkos::View<double[2][6]>("node_u_dot");
+    auto node_u_ddot = Kokkos::View<double[2][6]>("node_u_ddot");
+
+    Kokkos::parallel_for("UpdateNodeState", 2, UpdateNodeState{indices, node_u, node_u_dot, node_u_ddot, Q, V, A});
+
+    auto node_u_mirror = Kokkos::create_mirror(node_u);
+    Kokkos::deep_copy(node_u_mirror, node_u);
+    for(int j = 0; j < 7; ++j) {
+        EXPECT_EQ(node_u_mirror(0, j), Q_host(1, j));
+    }
+    for(int j = 0; j < 7; ++j) {
+        EXPECT_EQ(node_u_mirror(1, j), Q_host(0, j));
+    }
+
+    auto node_u_dot_mirror = Kokkos::create_mirror(node_u_dot);
+    Kokkos::deep_copy(node_u_dot_mirror, node_u_dot);
+    for(int j = 0; j < 6; ++j) {
+        EXPECT_EQ(node_u_dot_mirror(0, j), V_host(1, j));
+    }
+    for(int j = 0; j < 6; ++j) {
+        EXPECT_EQ(node_u_dot_mirror(1, j), V_host(0, j));
+    }
+
+    auto node_u_ddot_mirror = Kokkos::create_mirror(node_u_ddot);
+    Kokkos::deep_copy(node_u_ddot_mirror, node_u_ddot);
+    for(int j = 0; j < 6; ++j) {
+        EXPECT_EQ(node_u_ddot_mirror(0, j), A_host(1, j));
+    }
+    for(int j = 0; j < 6; ++j) {
+        EXPECT_EQ(node_u_ddot_mirror(1, j), A_host(0, j));
+    }
+}
+
+}  // namespace openturbine::restruct_poc::tests

--- a/tests/unit_tests/restruct_poc/system/test_update_node_state.cpp
+++ b/tests/unit_tests/restruct_poc/system/test_update_node_state.cpp
@@ -3,11 +3,10 @@
 
 #include "src/restruct_poc/system/update_node_state.hpp"
 #include "src/restruct_poc/types.hpp"
-#include "tests/unit_tests/restruct_poc/test_utilities.hpp"
 
 namespace openturbine::restruct_poc::tests {
 
-TEST(UpdateNodeStateStests, TwoNodes_InOrder) {
+TEST(UpdateNodeStateTests, TwoNodes_InOrder) {
     auto indices = Kokkos::View<int[2]>("node_state_indices");
     auto indices_data = std::array<int, 2>{0, 1};
     auto indices_host = Kokkos::View<int[2], Kokkos::HostSpace>(indices_data.data());
@@ -21,12 +20,14 @@ TEST(UpdateNodeStateStests, TwoNodes_InOrder) {
     auto Q_mirror = Kokkos::create_mirror(Q);
     Kokkos::deep_copy(Q_mirror, Q_host);
     Kokkos::deep_copy(Q, Q_mirror);
+
     auto V = Kokkos::View<double[2][6]>("V");
     auto V_data = std::array<double, 12>{15., 16., 17., 18., 19., 20., 21., 22., 23., 24., 25., 26.};
     auto V_host = Kokkos::View<double[2][6], Kokkos::HostSpace>(V_data.data());
     auto V_mirror = Kokkos::create_mirror(V);
     Kokkos::deep_copy(V_mirror, V_host);
     Kokkos::deep_copy(V, V_mirror);
+
     auto A = Kokkos::View<double[2][6]>("A");
     auto A_data = std::array<double, 12>{27., 28., 29., 30., 31., 32., 33., 34., 35., 36., 37., 38.};
     auto A_host = Kokkos::View<double[2][6], Kokkos::HostSpace>(A_data.data());
@@ -68,7 +69,7 @@ TEST(UpdateNodeStateStests, TwoNodes_InOrder) {
     }
 }
 
-TEST(UpdateNodeStateStests, TwoNodes_OutOfOrder) {
+TEST(UpdateNodeStateTests, TwoNodes_OutOfOrder) {
     auto indices = Kokkos::View<int[2]>("node_state_indices");
     auto indices_data = std::array<int, 2>{1, 0};
     auto indices_host = Kokkos::View<int[2], Kokkos::HostSpace>(indices_data.data());
@@ -82,12 +83,14 @@ TEST(UpdateNodeStateStests, TwoNodes_OutOfOrder) {
     auto Q_mirror = Kokkos::create_mirror(Q);
     Kokkos::deep_copy(Q_mirror, Q_host);
     Kokkos::deep_copy(Q, Q_mirror);
+
     auto V = Kokkos::View<double[2][6]>("V");
     auto V_data = std::array<double, 12>{15., 16., 17., 18., 19., 20., 21., 22., 23., 24., 25., 26.};
     auto V_host = Kokkos::View<double[2][6], Kokkos::HostSpace>(V_data.data());
     auto V_mirror = Kokkos::create_mirror(V);
     Kokkos::deep_copy(V_mirror, V_host);
     Kokkos::deep_copy(V, V_mirror);
+    
     auto A = Kokkos::View<double[2][6]>("A");
     auto A_data = std::array<double, 12>{27., 28., 29., 30., 31., 32., 33., 34., 35., 36., 37., 38.};
     auto A_host = Kokkos::View<double[2][6], Kokkos::HostSpace>(A_data.data());

--- a/tests/unit_tests/restruct_poc/system/test_update_node_state.cpp
+++ b/tests/unit_tests/restruct_poc/system/test_update_node_state.cpp
@@ -13,9 +13,10 @@ TEST(UpdateNodeStateTests, TwoNodes_InOrder) {
     auto indices_mirror = Kokkos::create_mirror(indices);
     Kokkos::deep_copy(indices_mirror, indices_host);
     Kokkos::deep_copy(indices, indices_host);
-    
+
     auto Q = Kokkos::View<double[2][7]>("Q");
-    auto Q_data = std::array<double, 14>{1., 2., 3., 4., 5., 6., 7., 8., 9., 10., 11., 12., 13., 14.};
+    auto Q_data =
+        std::array<double, 14>{1., 2., 3., 4., 5., 6., 7., 8., 9., 10., 11., 12., 13., 14.};
     auto Q_host = Kokkos::View<double[2][7], Kokkos::HostSpace>(Q_data.data());
     auto Q_mirror = Kokkos::create_mirror(Q);
     Kokkos::deep_copy(Q_mirror, Q_host);
@@ -39,32 +40,34 @@ TEST(UpdateNodeStateTests, TwoNodes_InOrder) {
     auto node_u_dot = Kokkos::View<double[2][6]>("node_u_dot");
     auto node_u_ddot = Kokkos::View<double[2][6]>("node_u_ddot");
 
-    Kokkos::parallel_for("UpdateNodeState", 2, UpdateNodeState{indices, node_u, node_u_dot, node_u_ddot, Q, V, A});
+    Kokkos::parallel_for(
+        "UpdateNodeState", 2, UpdateNodeState{indices, node_u, node_u_dot, node_u_ddot, Q, V, A}
+    );
 
     auto node_u_mirror = Kokkos::create_mirror(node_u);
     Kokkos::deep_copy(node_u_mirror, node_u);
-    for(int j = 0; j < 7; ++j) {
+    for (int j = 0; j < 7; ++j) {
         EXPECT_EQ(node_u_mirror(0, j), Q_host(0, j));
     }
-    for(int j = 0; j < 7; ++j) {
+    for (int j = 0; j < 7; ++j) {
         EXPECT_EQ(node_u_mirror(1, j), Q_host(1, j));
     }
 
     auto node_u_dot_mirror = Kokkos::create_mirror(node_u_dot);
     Kokkos::deep_copy(node_u_dot_mirror, node_u_dot);
-    for(int j = 0; j < 6; ++j) {
+    for (int j = 0; j < 6; ++j) {
         EXPECT_EQ(node_u_dot_mirror(0, j), V_host(0, j));
     }
-    for(int j = 0; j < 6; ++j) {
+    for (int j = 0; j < 6; ++j) {
         EXPECT_EQ(node_u_dot_mirror(1, j), V_host(1, j));
     }
 
     auto node_u_ddot_mirror = Kokkos::create_mirror(node_u_ddot);
     Kokkos::deep_copy(node_u_ddot_mirror, node_u_ddot);
-    for(int j = 0; j < 6; ++j) {
+    for (int j = 0; j < 6; ++j) {
         EXPECT_EQ(node_u_ddot_mirror(0, j), A_host(0, j));
     }
-    for(int j = 0; j < 6; ++j) {
+    for (int j = 0; j < 6; ++j) {
         EXPECT_EQ(node_u_ddot_mirror(1, j), A_host(1, j));
     }
 }
@@ -76,9 +79,10 @@ TEST(UpdateNodeStateTests, TwoNodes_OutOfOrder) {
     auto indices_mirror = Kokkos::create_mirror(indices);
     Kokkos::deep_copy(indices_mirror, indices_host);
     Kokkos::deep_copy(indices, indices_host);
-    
+
     auto Q = Kokkos::View<double[2][7]>("Q");
-    auto Q_data = std::array<double, 14>{1., 2., 3., 4., 5., 6., 7., 8., 9., 10., 11., 12., 13., 14.};
+    auto Q_data =
+        std::array<double, 14>{1., 2., 3., 4., 5., 6., 7., 8., 9., 10., 11., 12., 13., 14.};
     auto Q_host = Kokkos::View<double[2][7], Kokkos::HostSpace>(Q_data.data());
     auto Q_mirror = Kokkos::create_mirror(Q);
     Kokkos::deep_copy(Q_mirror, Q_host);
@@ -90,7 +94,7 @@ TEST(UpdateNodeStateTests, TwoNodes_OutOfOrder) {
     auto V_mirror = Kokkos::create_mirror(V);
     Kokkos::deep_copy(V_mirror, V_host);
     Kokkos::deep_copy(V, V_mirror);
-    
+
     auto A = Kokkos::View<double[2][6]>("A");
     auto A_data = std::array<double, 12>{27., 28., 29., 30., 31., 32., 33., 34., 35., 36., 37., 38.};
     auto A_host = Kokkos::View<double[2][6], Kokkos::HostSpace>(A_data.data());
@@ -102,32 +106,34 @@ TEST(UpdateNodeStateTests, TwoNodes_OutOfOrder) {
     auto node_u_dot = Kokkos::View<double[2][6]>("node_u_dot");
     auto node_u_ddot = Kokkos::View<double[2][6]>("node_u_ddot");
 
-    Kokkos::parallel_for("UpdateNodeState", 2, UpdateNodeState{indices, node_u, node_u_dot, node_u_ddot, Q, V, A});
+    Kokkos::parallel_for(
+        "UpdateNodeState", 2, UpdateNodeState{indices, node_u, node_u_dot, node_u_ddot, Q, V, A}
+    );
 
     auto node_u_mirror = Kokkos::create_mirror(node_u);
     Kokkos::deep_copy(node_u_mirror, node_u);
-    for(int j = 0; j < 7; ++j) {
+    for (int j = 0; j < 7; ++j) {
         EXPECT_EQ(node_u_mirror(0, j), Q_host(1, j));
     }
-    for(int j = 0; j < 7; ++j) {
+    for (int j = 0; j < 7; ++j) {
         EXPECT_EQ(node_u_mirror(1, j), Q_host(0, j));
     }
 
     auto node_u_dot_mirror = Kokkos::create_mirror(node_u_dot);
     Kokkos::deep_copy(node_u_dot_mirror, node_u_dot);
-    for(int j = 0; j < 6; ++j) {
+    for (int j = 0; j < 6; ++j) {
         EXPECT_EQ(node_u_dot_mirror(0, j), V_host(1, j));
     }
-    for(int j = 0; j < 6; ++j) {
+    for (int j = 0; j < 6; ++j) {
         EXPECT_EQ(node_u_dot_mirror(1, j), V_host(0, j));
     }
 
     auto node_u_ddot_mirror = Kokkos::create_mirror(node_u_ddot);
     Kokkos::deep_copy(node_u_ddot_mirror, node_u_ddot);
-    for(int j = 0; j < 6; ++j) {
+    for (int j = 0; j < 6; ++j) {
         EXPECT_EQ(node_u_ddot_mirror(0, j), A_host(1, j));
     }
-    for(int j = 0; j < 6; ++j) {
+    for (int j = 0; j < 6; ++j) {
         EXPECT_EQ(node_u_ddot_mirror(1, j), A_host(0, j));
     }
 }


### PR DESCRIPTION
In addition to unit testing, This PR provides some cleanup of the implementation of CalculateNodeForces and UpdateNodeState specifically.  It also adds typedefs for the KokkosKernels types used in these kernels, which greatly improves readability.  