### PR TITLE
Fixes namespaces in tests to no longer include restruct_poc

### DIFF
--- a/tests/unit_tests/restruct_poc/beams/test_interpolate_QP.hpp
+++ b/tests/unit_tests/restruct_poc/beams/test_interpolate_QP.hpp
@@ -3,7 +3,7 @@
 #include <Kokkos_Core.hpp>
 #include <gtest/gtest.h>
 
-namespace openturbine::restruct_poc::tests {
+namespace openturbine::tests {
 
 inline auto create_shape_interp_OneNodeOneQP() {
     constexpr auto num_qp = 1;
@@ -121,4 +121,4 @@ inline auto create_shape_deriv_TwoNodeTwoQP() {
     return shape_deriv;
 }
 
-}  // namespace openturbine::restruct_poc::tests
+}  // namespace openturbine::tests

--- a/tests/unit_tests/restruct_poc/beams/test_interpolate_QP_state.cpp
+++ b/tests/unit_tests/restruct_poc/beams/test_interpolate_QP_state.cpp
@@ -5,7 +5,7 @@
 
 #include "src/restruct_poc/beams/interpolate_QP_state.hpp"
 
-namespace openturbine::restruct_poc::tests {
+namespace openturbine::tests {
 
 inline auto create_node_u_OneNode() {
     constexpr auto num_nodes = 1;
@@ -322,4 +322,4 @@ TEST(InterpolateQPStateTests, rprime_TwoNodeTwoQP) {
     EXPECT_NEAR(qp_rprime_mirror(1, 3), 91., tolerance);
 }
 
-}  // namespace openturbine::restruct_poc::tests
+}  // namespace openturbine::tests

--- a/tests/unit_tests/restruct_poc/beams/test_interpolate_QP_vector.cpp
+++ b/tests/unit_tests/restruct_poc/beams/test_interpolate_QP_vector.cpp
@@ -5,7 +5,7 @@
 
 #include "src/restruct_poc/beams/interpolate_QP_vector.hpp"
 
-namespace openturbine::restruct_poc::tests {
+namespace openturbine::tests {
 
 inline auto create_node_u_dot_OneNode() {
     constexpr auto num_nodes = 1;
@@ -108,4 +108,4 @@ TEST(InterpolateQPVectorTests, TwoNodeTwoQP) {
     EXPECT_NEAR(qp_u_dot_mirror(1, 2), 54., tolerance);
 }
 
-}  // namespace openturbine::restruct_poc::tests
+}  // namespace openturbine::tests

--- a/tests/unit_tests/restruct_poc/iea15_rotor_data.hpp
+++ b/tests/unit_tests/restruct_poc/iea15_rotor_data.hpp
@@ -3,7 +3,7 @@
 #include "src/restruct_poc/beams/beam_section.hpp"
 #include "src/restruct_poc/types.hpp"
 
-namespace openturbine::restruct_poc::tests {
+namespace openturbine::tests {
 
 // Node location from [-1, 1]
 static constexpr auto node_xi = std::array{
@@ -792,4 +792,4 @@ static const std::vector<BeamSection> material_sections = {
     },
 };
 
-}  // namespace openturbine::restruct_poc::tests
+}  // namespace openturbine::tests

--- a/tests/unit_tests/restruct_poc/solver/test_compute_number_of_non_zeros.cpp
+++ b/tests/unit_tests/restruct_poc/solver/test_compute_number_of_non_zeros.cpp
@@ -3,7 +3,7 @@
 
 #include "src/restruct_poc/solver/compute_number_of_non_zeros.hpp"
 
-namespace openturbine::restruct_poc::tests {
+namespace openturbine::tests {
 
 TEST(ComputeNumberOfNonZeros, SingleElement) {
     auto elem_indices_host =
@@ -35,4 +35,4 @@ TEST(ComputeNumberOfNonZeros, TwoElements) {
         num_dof_elem1 * num_dof_elem1 + num_dof_elem2 * num_dof_elem2;
     EXPECT_EQ(num_non_zero, expected_num_non_zero);
 }
-}  // namespace openturbine::restruct_poc::tests
+}  // namespace openturbine::tests

--- a/tests/unit_tests/restruct_poc/solver/test_copy_into_sparse_matrix.cpp
+++ b/tests/unit_tests/restruct_poc/solver/test_copy_into_sparse_matrix.cpp
@@ -4,7 +4,7 @@
 
 #include "src/restruct_poc/solver/copy_into_sparse_matrix.hpp"
 
-namespace openturbine::restruct_poc::tests {
+namespace openturbine::tests {
 
 auto createDenseMatrix_1x1() {
     auto dense = Kokkos::View<double[1][1]>("dense");
@@ -187,4 +187,4 @@ TEST(CopyIntoSparseMatrix, Block) {
     ASSERT_EQ(values_mirror(12), 13.);
 }
 
-}  // namespace openturbine::restruct_poc::tests
+}  // namespace openturbine::tests

--- a/tests/unit_tests/restruct_poc/solver/test_populate_sparse_indices.cpp
+++ b/tests/unit_tests/restruct_poc/solver/test_populate_sparse_indices.cpp
@@ -3,7 +3,7 @@
 
 #include "src/restruct_poc/solver/populate_sparse_indices.hpp"
 
-namespace openturbine::restruct_poc::tests {
+namespace openturbine::tests {
 
 TEST(PopulateSparseIndices, SingleElement) {
     constexpr auto num_nodes = 5;
@@ -76,4 +76,4 @@ TEST(PopulateSparseIndices, TwoElements) {
         }
     }
 }
-}  // namespace openturbine::restruct_poc::tests
+}  // namespace openturbine::tests

--- a/tests/unit_tests/restruct_poc/solver/test_populate_sparse_row_ptrs.cpp
+++ b/tests/unit_tests/restruct_poc/solver/test_populate_sparse_row_ptrs.cpp
@@ -3,7 +3,7 @@
 
 #include "src/restruct_poc/solver/populate_sparse_row_ptrs.hpp"
 
-namespace openturbine::restruct_poc::tests {
+namespace openturbine::tests {
 
 TEST(PopulateSparseRowPtrs, SingleElement) {
     auto elem_indices_host =
@@ -52,4 +52,4 @@ TEST(PopulateSparseRowPtrs, TwoElements) {
     }
 }
 
-}  // namespace openturbine::restruct_poc::tests
+}  // namespace openturbine::tests

--- a/tests/unit_tests/restruct_poc/system/test_calculate.hpp
+++ b/tests/unit_tests/restruct_poc/system/test_calculate.hpp
@@ -3,7 +3,7 @@
 #include <Kokkos_Core.hpp>
 #include <gtest/gtest.h>
 
-namespace openturbine::restruct_poc::tests {
+namespace openturbine::tests {
 
 inline void CompareWithExpected(
     const Kokkos::View<const double**>::host_mirror_type& result,
@@ -29,4 +29,4 @@ inline void CompareWithExpected(
     }
 }
 
-}  // namespace openturbine::restruct_poc::tests
+}  // namespace openturbine::tests

--- a/tests/unit_tests/restruct_poc/system/test_calculate_Ouu.cpp
+++ b/tests/unit_tests/restruct_poc/system/test_calculate_Ouu.cpp
@@ -6,7 +6,7 @@
 #include "src/restruct_poc/system/calculate_Ouu.hpp"
 #include "src/restruct_poc/types.hpp"
 
-namespace openturbine::restruct_poc::tests {
+namespace openturbine::tests {
 
 TEST(CalculateOuuTests, OneNode) {
     const auto Cuu = Kokkos::View<double[1][6][6]>("Cuu");
@@ -58,4 +58,4 @@ TEST(CalculateOuuTests, OneNode) {
     CompareWithExpected(Ouu_mirror, Ouu_exact);
 }
 
-}  // namespace openturbine::restruct_poc::tests
+}  // namespace openturbine::tests

--- a/tests/unit_tests/restruct_poc/system/test_calculate_Puu.cpp
+++ b/tests/unit_tests/restruct_poc/system/test_calculate_Puu.cpp
@@ -6,7 +6,7 @@
 #include "src/restruct_poc/system/calculate_Puu.hpp"
 #include "src/restruct_poc/types.hpp"
 
-namespace openturbine::restruct_poc::tests {
+namespace openturbine::tests {
 
 TEST(CalculatePuuTests, OneNode) {
     const auto Cuu = Kokkos::View<double[1][6][6]>("Cuu");
@@ -58,4 +58,4 @@ TEST(CalculatePuuTests, OneNode) {
     CompareWithExpected(Puu_mirror, Puu_exact);
 }
 
-}  // namespace openturbine::restruct_poc::tests
+}  // namespace openturbine::tests

--- a/tests/unit_tests/restruct_poc/system/test_calculate_Quu.cpp
+++ b/tests/unit_tests/restruct_poc/system/test_calculate_Quu.cpp
@@ -6,7 +6,7 @@
 #include "src/restruct_poc/system/calculate_Quu.hpp"
 #include "src/restruct_poc/types.hpp"
 
-namespace openturbine::restruct_poc::tests {
+namespace openturbine::tests {
 
 TEST(CalculateQuuTests, OneNode) {
     const auto Cuu = Kokkos::View<double[1][6][6]>("Cuu");
@@ -58,4 +58,4 @@ TEST(CalculateQuuTests, OneNode) {
     CompareWithExpected(Quu_mirror, Quu_exact);
 }
 
-}  // namespace openturbine::restruct_poc::tests
+}  // namespace openturbine::tests

--- a/tests/unit_tests/restruct_poc/system/test_calculate_RR0.cpp
+++ b/tests/unit_tests/restruct_poc/system/test_calculate_RR0.cpp
@@ -6,7 +6,7 @@
 #include "src/restruct_poc/system/calculate_RR0.hpp"
 #include "src/restruct_poc/types.hpp"
 
-namespace openturbine::restruct_poc::tests {
+namespace openturbine::tests {
 
 TEST(CalculateRR0Tests, OneNode) {
     const auto r0 = Kokkos::View<double[1][4]>("r0");
@@ -85,4 +85,4 @@ TEST(CalculateRR0Tests, TwoNodes) {
     }
 }
 
-}  // namespace openturbine::restruct_poc::tests
+}  // namespace openturbine::tests

--- a/tests/unit_tests/restruct_poc/system/test_calculate_force_FC.cpp
+++ b/tests/unit_tests/restruct_poc/system/test_calculate_force_FC.cpp
@@ -6,7 +6,7 @@
 #include "src/restruct_poc/system/calculate_force_FC.hpp"
 #include "src/restruct_poc/types.hpp"
 
-namespace openturbine::restruct_poc::tests {
+namespace openturbine::tests {
 
 TEST(CalculateForceFCTests, OneNode) {
     const auto Cuu = Kokkos::View<double[1][6][6]>("Cuu");
@@ -58,4 +58,4 @@ TEST(CalculateForceFCTests, OneNode) {
     CompareWithExpected(N_tilde_mirror, N_tilde_exact);
 }
 
-}  // namespace openturbine::restruct_poc::tests
+}  // namespace openturbine::tests

--- a/tests/unit_tests/restruct_poc/system/test_calculate_force_FD.cpp
+++ b/tests/unit_tests/restruct_poc/system/test_calculate_force_FD.cpp
@@ -6,7 +6,7 @@
 #include "src/restruct_poc/system/calculate_force_FD.hpp"
 #include "src/restruct_poc/types.hpp"
 
-namespace openturbine::restruct_poc::tests {
+namespace openturbine::tests {
 
 TEST(CalculateForceFDTests, OneNode) {
     const auto x0pupSS = Kokkos::View<double[1][3][3]>("x0pupSS");
@@ -36,4 +36,4 @@ TEST(CalculateForceFDTests, OneNode) {
     CompareWithExpected(FD_mirror, FD_exact);
 }
 
-}  // namespace openturbine::restruct_poc::tests
+}  // namespace openturbine::tests

--- a/tests/unit_tests/restruct_poc/system/test_calculate_gravity_force.cpp
+++ b/tests/unit_tests/restruct_poc/system/test_calculate_gravity_force.cpp
@@ -6,7 +6,7 @@
 #include "src/restruct_poc/system/calculate_gravity_force.hpp"
 #include "src/restruct_poc/types.hpp"
 
-namespace openturbine::restruct_poc::tests {
+namespace openturbine::tests {
 
 TEST(CalculateGravityForceTests, OneNode) {
     const auto Muu = Kokkos::View<double[1][6][6]>("Muu");
@@ -47,4 +47,4 @@ TEST(CalculateGravityForceTests, OneNode) {
     CompareWithExpected(FG_mirror, FG_exact);
 }
 
-}  // namespace openturbine::restruct_poc::tests
+}  // namespace openturbine::tests

--- a/tests/unit_tests/restruct_poc/system/test_calculate_gyroscopic_matrix.cpp
+++ b/tests/unit_tests/restruct_poc/system/test_calculate_gyroscopic_matrix.cpp
@@ -6,7 +6,7 @@
 #include "src/restruct_poc/system/calculate_gyroscopic_matrix.hpp"
 #include "src/restruct_poc/types.hpp"
 
-namespace openturbine::restruct_poc::tests {
+namespace openturbine::tests {
 
 TEST(CalculateGyroscopicMatrixTests, OneNode) {
     const auto Muu = Kokkos::View<double[1][6][6]>("Muu");
@@ -66,4 +66,4 @@ TEST(CalculateGyroscopicMatrixTests, OneNode) {
     CompareWithExpected(Guu_mirror, Guu_exact);
 }
 
-}  // namespace openturbine::restruct_poc::tests
+}  // namespace openturbine::tests

--- a/tests/unit_tests/restruct_poc/system/test_calculate_inertia_stiffness_matrix.cpp
+++ b/tests/unit_tests/restruct_poc/system/test_calculate_inertia_stiffness_matrix.cpp
@@ -6,7 +6,7 @@
 #include "src/restruct_poc/system/calculate_inertia_stiffness_matrix.hpp"
 #include "src/restruct_poc/types.hpp"
 
-namespace openturbine::restruct_poc::tests {
+namespace openturbine::tests {
 
 TEST(CalculateInertiaStiffnessMatrixTests, OneNode) {
     const auto Muu = Kokkos::View<double[1][6][6]>("Muu");
@@ -98,4 +98,4 @@ TEST(CalculateInertiaStiffnessMatrixTests, OneNode) {
     CompareWithExpected(Kuu_mirror, Kuu_exact);
 }
 
-}  // namespace openturbine::restruct_poc::tests
+}  // namespace openturbine::tests

--- a/tests/unit_tests/restruct_poc/system/test_calculate_inertial_forces.cpp
+++ b/tests/unit_tests/restruct_poc/system/test_calculate_inertial_forces.cpp
@@ -6,7 +6,7 @@
 #include "src/restruct_poc/system/calculate_inertial_forces.hpp"
 #include "src/restruct_poc/types.hpp"
 
-namespace openturbine::restruct_poc::tests {
+namespace openturbine::tests {
 
 TEST(CalculateInertialForcesTests, OneNode) {
     const auto Muu = Kokkos::View<double[1][6][6]>("Muu");
@@ -97,4 +97,4 @@ TEST(CalculateInertialForcesTests, OneNode) {
     CompareWithExpected(FI_mirror, FI_exact);
 }
 
-}  // namespace openturbine::restruct_poc::tests
+}  // namespace openturbine::tests

--- a/tests/unit_tests/restruct_poc/system/test_calculate_mass_matrix_components.cpp
+++ b/tests/unit_tests/restruct_poc/system/test_calculate_mass_matrix_components.cpp
@@ -6,7 +6,7 @@
 #include "src/restruct_poc/system/calculate_mass_matrix_components.hpp"
 #include "src/restruct_poc/types.hpp"
 
-namespace openturbine::restruct_poc::tests {
+namespace openturbine::tests {
 
 TEST(CalculateMassMatrixComponentsTests, OneQuadPoint) {
     const auto Muu = Kokkos::View<double[1][6][6]>("Muu");
@@ -51,4 +51,4 @@ TEST(CalculateMassMatrixComponentsTests, OneQuadPoint) {
     CompareWithExpected(eta_tilde_mirror, eta_tilde_exact);
 }
 
-}  // namespace openturbine::restruct_poc::tests
+}  // namespace openturbine::tests

--- a/tests/unit_tests/restruct_poc/system/test_calculate_node_forces.cpp
+++ b/tests/unit_tests/restruct_poc/system/test_calculate_node_forces.cpp
@@ -6,7 +6,7 @@
 #include "src/restruct_poc/system/calculate_node_forces.hpp"
 #include "src/restruct_poc/types.hpp"
 
-namespace openturbine::restruct_poc::tests {
+namespace openturbine::tests {
 
 TEST(CalculateNodeForcesTests, FE_OneNodeOneQP) {
     constexpr auto first_node = 0;
@@ -272,4 +272,4 @@ TEST(CalculateNodeForcesTests, FI_FG_TwoNodesTwoQP) {
     CompareWithExpected(FIG_mirror, FIG_exact);
 }
 
-}  // namespace openturbine::restruct_poc::tests
+}  // namespace openturbine::tests

--- a/tests/unit_tests/restruct_poc/system/test_calculate_strain.cpp
+++ b/tests/unit_tests/restruct_poc/system/test_calculate_strain.cpp
@@ -6,7 +6,7 @@
 #include "src/restruct_poc/system/calculate_strain.hpp"
 #include "src/restruct_poc/types.hpp"
 
-namespace openturbine::restruct_poc::tests {
+namespace openturbine::tests {
 
 TEST(CalculateStrainTests, OneNode) {
     const auto x0_prime = Kokkos::View<double[1][3]>("x0_prime");
@@ -55,4 +55,4 @@ TEST(CalculateStrainTests, OneNode) {
     CompareWithExpected(strain_mirror, strain_exact);
 }
 
-}  // namespace openturbine::restruct_poc::tests
+}  // namespace openturbine::tests

--- a/tests/unit_tests/restruct_poc/system/test_calculate_temporary_variables.cpp
+++ b/tests/unit_tests/restruct_poc/system/test_calculate_temporary_variables.cpp
@@ -6,7 +6,7 @@
 #include "src/restruct_poc/system/calculate_temporary_variables.hpp"
 #include "src/restruct_poc/types.hpp"
 
-namespace openturbine::restruct_poc::tests {
+namespace openturbine::tests {
 
 TEST(CalculateTemporaryVariablesTests, OneNode) {
     const auto x0_prime = Kokkos::View<double[1][3]>("x0_prime");
@@ -40,4 +40,4 @@ TEST(CalculateTemporaryVariablesTests, OneNode) {
     CompareWithExpected(x0pupSS_mirror, x0pupSS_exact);
 }
 
-}  // namespace openturbine::restruct_poc::tests
+}  // namespace openturbine::tests

--- a/tests/unit_tests/restruct_poc/system/test_integrate_inertia_matrix.cpp
+++ b/tests/unit_tests/restruct_poc/system/test_integrate_inertia_matrix.cpp
@@ -9,7 +9,7 @@
 #include "src/restruct_poc/types.hpp"
 #include "tests/unit_tests/restruct_poc/test_utilities.hpp"
 
-namespace openturbine::restruct_poc::tests {
+namespace openturbine::tests {
 
 inline void IntegrateInertiaMatrix_TestOneElementOneNodeOneQP_Muu() {
     constexpr auto number_of_elements = 1;
@@ -313,4 +313,4 @@ TEST(IntegrateInertiaMatrixTests, OneElementOneNodeOneQP_WithMultiplicationFacto
     IntegrateInertiaMatrix_TestOneElementOneNodeOneQP_WithMultiplicationFactor();
 }
 
-}  // namespace openturbine::restruct_poc::tests
+}  // namespace openturbine::tests

--- a/tests/unit_tests/restruct_poc/system/test_integrate_matrix.hpp
+++ b/tests/unit_tests/restruct_poc/system/test_integrate_matrix.hpp
@@ -5,7 +5,7 @@
 
 #include "src/restruct_poc/beams/beams.hpp"
 
-namespace openturbine::restruct_poc::tests {
+namespace openturbine::tests {
 
 template <size_t n_elem, size_t n_nodes, size_t n_qps>
 auto get_element_indices() {
@@ -131,4 +131,4 @@ auto get_qp_Ouu(const std::array<double, n_elem * n_qps * 6 * 6>& Ouu_data) {
     return get_qp_matrix<n_elem, n_qps>("Ouu", Ouu_data);
 }
 
-}  // namespace openturbine::restruct_poc::tests
+}  // namespace openturbine::tests

--- a/tests/unit_tests/restruct_poc/system/test_integrate_residual_vector.cpp
+++ b/tests/unit_tests/restruct_poc/system/test_integrate_residual_vector.cpp
@@ -8,7 +8,7 @@
 #include "src/restruct_poc/types.hpp"
 #include "tests/unit_tests/restruct_poc/test_utilities.hpp"
 
-namespace openturbine::restruct_poc::tests {
+namespace openturbine::tests {
 
 void TestIntegrateResidualVector_1Element1Node_AllZeros() {
     constexpr auto num_elements = size_t{1U};
@@ -252,4 +252,4 @@ TEST(IntegrateResidualVector, TwoElementsTwoNodes) {
     TestIntegrateResidualVector_2Elements2Nodes();
 }
 
-}  // namespace openturbine::restruct_poc::tests
+}  // namespace openturbine::tests

--- a/tests/unit_tests/restruct_poc/system/test_integrate_stiffness_matrix.cpp
+++ b/tests/unit_tests/restruct_poc/system/test_integrate_stiffness_matrix.cpp
@@ -9,7 +9,7 @@
 #include "src/restruct_poc/types.hpp"
 #include "tests/unit_tests/restruct_poc/test_utilities.hpp"
 
-namespace openturbine::restruct_poc::tests {
+namespace openturbine::tests {
 
 void TestIntegrateStiffnessMatrix_1Element1Node1QP(
     const Kokkos::View<const double[1][6][6]>& qp_Kuu,
@@ -629,4 +629,4 @@ TEST(IntegrateStiffnessMatrixTests, OneElementOneNodeTwoQPs_Quu) {
     TestIntegrateStiffnessMatrix_1Element1Node2QPs_Quu();
 }
 
-}  // namespace openturbine::restruct_poc::tests
+}  // namespace openturbine::tests

--- a/tests/unit_tests/restruct_poc/system/test_rotate_section_matrix.cpp
+++ b/tests/unit_tests/restruct_poc/system/test_rotate_section_matrix.cpp
@@ -6,7 +6,7 @@
 #include "src/restruct_poc/system/rotate_section_matrix.hpp"
 #include "src/restruct_poc/types.hpp"
 
-namespace openturbine::restruct_poc::tests {
+namespace openturbine::tests {
 
 TEST(RotateSectionMatrixTests, OneNode) {
     const auto rr0 = Kokkos::View<double[1][6][6]>("rr0");
@@ -44,4 +44,4 @@ TEST(RotateSectionMatrixTests, OneNode) {
     CompareWithExpected(Cuu_mirror, Cuu_exact);
 }
 
-}  // namespace openturbine::restruct_poc::tests
+}  // namespace openturbine::tests

--- a/tests/unit_tests/restruct_poc/system/test_update_node_state.cpp
+++ b/tests/unit_tests/restruct_poc/system/test_update_node_state.cpp
@@ -4,7 +4,7 @@
 #include "src/restruct_poc/system/update_node_state.hpp"
 #include "src/restruct_poc/types.hpp"
 
-namespace openturbine::restruct_poc::tests {
+namespace openturbine::tests {
 
 inline void CompareInOrder(
     const Kokkos::View<const double**>::host_mirror_type& result,
@@ -130,4 +130,4 @@ TEST(UpdateNodeStateTests, TwoNodes_OutOfOrder) {
     CompareOutOfOrder(node_u_ddot_mirror, A_host);
 }
 
-}  // namespace openturbine::restruct_poc::tests
+}  // namespace openturbine::tests

--- a/tests/unit_tests/restruct_poc/test_beams.cpp
+++ b/tests/unit_tests/restruct_poc/test_beams.cpp
@@ -16,7 +16,7 @@
 #include "src/restruct_poc/system/update_state.hpp"
 #include "src/restruct_poc/types.hpp"
 
-namespace openturbine::restruct_poc::tests {
+namespace openturbine::tests {
 
 inline auto SetUpBeams() {
     // Stiffness matrix for uniform composite beam section
@@ -781,4 +781,4 @@ TEST(BeamsTest, ResidualForceVector) {
     );
 }
 
-}  // namespace openturbine::restruct_poc::tests
+}  // namespace openturbine::tests

--- a/tests/unit_tests/restruct_poc/test_cantilever_beam.cpp
+++ b/tests/unit_tests/restruct_poc/test_cantilever_beam.cpp
@@ -17,7 +17,7 @@
 #include "src/restruct_poc/solver/step.hpp"
 #include "src/restruct_poc/types.hpp"
 
-namespace openturbine::restruct_poc::tests {
+namespace openturbine::tests {
 
 template <typename T>
 void WriteMatrixToFile(const std::vector<std::vector<T>>& data, const std::string& filename) {
@@ -139,4 +139,4 @@ TEST(DynamicBeamTest, CantileverBeamSineLoad) {
     }
 }
 
-}  // namespace openturbine::restruct_poc::tests
+}  // namespace openturbine::tests

--- a/tests/unit_tests/restruct_poc/test_controller.cpp
+++ b/tests/unit_tests/restruct_poc/test_controller.cpp
@@ -7,7 +7,7 @@
 #include "src/utilities/controllers/turbine_controller.hpp"
 #include "src/vendor/dylib/dylib.hpp"
 
-namespace openturbine::restruct_poc::tests {
+namespace openturbine::tests {
 
 TEST(ControllerTest, DisconController) {
     // Test data generated using the following regression test from the
@@ -148,4 +148,4 @@ TEST(ControllerTest, TurbineControllerExceptionInvalidControllerFunctionName) {
     );
 }
 
-}  // namespace openturbine::restruct_poc::tests
+}  // namespace openturbine::tests

--- a/tests/unit_tests/restruct_poc/test_math.cpp
+++ b/tests/unit_tests/restruct_poc/test_math.cpp
@@ -5,7 +5,7 @@
 #include "src/restruct_poc/math/quaternion_operations.hpp"
 #include "src/restruct_poc/math/vector_operations.hpp"
 
-namespace openturbine::restruct_poc::tests {
+namespace openturbine::tests {
 
 template <unsigned size>
 auto Create1DView(const std::array<double, size>& input) {
@@ -299,4 +299,4 @@ TEST(MatrixTest, AX_Matrix) {
     test_AX_Matrix();
 }
 
-}  // namespace openturbine::restruct_poc::tests
+}  // namespace openturbine::tests

--- a/tests/unit_tests/restruct_poc/test_rotating_beam.cpp
+++ b/tests/unit_tests/restruct_poc/test_rotating_beam.cpp
@@ -23,7 +23,7 @@
 
 using Array_7 = std::array<double, 7>;
 
-namespace openturbine::restruct_poc::tests {
+namespace openturbine::tests {
 
 template <typename T>
 void WriteMatrixToFile(const std::vector<std::vector<T>>& data, const std::string& filename) {
@@ -602,4 +602,4 @@ TEST(RotatingBeamTest, CylindricalConstraint) {
     );
 }
 
-}  // namespace openturbine::restruct_poc::tests
+}  // namespace openturbine::tests

--- a/tests/unit_tests/restruct_poc/test_rotor.cpp
+++ b/tests/unit_tests/restruct_poc/test_rotor.cpp
@@ -26,7 +26,7 @@
 #include "vtkout.hpp"
 #endif
 
-namespace openturbine::restruct_poc::tests {
+namespace openturbine::tests {
 
 template <typename T>
 void WriteMatrixToFile(const std::vector<std::vector<T>>& data, const std::string& filename) {
@@ -550,4 +550,4 @@ TEST(RotorTest, IEA15RotorController) {
     }
 }
 
-}  // namespace openturbine::restruct_poc::tests
+}  // namespace openturbine::tests

--- a/tests/unit_tests/restruct_poc/test_solver.cpp
+++ b/tests/unit_tests/restruct_poc/test_solver.cpp
@@ -18,7 +18,7 @@
 #include "src/restruct_poc/solver/step.hpp"
 #include "src/restruct_poc/types.hpp"
 
-namespace openturbine::restruct_poc::tests {
+namespace openturbine::tests {
 
 inline std::pair<Beams, Solver> MakeBeamsAndSolver(size_t max_iter) {
     // Mass matrix for uniform composite beam section
@@ -823,4 +823,4 @@ TEST(SolverStep2Test, SolutionVector) {
     );
 }
 
-}  // namespace openturbine::restruct_poc::tests
+}  // namespace openturbine::tests

--- a/tests/unit_tests/restruct_poc/test_utilities.cpp
+++ b/tests/unit_tests/restruct_poc/test_utilities.cpp
@@ -4,7 +4,7 @@
 
 #include <gtest/gtest.h>
 
-namespace openturbine::restruct_poc::tests {
+namespace openturbine::tests {
 
 Kokkos::View<double**> create_diagonal_matrix(const std::vector<double>& values) {
     auto matrix = Kokkos::View<double**>("matrix", values.size(), values.size());
@@ -76,4 +76,4 @@ void expect_kokkos_view_3D_equal(
     }
 }
 
-}  // namespace openturbine::restruct_poc::tests
+}  // namespace openturbine::tests

--- a/tests/unit_tests/restruct_poc/test_utilities.hpp
+++ b/tests/unit_tests/restruct_poc/test_utilities.hpp
@@ -2,7 +2,7 @@
 
 #include "src/restruct_poc/types.hpp"
 
-namespace openturbine::restruct_poc::tests {
+namespace openturbine::tests {
 
 Kokkos::View<double**> create_diagonal_matrix(const std::vector<double>& values);
 
@@ -36,4 +36,4 @@ std::vector<T> kokkos_view_1D_to_vector(Kokkos::View<T*> view) {
 
 std::vector<std::vector<double>> kokkos_view_2D_to_vector(const Kokkos::View<double**>& view);
 
-}  // namespace openturbine::restruct_poc::tests
+}  // namespace openturbine::tests

--- a/tests/unit_tests/restruct_poc/vtkout.hpp
+++ b/tests/unit_tests/restruct_poc/vtkout.hpp
@@ -17,7 +17,7 @@
 #include "src/restruct_poc/beams/beams.hpp"
 #include "src/restruct_poc/math/quaternion_operations.hpp"
 
-namespace openturbine {
+namespace openturbine::tests {
 
 inline std::vector<std::vector<double>> kokkos_view_2D_to_vector(Kokkos::View<double**> view) {
     Kokkos::View<double**> view_contiguous("view_contiguous", view.extent(0), view.extent(1));
@@ -165,4 +165,4 @@ inline void BeamsWriteVTK(Beams& beams, std::string filename) {
     writer->Write();
 }
 
-}  // namespace openturbine
+}  // namespace openturbine::tests


### PR DESCRIPTION
This reflects a change we made a long time ago in the source files