### PR TITLE
Check Headers for Formatting in CI

### DIFF
--- a/.github/workflows/formatting.yaml
+++ b/.github/workflows/formatting.yaml
@@ -13,5 +13,5 @@ jobs:
       with:
         source: './src ./tests/unit_tests'
         exclude: '.'
-        extensions: 'H,h,cpp'
+        extensions: 'cpp,hpp'
         clangFormatVersion: 16

--- a/src/restruct_poc/CMakeLists.txt
+++ b/src/restruct_poc/CMakeLists.txt
@@ -1,3 +1,1 @@
-target_sources(${oturb_lib_name}
-    PRIVATE
-)
+target_sources(${oturb_lib_name} PRIVATE)

--- a/src/restruct_poc/solver/solve_system.hpp
+++ b/src/restruct_poc/solver/solve_system.hpp
@@ -12,7 +12,7 @@ namespace openturbine {
 
 inline void SolveSystem(Solver& solver) {
     auto region = Kokkos::Profiling::ScopedRegion("Solve System");
-    
+
     {
         auto assemble_region = Kokkos::Profiling::ScopedRegion("Assemble Full System");
         KokkosSparse::spadd_numeric(

--- a/src/restruct_poc/solver/solver.hpp
+++ b/src/restruct_poc/solver/solver.hpp
@@ -65,7 +65,7 @@ struct Solver {
     CrsMatrixType transpose_matrix_full;
     CrsMatrixType system_plus_constraints;
     CrsMatrixType full_matrix;
-    View_NxN St;       // Iteration matrix
+    View_NxN St;  // Iteration matrix
     DenseMatrixType St_left;
     Kokkos::View<int*, Kokkos::LayoutLeft> IPIV;
     View_Nx6x6 T_dense;
@@ -206,9 +206,7 @@ struct Solver {
         KokkosSparse::spgemm_symbolic(
             system_spgemm_handle, K, false, T, false, static_system_matrix
         );
-        KokkosSparse::spgemm_numeric(
-            system_spgemm_handle, K, false, T, false, static_system_matrix
-        );
+        KokkosSparse::spgemm_numeric(system_spgemm_handle, K, false, T, false, static_system_matrix);
 
         constraints_spgemm_handle.create_spgemm_handle();
         KokkosSparse::spgemm_symbolic(
@@ -220,7 +218,9 @@ struct Solver {
 
         system_spadd_handle.create_spadd_handle(true, true);
         KokkosSparse::spadd_symbolic(&system_spadd_handle, K, static_system_matrix, system_matrix);
-        KokkosSparse::spadd_numeric(&system_spadd_handle, 1., K, 1., static_system_matrix, system_matrix);
+        KokkosSparse::spadd_numeric(
+            &system_spadd_handle, 1., K, 1., static_system_matrix, system_matrix
+        );
 
         auto system_matrix_full_row_ptrs =
             Kokkos::View<int*>("system_matrix_full_row_ptrs", num_dofs + 1);
@@ -268,7 +268,8 @@ struct Solver {
             &spc_spadd_handle, system_matrix_full, constraints_matrix_full, system_plus_constraints
         );
         KokkosSparse::spadd_numeric(
-            &spc_spadd_handle, 1., system_matrix_full, 1., constraints_matrix_full, system_plus_constraints
+            &spc_spadd_handle, 1., system_matrix_full, 1., constraints_matrix_full,
+            system_plus_constraints
         );
 
         full_system_spadd_handle.create_spadd_handle(true, true);
@@ -276,7 +277,8 @@ struct Solver {
             &full_system_spadd_handle, system_plus_constraints, transpose_matrix_full, full_matrix
         );
         KokkosSparse::spadd_numeric(
-            &full_system_spadd_handle, 1., system_plus_constraints, 1., transpose_matrix_full, full_matrix
+            &full_system_spadd_handle, 1., system_plus_constraints, 1., transpose_matrix_full,
+            full_matrix
         );
     }
 };

--- a/src/restruct_poc/system/assemble_inertia_matrix.hpp
+++ b/src/restruct_poc/system/assemble_inertia_matrix.hpp
@@ -15,14 +15,12 @@ inline void AssembleInertiaMatrix(
     auto region = Kokkos::Profiling::ScopedRegion("Assemble Inertia Matrix");
     auto range_policy = Kokkos::TeamPolicy<>(beams.num_elems, Kokkos::AUTO());
 
-
     Kokkos::parallel_for(
         "IntegrateInertiaMatrix", range_policy,
         IntegrateInertiaMatrix{
             beams.elem_indices, beams.qp_weight, beams.qp_jacobian, beams.shape_interp, beams.qp_Muu,
             beams.qp_Guu, beta_prime, gamma_prime, M}
     );
-
 }
 
 }  // namespace openturbine


### PR DESCRIPTION
We had previously only been checking formatting in .h and .H header files in CI.  We use .hpp for our headers.  This PR enables that check and makes the changes to our format.  