### PR TITLE
Reduced the amount of scratch memory used for assembling the system.

### DIFF
--- a/src/restruct_poc/solver/assemble_system.hpp
+++ b/src/restruct_poc/solver/assemble_system.hpp
@@ -35,10 +35,9 @@ void AssembleSystem(Solver& solver, Beams& beams, Subview_N R_system) {
     );
 
     auto num_rows = solver.num_system_dofs;
-    auto num_columns = solver.num_system_dofs;
 
-    auto row_data_size = Kokkos::View<double*>::shmem_size(num_columns);
-    auto col_idx_size = Kokkos::View<int*>::shmem_size(num_columns);
+    auto row_data_size = Kokkos::View<double*>::shmem_size(solver.matrix_terms.extent(2));
+    auto col_idx_size = Kokkos::View<int*>::shmem_size(solver.matrix_terms.extent(2));
     auto sparse_matrix_policy = Kokkos::TeamPolicy<>(num_rows, Kokkos::AUTO());
     sparse_matrix_policy.set_scratch_size(1, Kokkos::PerTeam(row_data_size + col_idx_size));
 


### PR DESCRIPTION
For large systems, this was a vast overallocation (large enough for all columns instead of just the non-zero ones).