### PR TITLE
Removed ElemIndices data structure with two Views of size_t

### DIFF
--- a/src/restruct_poc/beams/beams.hpp
+++ b/src/restruct_poc/beams/beams.hpp
@@ -9,29 +9,14 @@
 namespace openturbine {
 
 struct Beams {
-    // Node and quadrature point index data for an element
-    struct ElemIndices {
-        size_t num_nodes;
-        size_t num_qps;
-        Kokkos::pair<size_t, size_t> node_range;
-        Kokkos::pair<size_t, size_t> qp_range;
-        Kokkos::pair<size_t, size_t> qp_shape_range;
-        ElemIndices() = default;
-        ElemIndices(size_t n_nodes, size_t n_qps, size_t i_node_start, size_t i_qp_start)
-            : num_nodes(n_nodes),
-              num_qps(n_qps),
-              node_range(Kokkos::make_pair(i_node_start, i_node_start + n_nodes)),
-              qp_range(Kokkos::make_pair(i_qp_start, i_qp_start + n_qps)),
-              qp_shape_range(Kokkos::make_pair(0, n_qps)) {}
-    };
-
     size_t num_elems;  // Number of beams
     size_t num_nodes;  // Number of nodes
     size_t num_qps;    // Number of quadrature points
     size_t max_elem_nodes;
     size_t max_elem_qps;
 
-    Kokkos::View<ElemIndices*> elem_indices;    // View of element node and qp indices into views
+    Kokkos::View<size_t*> num_nodes_per_element;
+    Kokkos::View<size_t*> num_qps_per_element;
     Kokkos::View<size_t**> node_state_indices;  // State row index for each node
 
     View_3 gravity;
@@ -100,7 +85,8 @@ struct Beams {
           max_elem_nodes(max_e_nodes),
           max_elem_qps(max_e_qps),
           // Element Data
-          elem_indices("elem_indices", num_elems),
+          num_nodes_per_element("num_nodes_per_element", num_elems),
+          num_qps_per_element("num_qps_per_element", num_elems),
           node_state_indices("node_state_indices", num_elems, max_elem_nodes),
           gravity("gravity"),
           // Node Data

--- a/src/restruct_poc/beams/calculate_jacobian.hpp
+++ b/src/restruct_poc/beams/calculate_jacobian.hpp
@@ -10,8 +10,9 @@
 namespace openturbine {
 
 struct CalculateJacobian {
-    Kokkos::View<Beams::ElemIndices*>::const_type elem_indices;  // Element indices
-    Kokkos::View<double***>::const_type shape_derivative;        // Num Nodes x Num Quadrature points
+    Kokkos::View<size_t*>::const_type num_nodes_per_element;
+    Kokkos::View<size_t*>::const_type num_qps_per_element;
+    Kokkos::View<double***>::const_type shape_derivative;  // Num Nodes x Num Quadrature points
     Kokkos::View<double** [7]>::const_type
         node_position_rotation;                         // Node global position/rotation vector
     Kokkos::View<double** [3]> qp_position_derivative;  // quadrature point position derivative
@@ -19,24 +20,25 @@ struct CalculateJacobian {
 
     KOKKOS_FUNCTION
     void operator()(const int i_elem) const {
-        const auto& idx = elem_indices[i_elem];
+        const auto num_nodes = num_nodes_per_element(i_elem);
+        const auto num_qps = num_qps_per_element(i_elem);
         const auto shape_deriv = Kokkos::subview(
-            shape_derivative, i_elem, Kokkos::make_pair(size_t{0U}, idx.num_nodes),
-            idx.qp_shape_range
+            shape_derivative, i_elem, Kokkos::make_pair(size_t{0U}, num_nodes),
+            Kokkos::make_pair(size_t{0U}, num_qps)
         );
         const auto qp_pos_deriv = Kokkos::subview(
-            qp_position_derivative, i_elem, Kokkos::make_pair(size_t{0U}, idx.num_qps), Kokkos::ALL
+            qp_position_derivative, i_elem, Kokkos::make_pair(size_t{0U}, num_qps), Kokkos::ALL
         );
         const auto node_pos = Kokkos::subview(
-            node_position_rotation, i_elem, Kokkos::make_pair(size_t{0U}, idx.num_nodes),
+            node_position_rotation, i_elem, Kokkos::make_pair(size_t{0U}, num_nodes),
             Kokkos::make_pair(0U, 3U)
         );
         const auto qp_jacob =
-            Kokkos::subview(qp_jacobian, i_elem, Kokkos::make_pair(size_t{0U}, idx.num_qps));
+            Kokkos::subview(qp_jacobian, i_elem, Kokkos::make_pair(size_t{0U}, num_qps));
 
         InterpVector3(shape_deriv, node_pos, qp_pos_deriv);
 
-        for (auto j = 0U; j < idx.num_qps; ++j) {
+        for (auto j = 0U; j < num_qps; ++j) {
             const auto jacobian = Kokkos::sqrt(
                 Kokkos::pow(qp_pos_deriv(j, 0), 2.) + Kokkos::pow(qp_pos_deriv(j, 1), 2.) +
                 Kokkos::pow(qp_pos_deriv(j, 2), 2.)

--- a/src/restruct_poc/beams/create_beams.hpp
+++ b/src/restruct_poc/beams/create_beams.hpp
@@ -17,7 +17,8 @@ inline Beams CreateBeams(const BeamsInput& beams_input) {
 
     auto host_gravity = Kokkos::create_mirror(beams.gravity);
 
-    auto host_elem_indices = Kokkos::create_mirror(beams.elem_indices);
+    auto host_num_nodes_per_element = Kokkos::create_mirror(beams.num_nodes_per_element);
+    auto host_num_qps_per_element = Kokkos::create_mirror(beams.num_qps_per_element);
     auto host_node_state_indices = Kokkos::create_mirror(beams.node_state_indices);
     auto host_node_x0 = Kokkos::create_mirror(beams.node_x0);
     auto host_node_u = Kokkos::create_mirror(beams.node_u);
@@ -35,17 +36,14 @@ inline Beams CreateBeams(const BeamsInput& beams_input) {
     host_gravity(1) = beams_input.gravity[1];
     host_gravity(2) = beams_input.gravity[2];
 
-    size_t node_counter = 0;
-    size_t qp_counter = 0;
-
     for (size_t i = 0; i < beams_input.NumElements(); i++) {
         // Get number of nodes and quadrature points in element
         const auto num_nodes = beams_input.elements[i].nodes.size();
         const auto num_qps = beams_input.elements[i].quadrature.size();
 
         // Create element indices and set in host mirror
-        host_elem_indices[i] = Beams::ElemIndices(num_nodes, num_qps, node_counter, qp_counter);
-        const auto& idx = host_elem_indices[i];
+        host_num_nodes_per_element(i) = num_nodes;
+        host_num_qps_per_element(i) = num_qps;
 
         // Populate beam node->state indices
         for (size_t j = 0; j < num_nodes; ++j) {
@@ -53,37 +51,31 @@ inline Beams CreateBeams(const BeamsInput& beams_input) {
                 static_cast<size_t>(beams_input.elements[i].nodes[j].node.ID);
         }
 
-        // Increment counters for beam nodes and quadrature points
-        node_counter += num_nodes;
-        qp_counter += num_qps;
-
         // Populate views for this element
         PopulateElementViews(
             beams_input.elements[i],  // Element inputs
+            Kokkos::subview(host_node_x0, i, Kokkos::make_pair(size_t{0U}, num_nodes), Kokkos::ALL),
+            Kokkos::subview(host_qp_weight, i, Kokkos::make_pair(size_t{0U}, num_qps)),
             Kokkos::subview(
-                host_node_x0, i, Kokkos::make_pair(size_t{0U}, idx.num_nodes), Kokkos::ALL
-            ),
-            Kokkos::subview(host_qp_weight, i, Kokkos::make_pair(size_t{0U}, idx.num_qps)),
-            Kokkos::subview(
-                host_qp_Mstar, i, Kokkos::make_pair(size_t{0U}, idx.num_qps), Kokkos::ALL,
-                Kokkos::ALL
+                host_qp_Mstar, i, Kokkos::make_pair(size_t{0U}, num_qps), Kokkos::ALL, Kokkos::ALL
             ),
             Kokkos::subview(
-                host_qp_Cstar, i, Kokkos::make_pair(size_t{0U}, idx.num_qps), Kokkos::ALL,
-                Kokkos::ALL
+                host_qp_Cstar, i, Kokkos::make_pair(size_t{0U}, num_qps), Kokkos::ALL, Kokkos::ALL
             ),
             Kokkos::subview(
-                host_shape_interp, i, Kokkos::make_pair(size_t{0U}, idx.num_nodes),
-                idx.qp_shape_range
+                host_shape_interp, i, Kokkos::make_pair(size_t{0U}, num_nodes),
+                Kokkos::make_pair(size_t{0U}, num_qps)
             ),
             Kokkos::subview(
-                host_shape_deriv, i, Kokkos::make_pair(size_t{0U}, idx.num_nodes), idx.qp_shape_range
+                host_shape_deriv, i, Kokkos::make_pair(size_t{0U}, num_nodes),
+                Kokkos::make_pair(size_t{0U}, num_qps)
             )
         );
     }
 
     Kokkos::deep_copy(beams.gravity, host_gravity);
-    Kokkos::deep_copy(beams.elem_indices, host_elem_indices);
+    Kokkos::deep_copy(beams.num_nodes_per_element, host_num_nodes_per_element);
+    Kokkos::deep_copy(beams.num_qps_per_element, host_num_qps_per_element);
     Kokkos::deep_copy(beams.node_state_indices, host_node_state_indices);
     Kokkos::deep_copy(beams.node_x0, host_node_x0);
     Kokkos::deep_copy(beams.node_u, host_node_u);
@@ -97,18 +89,23 @@ inline Beams CreateBeams(const BeamsInput& beams_input) {
 
     Kokkos::parallel_for(
         "InterpolateQPPosition", beams.num_elems,
-        InterpolateQPPosition{beams.elem_indices, beams.shape_interp, beams.node_x0, beams.qp_x0}
+        InterpolateQPPosition{
+            beams.num_nodes_per_element, beams.num_qps_per_element, beams.shape_interp,
+            beams.node_x0, beams.qp_x0}
     );
 
     Kokkos::parallel_for(
         "InterpolateQPRotation", beams.num_elems,
-        InterpolateQPRotation{beams.elem_indices, beams.shape_interp, beams.node_x0, beams.qp_r0}
+        InterpolateQPRotation{
+            beams.num_nodes_per_element, beams.num_qps_per_element, beams.shape_interp,
+            beams.node_x0, beams.qp_r0}
     );
 
     Kokkos::parallel_for(
         "CalculateJacobian", beams.num_elems,
         CalculateJacobian{
-            beams.elem_indices,
+            beams.num_nodes_per_element,
+            beams.num_qps_per_element,
             beams.shape_deriv,
             beams.node_x0,
             beams.qp_x0_prime,
@@ -120,10 +117,10 @@ inline Beams CreateBeams(const BeamsInput& beams_input) {
     Kokkos::parallel_for(
         "InterpolateToQuadraturePoints", range_policy,
         InterpolateToQuadraturePoints{
-            beams.elem_indices, beams.shape_interp, beams.shape_deriv, beams.qp_jacobian,
-            beams.node_u, beams.node_u_dot, beams.node_u_ddot, beams.qp_u, beams.qp_u_prime,
-            beams.qp_r, beams.qp_r_prime, beams.qp_u_dot, beams.qp_omega, beams.qp_u_ddot,
-            beams.qp_omega_dot}
+            beams.num_nodes_per_element, beams.num_qps_per_element, beams.shape_interp,
+            beams.shape_deriv, beams.qp_jacobian, beams.node_u, beams.node_u_dot, beams.node_u_ddot,
+            beams.qp_u, beams.qp_u_prime, beams.qp_r, beams.qp_r_prime, beams.qp_u_dot,
+            beams.qp_omega, beams.qp_u_ddot, beams.qp_omega_dot}
     );
     return beams;
 }

--- a/src/restruct_poc/beams/interpolate_QP_position.hpp
+++ b/src/restruct_poc/beams/interpolate_QP_position.hpp
@@ -9,36 +9,27 @@
 namespace openturbine {
 
 struct InterpolateQPPosition {
-    Kokkos::View<Beams::ElemIndices*>::const_type elem_indices;  // Element indices
-    Kokkos::View<double***>::const_type shape_interpolation;     // Num Nodes x Num Quadrature points
+    Kokkos::View<size_t*>::const_type num_nodes_per_element;
+    Kokkos::View<size_t*>::const_type num_qps_per_element;
+    Kokkos::View<double***>::const_type shape_interpolation;  // Num Nodes x Num Quadrature points
     Kokkos::View<double** [7]>::const_type node_position_rotation;  // Node global position vector
     Kokkos::View<double** [3]> qp_position;                         // quadrature point position
 
     KOKKOS_FUNCTION
     void operator()(const int i_elem) const {
-        const auto& idx = elem_indices[i_elem];
-        const auto shape_interp = Kokkos::subview(
-            shape_interpolation, i_elem, Kokkos::make_pair(size_t{0U}, idx.num_nodes),
-            idx.qp_shape_range
-        );
-        const auto node_pos = Kokkos::subview(
-            node_position_rotation, i_elem, Kokkos::make_pair(size_t{0U}, idx.num_nodes),
-            Kokkos::make_pair(0, 3)
-        );
-        const auto qp_pos = Kokkos::subview(
-            qp_position, i_elem, Kokkos::make_pair(size_t{0U}, idx.num_qps), Kokkos::ALL
-        );
+        const auto num_nodes = num_nodes_per_element(i_elem);
+        const auto num_qps = num_qps_per_element(i_elem);
 
-        for (auto j = 0U; j < idx.num_qps; ++j) {
+        for (auto j = 0U; j < num_qps; ++j) {
             auto local_result = Kokkos::Array<double, 3>{};
-            for (auto i = 0U; i < idx.num_nodes; ++i) {
-                const auto phi = shape_interp(i, j);
+            for (auto i = 0U; i < num_nodes; ++i) {
+                const auto phi = shape_interpolation(i_elem, i, j);
                 for (auto k = 0U; k < kVectorComponents; ++k) {
-                    local_result[k] += node_pos(i, k) * phi;
+                    local_result[k] += node_position_rotation(i_elem, i, k) * phi;
                 }
             }
             for (auto k = 0U; k < 3U; ++k) {
-                qp_pos(j, k) = local_result[k];
+                qp_position(i_elem, j, k) = local_result[k];
             }
         }
     }

--- a/src/restruct_poc/beams/interpolate_QP_rotation.hpp
+++ b/src/restruct_poc/beams/interpolate_QP_rotation.hpp
@@ -10,24 +10,26 @@
 namespace openturbine {
 
 struct InterpolateQPRotation {
-    Kokkos::View<Beams::ElemIndices*>::const_type elem_indices;  // Element indices
-    Kokkos::View<double***>::const_type shape_interpolation;     // Num Nodes x Num Quadrature points
+    Kokkos::View<size_t*>::const_type num_nodes_per_element;
+    Kokkos::View<size_t*>::const_type num_qps_per_element;
+    Kokkos::View<double***>::const_type shape_interpolation;  // Num Nodes x Num Quadrature points
     Kokkos::View<double** [7]>::const_type node_position_rotation;  // Node global position vector
     Kokkos::View<double** [4]> qp_rotation;                         // quadrature point rotation
 
     KOKKOS_FUNCTION
     void operator()(const int i_elem) const {
-        const auto& idx = elem_indices[i_elem];
+        const auto num_nodes = num_nodes_per_element(i_elem);
+        const auto num_qps = num_qps_per_element(i_elem);
         const auto shape_interp = Kokkos::subview(
-            shape_interpolation, i_elem, Kokkos::make_pair(size_t{0U}, idx.num_nodes),
-            idx.qp_shape_range
+            shape_interpolation, i_elem, Kokkos::make_pair(size_t{0U}, num_nodes),
+            Kokkos::make_pair(size_t{0U}, num_qps)
         );
         const auto node_rot = Kokkos::subview(
-            node_position_rotation, i_elem, Kokkos::make_pair(size_t{0U}, idx.num_nodes),
+            node_position_rotation, i_elem, Kokkos::make_pair(size_t{0U}, num_nodes),
             Kokkos::make_pair(3, 7)
         );
         const auto qp_rot = Kokkos::subview(
-            qp_rotation, i_elem, Kokkos::make_pair(size_t{0U}, idx.num_qps), Kokkos::ALL
+            qp_rotation, i_elem, Kokkos::make_pair(size_t{0U}, num_qps), Kokkos::ALL
         );
 
         InterpQuaternion(shape_interp, node_rot, qp_rot);

--- a/src/restruct_poc/beams/interpolate_QP_state.hpp
+++ b/src/restruct_poc/beams/interpolate_QP_state.hpp
@@ -8,8 +8,6 @@ namespace openturbine {
 
 struct InterpolateQPState_u {
     size_t i_elem;
-    size_t first_qp;
-    size_t first_node;
     size_t num_nodes;
     Kokkos::View<double***>::const_type shape_interp;
     Kokkos::View<double** [7]>::const_type node_u;
@@ -33,8 +31,6 @@ struct InterpolateQPState_u {
 
 struct InterpolateQPState_uprime {
     size_t i_elem;
-    size_t first_qp;
-    size_t first_node;
     size_t num_nodes;
     Kokkos::View<double***>::const_type shape_deriv;
     Kokkos::View<double**>::const_type qp_jacobian;
@@ -60,8 +56,6 @@ struct InterpolateQPState_uprime {
 
 struct InterpolateQPState_r {
     size_t i_elem;
-    size_t first_qp;
-    size_t first_node;
     size_t num_nodes;
     Kokkos::View<double***>::const_type shape_interp;
     Kokkos::View<double** [7]>::const_type node_u;
@@ -93,8 +87,6 @@ struct InterpolateQPState_r {
 
 struct InterpolateQPState_rprime {
     size_t i_elem;
-    size_t first_qp;
-    size_t first_node;
     size_t num_nodes;
     Kokkos::View<double***>::const_type shape_deriv;
     Kokkos::View<double**>::const_type qp_jacobian;

--- a/src/restruct_poc/beams/interpolate_QP_vector.hpp
+++ b/src/restruct_poc/beams/interpolate_QP_vector.hpp
@@ -8,8 +8,6 @@ namespace openturbine {
 
 struct InterpolateQPVector {
     size_t i_elem;
-    size_t first_qp;
-    size_t first_node;
     size_t num_nodes;
     Kokkos::View<double***>::const_type shape_interp;
     Kokkos::View<double** [3], Kokkos::LayoutStride>::const_type node_vector;

--- a/src/restruct_poc/solver/compute_number_of_non_zeros.hpp
+++ b/src/restruct_poc/solver/compute_number_of_non_zeros.hpp
@@ -6,13 +6,12 @@
 
 namespace openturbine {
 struct ComputeNumberOfNonZeros {
-    Kokkos::View<Beams::ElemIndices*>::const_type elem_indices;
+    Kokkos::View<size_t*>::const_type num_nodes_per_element;
 
     KOKKOS_FUNCTION
     void operator()(int i_elem, size_t& update) const {
-        auto idx = elem_indices[i_elem];
-        auto num_nodes = idx.num_nodes;
-        update += (num_nodes * 6) * (num_nodes * 6);
+        const auto num_nodes = num_nodes_per_element(i_elem);
+        update += (num_nodes * 6U) * (num_nodes * 6U);
     }
 };
 }  // namespace openturbine

--- a/src/restruct_poc/solver/populate_sparse_indices.hpp
+++ b/src/restruct_poc/solver/populate_sparse_indices.hpp
@@ -6,17 +6,16 @@
 
 namespace openturbine {
 struct PopulateSparseIndices {
-    Kokkos::View<Beams::ElemIndices*>::const_type elem_indices;
+    Kokkos::View<size_t*>::const_type num_nodes_per_element;
     Kokkos::View<size_t**>::const_type node_state_indices;
     Kokkos::View<int*> indices;
 
     KOKKOS_FUNCTION
     void operator()(int) const {
-        const auto num_elems = elem_indices.extent(0);
+        const auto num_elems = num_nodes_per_element.extent(0);
         auto entries_so_far = 0;
         for (auto i_elem = 0U; i_elem < num_elems; ++i_elem) {
-            auto idx = elem_indices[i_elem];
-            auto num_nodes = idx.num_nodes;
+            auto num_nodes = num_nodes_per_element(i_elem);
             for (auto j_index = 0U; j_index < num_nodes; ++j_index) {
                 for (auto n = 0U; n < kLieAlgebraComponents; ++n) {
                     for (auto i_index = 0U; i_index < num_nodes; ++i_index) {

--- a/src/restruct_poc/solver/populate_sparse_row_ptrs.hpp
+++ b/src/restruct_poc/solver/populate_sparse_row_ptrs.hpp
@@ -7,16 +7,15 @@
 namespace openturbine {
 template <typename RowPtrType>
 struct PopulateSparseRowPtrs {
-    Kokkos::View<Beams::ElemIndices*>::const_type elem_indices;
+    Kokkos::View<size_t*>::const_type num_nodes_per_element;
     RowPtrType row_ptrs;
 
     KOKKOS_FUNCTION
     void operator()(int) const {
-        const auto num_elems = static_cast<int>(elem_indices.extent(0));
+        const auto num_elems = num_nodes_per_element.extent(0);
         auto rows_so_far = 0;
-        for (int i_elem = 0; i_elem < num_elems; ++i_elem) {
-            auto idx = elem_indices[i_elem];
-            auto num_nodes = idx.num_nodes;
+        for (auto i_elem = 0U; i_elem < num_elems; ++i_elem) {
+            auto num_nodes = num_nodes_per_element(i_elem);
             for (auto i = 0U; i < num_nodes * kLieAlgebraComponents; ++i) {
                 row_ptrs(rows_so_far + 1) =
                     row_ptrs(rows_so_far) +

--- a/src/restruct_poc/solver/solver.hpp
+++ b/src/restruct_poc/solver/solver.hpp
@@ -129,17 +129,18 @@ struct Solver {
         auto K_num_non_zero = size_t{0U};
         Kokkos::parallel_reduce(
             "ComputeNumberOfNonZeros", beams_.num_elems,
-            ComputeNumberOfNonZeros{beams_.elem_indices}, K_num_non_zero
+            ComputeNumberOfNonZeros{beams_.num_nodes_per_element}, K_num_non_zero
         );
         auto K_row_ptrs = RowPtrType("K_row_ptrs", K_num_rows + 1);
         auto K_col_inds = IndicesType("indices", K_num_non_zero);
         Kokkos::parallel_for(
             "PopulateSparseRowPtrs", 1,
-            PopulateSparseRowPtrs<RowPtrType>{beams_.elem_indices, K_row_ptrs}
+            PopulateSparseRowPtrs<RowPtrType>{beams_.num_nodes_per_element, K_row_ptrs}
         );
         Kokkos::parallel_for(
             "PopulateSparseIndices", 1,
-            PopulateSparseIndices{beams_.elem_indices, beams_.node_state_indices, K_col_inds}
+            PopulateSparseIndices{
+                beams_.num_nodes_per_element, beams_.node_state_indices, K_col_inds}
         );
 
         Kokkos::fence();

--- a/src/restruct_poc/system/assemble_inertia_matrix.hpp
+++ b/src/restruct_poc/system/assemble_inertia_matrix.hpp
@@ -21,8 +21,9 @@ inline void AssembleInertiaMatrix(
     Kokkos::parallel_for(
         "IntegrateInertiaMatrix", range_policy,
         IntegrateInertiaMatrix{
-            beams.elem_indices, beams.qp_weight, beams.qp_jacobian, beams.shape_interp, beams.qp_Muu,
-            beams.qp_Guu, beta_prime, gamma_prime, M}
+            beams.num_nodes_per_element, beams.num_qps_per_element, beams.qp_weight,
+            beams.qp_jacobian, beams.shape_interp, beams.qp_Muu, beams.qp_Guu, beta_prime,
+            gamma_prime, M}
     );
 }
 

--- a/src/restruct_poc/system/assemble_residual_vector.hpp
+++ b/src/restruct_poc/system/assemble_residual_vector.hpp
@@ -16,7 +16,7 @@ inline void AssembleResidualVector(const Beams& beams, const View_N& residual_ve
     Kokkos::parallel_for(
         "IntegrateResidualVector", range_policy,
         IntegrateResidualVector{
-            beams.elem_indices, beams.node_state_indices, beams.node_FE, beams.node_FI,
+            beams.num_nodes_per_element, beams.node_state_indices, beams.node_FE, beams.node_FI,
             beams.node_FG, beams.node_FX, residual_vector}
     );
 }

--- a/src/restruct_poc/system/assemble_stiffness_matrix.hpp
+++ b/src/restruct_poc/system/assemble_stiffness_matrix.hpp
@@ -20,7 +20,8 @@ inline void AssembleStiffnessMatrix(const Beams& beams, const Kokkos::View<doubl
     Kokkos::parallel_for(
         "IntegrateStiffnessMatrix", range_policy,
         IntegrateStiffnessMatrix{
-            beams.elem_indices,
+            beams.num_nodes_per_element,
+            beams.num_qps_per_element,
             beams.qp_weight,
             beams.qp_jacobian,
             beams.shape_interp,

--- a/src/restruct_poc/system/integrate_inertia_matrix.hpp
+++ b/src/restruct_poc/system/integrate_inertia_matrix.hpp
@@ -8,12 +8,10 @@
 namespace openturbine {
 
 struct IntegrateInertiaMatrixElement {
-    int i_elem;
+    size_t i_elem;
     size_t num_qps;
-    size_t first_node;
-    size_t first_qp;
-    View_N::const_type qp_weight_;
-    View_N::const_type qp_jacobian_;
+    Kokkos::View<double*>::const_type qp_weight_;
+    Kokkos::View<double*>::const_type qp_jacobian_;
     Kokkos::View<double**>::const_type shape_interp_;
     Kokkos::View<double* [6][6]>::const_type qp_Muu_;
     Kokkos::View<double* [6][6]>::const_type qp_Guu_;
@@ -47,9 +45,10 @@ struct IntegrateInertiaMatrixElement {
 };
 
 struct IntegrateInertiaMatrix {
-    Kokkos::View<Beams::ElemIndices*>::const_type elem_indices;
-    View_NxN::const_type qp_weight_;
-    View_NxN::const_type qp_jacobian_;
+    Kokkos::View<size_t*>::const_type num_nodes_per_element;
+    Kokkos::View<size_t*>::const_type num_qps_per_element;
+    Kokkos::View<double**>::const_type qp_weight_;
+    Kokkos::View<double**>::const_type qp_jacobian_;
     Kokkos::View<double***>::const_type shape_interp_;
     Kokkos::View<double** [6][6]>::const_type qp_Muu_;
     Kokkos::View<double** [6][6]>::const_type qp_Guu_;
@@ -59,19 +58,19 @@ struct IntegrateInertiaMatrix {
 
     KOKKOS_FUNCTION
     void operator()(const Kokkos::TeamPolicy<>::member_type& member) const {
-        const auto i_elem = member.league_rank();
-        const auto idx = elem_indices(i_elem);
-        const auto shape_interp =
-            Kokkos::View<double**>(member.team_scratch(1), idx.num_nodes, idx.num_qps);
+        const auto i_elem = static_cast<size_t>(member.league_rank());
+        const auto num_nodes = num_nodes_per_element(i_elem);
+        const auto num_qps = num_qps_per_element(i_elem);
+        const auto shape_interp = Kokkos::View<double**>(member.team_scratch(1), num_nodes, num_qps);
 
-        const auto qp_weight = Kokkos::View<double*>(member.team_scratch(1), idx.num_qps);
-        const auto qp_jacobian = Kokkos::View<double*>(member.team_scratch(1), idx.num_qps);
+        const auto qp_weight = Kokkos::View<double*>(member.team_scratch(1), num_qps);
+        const auto qp_jacobian = Kokkos::View<double*>(member.team_scratch(1), num_qps);
 
-        const auto qp_Muu = Kokkos::View<double* [6][6]>(member.team_scratch(1), idx.num_qps);
-        const auto qp_Guu = Kokkos::View<double* [6][6]>(member.team_scratch(1), idx.num_qps);
+        const auto qp_Muu = Kokkos::View<double* [6][6]>(member.team_scratch(1), num_qps);
+        const auto qp_Guu = Kokkos::View<double* [6][6]>(member.team_scratch(1), num_qps);
 
-        Kokkos::parallel_for(Kokkos::TeamThreadRange(member, idx.num_qps), [&](size_t k) {
-            for (auto i = 0U; i < idx.num_nodes; ++i) {
+        Kokkos::parallel_for(Kokkos::TeamThreadRange(member, num_qps), [&](size_t k) {
+            for (auto i = 0U; i < num_nodes; ++i) {
                 shape_interp(i, k) = shape_interp_(i_elem, i, k);
             }
             qp_weight(k) = qp_weight_(i_elem, k);
@@ -85,11 +84,10 @@ struct IntegrateInertiaMatrix {
         });
         member.team_barrier();
 
-        const auto node_range = Kokkos::TeamThreadMDRange(member, idx.num_nodes, idx.num_nodes);
-        const auto element_integrator = IntegrateInertiaMatrixElement{
-            i_elem,    idx.num_qps, idx.node_range.first, idx.qp_range.first,
-            qp_weight, qp_jacobian, shape_interp,         qp_Muu,
-            qp_Guu,    beta_prime_, gamma_prime_,         gbl_M_};
+        const auto node_range = Kokkos::TeamThreadMDRange(member, num_nodes, num_nodes);
+        const auto element_integrator =
+            IntegrateInertiaMatrixElement{i_elem, num_qps, qp_weight,   qp_jacobian,  shape_interp,
+                                          qp_Muu, qp_Guu,  beta_prime_, gamma_prime_, gbl_M_};
         Kokkos::parallel_for(node_range, element_integrator);
     }
 };

--- a/src/restruct_poc/system/integrate_residual_vector.hpp
+++ b/src/restruct_poc/system/integrate_residual_vector.hpp
@@ -27,7 +27,7 @@ struct IntegrateResidualVectorElement {
 };
 
 struct IntegrateResidualVector {
-    Kokkos::View<Beams::ElemIndices*>::const_type elem_indices;
+    Kokkos::View<size_t*>::const_type num_nodes_per_element;
     Kokkos::View<size_t**>::const_type node_state_indices_;
     Kokkos::View<double** [6]>::const_type node_FE_;  // Elastic force
     Kokkos::View<double** [6]>::const_type node_FI_;  // Inertial force
@@ -37,10 +37,10 @@ struct IntegrateResidualVector {
 
     KOKKOS_FUNCTION void operator()(const Kokkos::TeamPolicy<>::member_type& member) const {
         const auto i_elem = static_cast<size_t>(member.league_rank());
-        const auto idx = elem_indices(i_elem);
+        const auto num_nodes = num_nodes_per_element(i_elem);
 
         Kokkos::parallel_for(
-            Kokkos::TeamThreadRange(member, idx.num_nodes),
+            Kokkos::TeamThreadRange(member, num_nodes),
             IntegrateResidualVectorElement{
                 i_elem, node_state_indices_, node_FE_, node_FI_, node_FG_, node_FX_,
                 residual_vector_}

--- a/src/restruct_poc/system/integrate_stiffness_matrix.hpp
+++ b/src/restruct_poc/system/integrate_stiffness_matrix.hpp
@@ -7,12 +7,10 @@
 
 namespace openturbine {
 struct IntegrateStiffnessMatrixElement {
-    int i_elem;
+    size_t i_elem;
     size_t num_qps;
-    size_t first_node;
-    size_t first_qp;
-    View_N::const_type qp_weight_;
-    View_N::const_type qp_jacobian_;
+    Kokkos::View<double*>::const_type qp_weight_;
+    Kokkos::View<double*>::const_type qp_jacobian_;
     Kokkos::View<double**>::const_type shape_interp_;
     Kokkos::View<double**>::const_type shape_deriv_;
     Kokkos::View<double* [6][6]>::const_type qp_Kuu_;
@@ -54,9 +52,10 @@ struct IntegrateStiffnessMatrixElement {
 };
 
 struct IntegrateStiffnessMatrix {
-    Kokkos::View<Beams::ElemIndices*>::const_type elem_indices;
-    View_NxN::const_type qp_weight_;
-    View_NxN::const_type qp_jacobian_;
+    Kokkos::View<size_t*>::const_type num_nodes_per_element;
+    Kokkos::View<size_t*>::const_type num_qps_per_element;
+    Kokkos::View<double**>::const_type qp_weight_;
+    Kokkos::View<double**>::const_type qp_jacobian_;
     Kokkos::View<double***>::const_type shape_interp_;
     Kokkos::View<double***>::const_type shape_deriv_;
     Kokkos::View<double** [6][6]>::const_type qp_Kuu_;
@@ -68,25 +67,24 @@ struct IntegrateStiffnessMatrix {
 
     KOKKOS_FUNCTION
     void operator()(Kokkos::TeamPolicy<>::member_type member) const {
-        const auto i_elem = member.league_rank();
-        const auto idx = elem_indices(i_elem);
+        const auto i_elem = static_cast<size_t>(member.league_rank());
+        const auto num_nodes = num_nodes_per_element(i_elem);
+        const auto num_qps = num_qps_per_element(i_elem);
 
-        const auto shape_interp =
-            Kokkos::View<double**>(member.team_scratch(1), idx.num_nodes, idx.num_qps);
-        const auto shape_deriv =
-            Kokkos::View<double**>(member.team_scratch(1), idx.num_nodes, idx.num_qps);
+        const auto shape_interp = Kokkos::View<double**>(member.team_scratch(1), num_nodes, num_qps);
+        const auto shape_deriv = Kokkos::View<double**>(member.team_scratch(1), num_nodes, num_qps);
 
-        const auto qp_weight = Kokkos::View<double*>(member.team_scratch(1), idx.num_qps);
-        const auto qp_jacobian = Kokkos::View<double*>(member.team_scratch(1), idx.num_qps);
+        const auto qp_weight = Kokkos::View<double*>(member.team_scratch(1), num_qps);
+        const auto qp_jacobian = Kokkos::View<double*>(member.team_scratch(1), num_qps);
 
-        const auto qp_Kuu = Kokkos::View<double* [6][6]>(member.team_scratch(1), idx.num_qps);
-        const auto qp_Puu = Kokkos::View<double* [6][6]>(member.team_scratch(1), idx.num_qps);
-        const auto qp_Cuu = Kokkos::View<double* [6][6]>(member.team_scratch(1), idx.num_qps);
-        const auto qp_Ouu = Kokkos::View<double* [6][6]>(member.team_scratch(1), idx.num_qps);
-        const auto qp_Quu = Kokkos::View<double* [6][6]>(member.team_scratch(1), idx.num_qps);
+        const auto qp_Kuu = Kokkos::View<double* [6][6]>(member.team_scratch(1), num_qps);
+        const auto qp_Puu = Kokkos::View<double* [6][6]>(member.team_scratch(1), num_qps);
+        const auto qp_Cuu = Kokkos::View<double* [6][6]>(member.team_scratch(1), num_qps);
+        const auto qp_Ouu = Kokkos::View<double* [6][6]>(member.team_scratch(1), num_qps);
+        const auto qp_Quu = Kokkos::View<double* [6][6]>(member.team_scratch(1), num_qps);
 
-        Kokkos::parallel_for(Kokkos::TeamThreadRange(member, idx.num_qps), [&](size_t k) {
-            for (auto i = 0U; i < idx.num_nodes; ++i) {
+        Kokkos::parallel_for(Kokkos::TeamThreadRange(member, num_qps), [&](size_t k) {
+            for (auto i = 0U; i < num_nodes; ++i) {
                 shape_interp(i, k) = shape_interp_(i_elem, i, k);
                 shape_deriv(i, k) = shape_deriv_(i_elem, i, k);
             }
@@ -104,22 +102,10 @@ struct IntegrateStiffnessMatrix {
         });
         member.team_barrier();
 
-        const auto node_range = Kokkos::TeamThreadMDRange(member, idx.num_nodes, idx.num_nodes);
+        const auto node_range = Kokkos::TeamThreadMDRange(member, num_nodes, num_nodes);
         const auto element_integrator = IntegrateStiffnessMatrixElement{
-            i_elem,
-            idx.num_qps,
-            idx.node_range.first,
-            idx.qp_range.first,
-            qp_weight,
-            qp_jacobian,
-            shape_interp,
-            shape_deriv,
-            qp_Kuu,
-            qp_Puu,
-            qp_Cuu,
-            qp_Ouu,
-            qp_Quu,
-            gbl_M_};
+            i_elem, num_qps, qp_weight, qp_jacobian, shape_interp, shape_deriv,
+            qp_Kuu, qp_Puu,  qp_Cuu,    qp_Ouu,      qp_Quu,       gbl_M_};
         Kokkos::parallel_for(node_range, element_integrator);
     }
 };

--- a/src/restruct_poc/system/update_node_state.hpp
+++ b/src/restruct_poc/system/update_node_state.hpp
@@ -32,7 +32,7 @@ struct UpdateNodeStateElement {
 };
 
 struct UpdateNodeState {
-    Kokkos::View<Beams::ElemIndices*>::const_type elem_indices;
+    Kokkos::View<size_t*>::const_type num_nodes_per_element;
     Kokkos::View<size_t**>::const_type node_state_indices;
     Kokkos::View<double** [7]> node_u;
     Kokkos::View<double** [6]> node_u_dot;
@@ -45,10 +45,10 @@ struct UpdateNodeState {
     KOKKOS_FUNCTION
     void operator()(const Kokkos::TeamPolicy<>::member_type& member) const {
         const auto i_elem = static_cast<size_t>(member.league_rank());
-        const auto idx = elem_indices(i_elem);
+        const auto num_nodes = num_nodes_per_element(i_elem);
 
         Kokkos::parallel_for(
-            Kokkos::TeamThreadRange(member, idx.num_nodes),
+            Kokkos::TeamThreadRange(member, num_nodes),
             UpdateNodeStateElement{
                 i_elem, node_state_indices, node_u, node_u_dot, node_u_ddot, Q, V, A}
         );

--- a/src/restruct_poc/system/update_state.hpp
+++ b/src/restruct_poc/system/update_state.hpp
@@ -21,7 +21,7 @@ inline void UpdateState(
     Kokkos::parallel_for(
         "UpdateNodeState", range_policy,
         UpdateNodeState{
-            beams.elem_indices,
+            beams.num_nodes_per_element,
             beams.node_state_indices,
             beams.node_u,
             beams.node_u_dot,
@@ -35,39 +35,56 @@ inline void UpdateState(
     Kokkos::parallel_for(
         "InterpolateToQuadraturePoints", range_policy,
         InterpolateToQuadraturePoints{
-            beams.elem_indices, beams.shape_interp, beams.shape_deriv, beams.qp_jacobian,
-            beams.node_u, beams.node_u_dot, beams.node_u_ddot, beams.qp_u, beams.qp_u_prime,
-            beams.qp_r, beams.qp_r_prime, beams.qp_u_dot, beams.qp_omega, beams.qp_u_ddot,
-            beams.qp_omega_dot}
+            beams.num_nodes_per_element, beams.num_qps_per_element, beams.shape_interp,
+            beams.shape_deriv, beams.qp_jacobian, beams.node_u, beams.node_u_dot, beams.node_u_ddot,
+            beams.qp_u, beams.qp_u_prime, beams.qp_r, beams.qp_r_prime, beams.qp_u_dot,
+            beams.qp_omega, beams.qp_u_ddot, beams.qp_omega_dot}
     );
 
     Kokkos::parallel_for(
         "CalculateQuadraturePointValues", range_policy,
-        CalculateQuadraturePointValues{beams.elem_indices,   beams.gravity,
-                                       beams.qp_u_prime,     beams.qp_r,
-                                       beams.qp_r_prime,     beams.qp_r0,
-                                       beams.qp_x0_prime,    beams.qp_u_ddot,
-                                       beams.qp_omega,       beams.qp_omega_dot,
-                                       beams.qp_Mstar,       beams.qp_Cstar,
-                                       beams.qp_RR0,         beams.qp_strain,
-                                       beams.qp_eta,         beams.qp_rho,
-                                       beams.qp_eta_tilde,   beams.qp_x0pupss,
-                                       beams.qp_M_tilde,     beams.qp_N_tilde,
-                                       beams.qp_omega_tilde, beams.qp_omega_dot_tilde,
-                                       beams.qp_Fc,          beams.qp_Fd,
-                                       beams.qp_Fi,          beams.qp_Fg,
-                                       beams.qp_Muu,         beams.qp_Cuu,
-                                       beams.qp_Ouu,         beams.qp_Puu,
-                                       beams.qp_Quu,         beams.qp_Guu,
-                                       beams.qp_Kuu}
+        CalculateQuadraturePointValues{
+            beams.num_qps_per_element,
+            beams.gravity,
+            beams.qp_u_prime,
+            beams.qp_r,
+            beams.qp_r_prime,
+            beams.qp_r0,
+            beams.qp_x0_prime,
+            beams.qp_u_ddot,
+            beams.qp_omega,
+            beams.qp_omega_dot,
+            beams.qp_Mstar,
+            beams.qp_Cstar,
+            beams.qp_RR0,
+            beams.qp_strain,
+            beams.qp_eta,
+            beams.qp_rho,
+            beams.qp_eta_tilde,
+            beams.qp_x0pupss,
+            beams.qp_M_tilde,
+            beams.qp_N_tilde,
+            beams.qp_omega_tilde,
+            beams.qp_omega_dot_tilde,
+            beams.qp_Fc,
+            beams.qp_Fd,
+            beams.qp_Fi,
+            beams.qp_Fg,
+            beams.qp_Muu,
+            beams.qp_Cuu,
+            beams.qp_Ouu,
+            beams.qp_Puu,
+            beams.qp_Quu,
+            beams.qp_Guu,
+            beams.qp_Kuu}
     );
 
     Kokkos::parallel_for(
         "CalculateNodeForces", range_policy,
         CalculateNodeForces{
-            beams.elem_indices, beams.qp_weight, beams.qp_jacobian, beams.shape_interp,
-            beams.shape_deriv, beams.qp_Fc, beams.qp_Fd, beams.qp_Fi, beams.qp_Fg, beams.node_FE,
-            beams.node_FI, beams.node_FG}
+            beams.num_nodes_per_element, beams.num_qps_per_element, beams.qp_weight,
+            beams.qp_jacobian, beams.shape_interp, beams.shape_deriv, beams.qp_Fc, beams.qp_Fd,
+            beams.qp_Fi, beams.qp_Fg, beams.node_FE, beams.node_FI, beams.node_FG}
     );
 }
 

--- a/tests/unit_tests/restruct_poc/beams/test_interpolate_QP_state.cpp
+++ b/tests/unit_tests/restruct_poc/beams/test_interpolate_QP_state.cpp
@@ -21,16 +21,12 @@ inline auto create_node_u_OneNode() {
 }
 
 TEST(InterpolateQPStateTests, u_OneNodeOneQP) {
-    constexpr auto first_qp = 0;
-    constexpr auto num_qp = 1;
-    constexpr auto first_node = 0;
-    constexpr auto num_nodes = 1;
+    constexpr auto num_qp = size_t{1U};
+    constexpr auto num_nodes = size_t{1U};
     auto shape_interp = create_shape_interp_OneNodeOneQP();
     auto node_u = create_node_u_OneNode();
     auto qp_u = Kokkos::View<double[1][num_qp][3]>("qp_u");
-    Kokkos::parallel_for(
-        num_qp, InterpolateQPState_u{0, first_qp, first_node, num_nodes, shape_interp, node_u, qp_u}
-    );
+    Kokkos::parallel_for(num_qp, InterpolateQPState_u{0U, num_nodes, shape_interp, node_u, qp_u});
     auto qp_u_mirror = Kokkos::create_mirror(qp_u);
     Kokkos::deep_copy(qp_u_mirror, qp_u);
     constexpr auto tolerance = 1.e-16;
@@ -40,18 +36,14 @@ TEST(InterpolateQPStateTests, u_OneNodeOneQP) {
 }
 
 TEST(InterpolateQPStateTests, uprime_OneNodeOneQP) {
-    constexpr auto first_qp = 0;
-    constexpr auto num_qp = 1;
-    constexpr auto first_node = 0;
-    constexpr auto num_nodes = 1;
+    constexpr auto num_qp = size_t{1U};
+    constexpr auto num_nodes = size_t{1U};
     auto shape_deriv = create_shape_deriv_OneNodeOneQP();
     auto jacobian = create_jacobian_OneQP();
     auto node_u = create_node_u_OneNode();
     auto qp_uprime = Kokkos::View<double[1][num_qp][3]>("qp_uprime");
     Kokkos::parallel_for(
-        num_qp,
-        InterpolateQPState_uprime{
-            0, first_qp, first_node, num_nodes, shape_deriv, jacobian, node_u, qp_uprime}
+        num_qp, InterpolateQPState_uprime{0, num_nodes, shape_deriv, jacobian, node_u, qp_uprime}
     );
     auto qp_uprime_mirror = Kokkos::create_mirror(qp_uprime);
     Kokkos::deep_copy(qp_uprime_mirror, qp_uprime);
@@ -62,16 +54,12 @@ TEST(InterpolateQPStateTests, uprime_OneNodeOneQP) {
 }
 
 TEST(InterpolateQPStateTests, r_OneNodeOneQP) {
-    constexpr auto first_qp = 0;
-    constexpr auto num_qp = 1;
-    constexpr auto first_node = 0;
-    constexpr auto num_nodes = 1;
+    constexpr auto num_qp = size_t{1U};
+    constexpr auto num_nodes = size_t{1U};
     auto shape_interp = create_shape_interp_OneNodeOneQP();
     auto node_u = create_node_u_OneNode();
     auto qp_r = Kokkos::View<double[1][num_qp][4]>("qp_r");
-    Kokkos::parallel_for(
-        num_qp, InterpolateQPState_r{0, first_qp, first_node, num_nodes, shape_interp, node_u, qp_r}
-    );
+    Kokkos::parallel_for(num_qp, InterpolateQPState_r{0, num_nodes, shape_interp, node_u, qp_r});
     auto qp_r_mirror = Kokkos::create_mirror(qp_r);
     Kokkos::deep_copy(qp_r_mirror, qp_r);
     constexpr auto tolerance = 1.e-16;
@@ -82,18 +70,14 @@ TEST(InterpolateQPStateTests, r_OneNodeOneQP) {
 }
 
 TEST(InterpolateQPStateTests, rprime_OneNodeOneQP) {
-    constexpr auto first_qp = 0;
-    constexpr auto num_qp = 1;
-    constexpr auto first_node = 0;
-    constexpr auto num_nodes = 1;
+    constexpr auto num_qp = size_t{1U};
+    constexpr auto num_nodes = size_t{1U};
     auto shape_deriv = create_shape_deriv_OneNodeOneQP();
     auto jacobian = create_jacobian_OneQP();
     auto node_u = create_node_u_OneNode();
     auto qp_rprime = Kokkos::View<double[1][num_qp][4]>("qp_uprime");
     Kokkos::parallel_for(
-        num_qp,
-        InterpolateQPState_rprime{
-            0, first_qp, first_node, num_nodes, shape_deriv, jacobian, node_u, qp_rprime}
+        num_qp, InterpolateQPState_rprime{0, num_nodes, shape_deriv, jacobian, node_u, qp_rprime}
     );
     auto qp_rprime_mirror = Kokkos::create_mirror(qp_rprime);
     Kokkos::deep_copy(qp_rprime_mirror, qp_rprime);
@@ -105,16 +89,12 @@ TEST(InterpolateQPStateTests, rprime_OneNodeOneQP) {
 }
 
 TEST(InterpolateQPStateTests, u_OneNodeTwoQP) {
-    constexpr auto first_qp = 0;
-    constexpr auto num_qp = 2;
-    constexpr auto first_node = 0;
-    constexpr auto num_nodes = 1;
+    constexpr auto num_qp = size_t{2U};
+    constexpr auto num_nodes = size_t{1U};
     auto shape_interp = create_shape_interp_OneNodeTwoQP();
     auto node_u = create_node_u_OneNode();
     auto qp_u = Kokkos::View<double[1][num_qp][3]>("qp_u");
-    Kokkos::parallel_for(
-        num_qp, InterpolateQPState_u{0, first_qp, first_node, num_nodes, shape_interp, node_u, qp_u}
-    );
+    Kokkos::parallel_for(num_qp, InterpolateQPState_u{0U, num_nodes, shape_interp, node_u, qp_u});
     auto qp_u_mirror = Kokkos::create_mirror(qp_u);
     Kokkos::deep_copy(qp_u_mirror, qp_u);
     constexpr auto tolerance = 1.e-16;
@@ -128,18 +108,14 @@ TEST(InterpolateQPStateTests, u_OneNodeTwoQP) {
 }
 
 TEST(InterpolateQPStateTests, uprime_OneNodeTwoQP) {
-    constexpr auto first_qp = 0;
-    constexpr auto num_qp = 2;
-    constexpr auto first_node = 0;
-    constexpr auto num_nodes = 1;
+    constexpr auto num_qp = size_t{2U};
+    constexpr auto num_nodes = size_t{1U};
     auto shape_deriv = create_shape_deriv_OneNodeTwoQP();
     auto jacobian = create_jacobian_TwoQP();
     auto node_u = create_node_u_OneNode();
     auto qp_uprime = Kokkos::View<double[1][num_qp][3]>("qp_uprime");
     Kokkos::parallel_for(
-        num_qp,
-        InterpolateQPState_uprime{
-            0, first_qp, first_node, num_nodes, shape_deriv, jacobian, node_u, qp_uprime}
+        num_qp, InterpolateQPState_uprime{0U, num_nodes, shape_deriv, jacobian, node_u, qp_uprime}
     );
     auto qp_uprime_mirror = Kokkos::create_mirror(qp_uprime);
     Kokkos::deep_copy(qp_uprime_mirror, qp_uprime);
@@ -154,16 +130,12 @@ TEST(InterpolateQPStateTests, uprime_OneNodeTwoQP) {
 }
 
 TEST(InterpolateQPStateTests, r_OneNodeTwoQP) {
-    constexpr auto first_qp = 0;
-    constexpr auto num_qp = 2;
-    constexpr auto first_node = 0;
-    constexpr auto num_nodes = 1;
+    constexpr auto num_qp = size_t{2U};
+    constexpr auto num_nodes = size_t{1U};
     auto shape_interp = create_shape_interp_OneNodeTwoQP();
     auto node_u = create_node_u_OneNode();
     auto qp_r = Kokkos::View<double[1][num_qp][4]>("qp_r");
-    Kokkos::parallel_for(
-        num_qp, InterpolateQPState_r{0, first_qp, first_node, num_nodes, shape_interp, node_u, qp_r}
-    );
+    Kokkos::parallel_for(num_qp, InterpolateQPState_r{0, num_nodes, shape_interp, node_u, qp_r});
     auto qp_r_mirror = Kokkos::create_mirror(qp_r);
     Kokkos::deep_copy(qp_r_mirror, qp_r);
     constexpr auto tolerance = 1.e-16;
@@ -179,18 +151,14 @@ TEST(InterpolateQPStateTests, r_OneNodeTwoQP) {
 }
 
 TEST(InterpolateQPStateTests, rprime_OneNodeTwoQP) {
-    constexpr auto first_qp = 0;
-    constexpr auto num_qp = 2;
-    constexpr auto first_node = 0;
-    constexpr auto num_nodes = 1;
+    constexpr auto num_qp = size_t{2U};
+    constexpr auto num_nodes = size_t{1U};
     auto shape_deriv = create_shape_deriv_OneNodeTwoQP();
     auto jacobian = create_jacobian_TwoQP();
     auto node_u = create_node_u_OneNode();
     auto qp_rprime = Kokkos::View<double[1][num_qp][4]>("qp_uprime");
     Kokkos::parallel_for(
-        num_qp,
-        InterpolateQPState_rprime{
-            0, first_qp, first_node, num_nodes, shape_deriv, jacobian, node_u, qp_rprime}
+        num_qp, InterpolateQPState_rprime{0U, num_nodes, shape_deriv, jacobian, node_u, qp_rprime}
     );
     auto qp_rprime_mirror = Kokkos::create_mirror(qp_rprime);
     Kokkos::deep_copy(qp_rprime_mirror, qp_rprime);
@@ -221,16 +189,12 @@ inline auto create_node_u_TwoNode() {
 }
 
 TEST(InterpolateQPStateTests, u_TwoNodeTwoQP) {
-    constexpr auto first_qp = 0;
-    constexpr auto num_qp = 2;
-    constexpr auto first_node = 0;
-    constexpr auto num_nodes = 2;
+    constexpr auto num_qp = size_t{2U};
+    constexpr auto num_nodes = size_t{2U};
     auto shape_interp = create_shape_interp_TwoNodeTwoQP();
     auto node_u = create_node_u_TwoNode();
     auto qp_u = Kokkos::View<double[1][num_qp][3]>("qp_u");
-    Kokkos::parallel_for(
-        num_qp, InterpolateQPState_u{0, first_qp, first_node, num_nodes, shape_interp, node_u, qp_u}
-    );
+    Kokkos::parallel_for(num_qp, InterpolateQPState_u{0, num_nodes, shape_interp, node_u, qp_u});
     auto qp_u_mirror = Kokkos::create_mirror(qp_u);
     Kokkos::deep_copy(qp_u_mirror, qp_u);
     constexpr auto tolerance = 1.e-16;
@@ -244,18 +208,14 @@ TEST(InterpolateQPStateTests, u_TwoNodeTwoQP) {
 }
 
 TEST(InterpolateQPStateTests, uprime_TwoNodeTwoQP) {
-    constexpr auto first_qp = 0;
-    constexpr auto num_qp = 2;
-    constexpr auto first_node = 0;
-    constexpr auto num_nodes = 2;
+    constexpr auto num_qp = size_t{2U};
+    constexpr auto num_nodes = size_t{2U};
     auto shape_deriv = create_shape_deriv_TwoNodeTwoQP();
     auto jacobian = create_jacobian_TwoQP();
     auto node_u = create_node_u_TwoNode();
     auto qp_uprime = Kokkos::View<double[1][num_qp][3]>("qp_uprime");
     Kokkos::parallel_for(
-        num_qp,
-        InterpolateQPState_uprime{
-            0, first_qp, first_node, num_nodes, shape_deriv, jacobian, node_u, qp_uprime}
+        num_qp, InterpolateQPState_uprime{0, num_nodes, shape_deriv, jacobian, node_u, qp_uprime}
     );
     auto qp_uprime_mirror = Kokkos::create_mirror(qp_uprime);
     Kokkos::deep_copy(qp_uprime_mirror, qp_uprime);
@@ -270,16 +230,12 @@ TEST(InterpolateQPStateTests, uprime_TwoNodeTwoQP) {
 }
 
 TEST(InterpolateQPStateTests, r_TwoNodeTwoQP) {
-    constexpr auto first_qp = 0;
-    constexpr auto num_qp = 2;
-    constexpr auto first_node = 0;
-    constexpr auto num_nodes = 2;
+    constexpr auto num_qp = size_t{2U};
+    constexpr auto num_nodes = size_t{2U};
     auto shape_interp = create_shape_interp_TwoNodeTwoQP();
     auto node_u = create_node_u_TwoNode();
     auto qp_r = Kokkos::View<double[1][num_qp][4]>("qp_r");
-    Kokkos::parallel_for(
-        num_qp, InterpolateQPState_r{0, first_qp, first_node, num_nodes, shape_interp, node_u, qp_r}
-    );
+    Kokkos::parallel_for(num_qp, InterpolateQPState_r{0, num_nodes, shape_interp, node_u, qp_r});
     auto qp_r_mirror = Kokkos::create_mirror(qp_r);
     Kokkos::deep_copy(qp_r_mirror, qp_r);
     constexpr auto tolerance = 1.e-16;
@@ -295,18 +251,14 @@ TEST(InterpolateQPStateTests, r_TwoNodeTwoQP) {
 }
 
 TEST(InterpolateQPStateTests, rprime_TwoNodeTwoQP) {
-    constexpr auto first_qp = 0;
-    constexpr auto num_qp = 2;
-    constexpr auto first_node = 0;
-    constexpr auto num_nodes = 2;
+    constexpr auto num_qp = size_t{2U};
+    constexpr auto num_nodes = size_t{2U};
     auto shape_deriv = create_shape_deriv_TwoNodeTwoQP();
     auto jacobian = create_jacobian_TwoQP();
     auto node_u = create_node_u_TwoNode();
     auto qp_rprime = Kokkos::View<double[1][num_qp][4]>("qp_uprime");
     Kokkos::parallel_for(
-        num_qp,
-        InterpolateQPState_rprime{
-            0, first_qp, first_node, num_nodes, shape_deriv, jacobian, node_u, qp_rprime}
+        num_qp, InterpolateQPState_rprime{0U, num_nodes, shape_deriv, jacobian, node_u, qp_rprime}
     );
     auto qp_rprime_mirror = Kokkos::create_mirror(qp_rprime);
     Kokkos::deep_copy(qp_rprime_mirror, qp_rprime);

--- a/tests/unit_tests/restruct_poc/beams/test_interpolate_QP_vector.cpp
+++ b/tests/unit_tests/restruct_poc/beams/test_interpolate_QP_vector.cpp
@@ -8,7 +8,7 @@
 namespace openturbine::tests {
 
 inline auto create_node_u_dot_OneNode() {
-    constexpr auto num_nodes = 1;
+    constexpr auto num_nodes = size_t{1U};
     constexpr auto num_entries = num_nodes * 6;
     auto node_u = Kokkos::View<double[1][num_nodes][6]>("node_u_dot");
     auto node_u_mirror = Kokkos::create_mirror(node_u);
@@ -21,17 +21,15 @@ inline auto create_node_u_dot_OneNode() {
 }
 
 TEST(InterpolateQPVectorTests, OneNodeOneQP) {
-    constexpr auto first_qp = 0;
-    constexpr auto num_qp = 1;
-    constexpr auto first_node = 0;
-    constexpr auto num_nodes = 1;
+    constexpr auto num_qp = size_t{1U};
+    constexpr auto num_nodes = size_t{1U};
     auto shape_interp = create_shape_interp_OneNodeOneQP();
     auto node_u_dot = create_node_u_dot_OneNode();
     auto qp_u_dot = Kokkos::View<double[1][num_qp][3]>("qp_u_dot");
     Kokkos::parallel_for(
         num_qp,
         InterpolateQPVector{
-            0, first_qp, first_node, num_nodes, shape_interp,
+            0U, num_nodes, shape_interp,
             Kokkos::subview(node_u_dot, Kokkos::ALL, Kokkos::ALL, Kokkos::pair(0, 3)), qp_u_dot}
     );
     auto qp_u_dot_mirror = Kokkos::create_mirror(qp_u_dot);
@@ -43,17 +41,15 @@ TEST(InterpolateQPVectorTests, OneNodeOneQP) {
 }
 
 TEST(InterpolateQPVectorTests, OneNodeTwoQP) {
-    constexpr auto first_qp = 0;
-    constexpr auto num_qp = 2;
-    constexpr auto first_node = 0;
-    constexpr auto num_nodes = 1;
+    constexpr auto num_qp = size_t{2U};
+    constexpr auto num_nodes = size_t{1U};
     auto shape_interp = create_shape_interp_OneNodeTwoQP();
     auto node_u_dot = create_node_u_dot_OneNode();
     auto qp_u_dot = Kokkos::View<double[1][num_qp][3]>("qp_u_dot");
     Kokkos::parallel_for(
         num_qp,
         InterpolateQPVector{
-            0, first_qp, first_node, num_nodes, shape_interp,
+            0, num_nodes, shape_interp,
             Kokkos::subview(node_u_dot, Kokkos::ALL, Kokkos::ALL, Kokkos::pair(0, 3)), qp_u_dot}
     );
     auto qp_u_dot_mirror = Kokkos::create_mirror(qp_u_dot);
@@ -84,17 +80,15 @@ inline auto create_node_u_dot_TwoNode() {
 }
 
 TEST(InterpolateQPVectorTests, TwoNodeTwoQP) {
-    constexpr auto first_qp = 0;
-    constexpr auto num_qp = 2;
-    constexpr auto first_node = 0;
-    constexpr auto num_nodes = 2;
+    constexpr auto num_qp = size_t{2U};
+    constexpr auto num_nodes = size_t{2U};
     auto shape_interp = create_shape_interp_TwoNodeTwoQP();
     auto node_u_dot = create_node_u_dot_TwoNode();
     auto qp_u_dot = Kokkos::View<double[1][num_qp][3]>("qp_u_dot");
     Kokkos::parallel_for(
         num_qp,
         InterpolateQPVector{
-            0, first_qp, first_node, num_nodes, shape_interp,
+            0U, num_nodes, shape_interp,
             Kokkos::subview(node_u_dot, Kokkos::ALL, Kokkos::ALL, Kokkos::pair(0, 3)), qp_u_dot}
     );
     auto qp_u_dot_mirror = Kokkos::create_mirror(qp_u_dot);

--- a/tests/unit_tests/restruct_poc/solver/test_compute_number_of_non_zeros.cpp
+++ b/tests/unit_tests/restruct_poc/solver/test_compute_number_of_non_zeros.cpp
@@ -6,31 +6,29 @@
 namespace openturbine::tests {
 
 TEST(ComputeNumberOfNonZeros, SingleElement) {
-    auto elem_indices_host =
-        Kokkos::View<Beams::ElemIndices[1], Kokkos::HostSpace>("elem_indices_host");
-    auto elem_indices = Kokkos::View<Beams::ElemIndices[1]>("elem_indices");
+    auto num_nodes = Kokkos::View<size_t[1]>("num_nodes");
+    auto num_nodes_host = Kokkos::create_mirror(num_nodes);
+    num_nodes_host(0) = size_t{5U};
+    Kokkos::deep_copy(num_nodes, num_nodes_host);
 
-    elem_indices_host(0).num_nodes = 5;
-    Kokkos::deep_copy(elem_indices, elem_indices_host);
     auto num_non_zero = size_t{0U};
-    Kokkos::parallel_reduce(1, ComputeNumberOfNonZeros{elem_indices}, num_non_zero);
+    Kokkos::parallel_reduce(1, ComputeNumberOfNonZeros{num_nodes}, num_non_zero);
     constexpr auto num_dof = 5 * 6;
     constexpr auto expected_num_non_zero = num_dof * num_dof;
     EXPECT_EQ(num_non_zero, expected_num_non_zero);
 }
 
 TEST(ComputeNumberOfNonZeros, TwoElements) {
-    auto elem_indices_host =
-        Kokkos::View<Beams::ElemIndices[2], Kokkos::HostSpace>("elem_indices_host");
-    auto elem_indices = Kokkos::View<Beams::ElemIndices[2]>("elem_indices");
+    auto num_nodes = Kokkos::View<size_t[2]>("num_nodes");
+    auto num_nodes_host = Kokkos::create_mirror(num_nodes);
+    num_nodes_host(0) = size_t{5U};
+    num_nodes_host(1) = size_t{3U};
+    Kokkos::deep_copy(num_nodes, num_nodes_host);
 
-    elem_indices_host(0).num_nodes = 5;
-    elem_indices_host(1).num_nodes = 3;
-    Kokkos::deep_copy(elem_indices, elem_indices_host);
     auto num_non_zero = size_t{0U};
-    Kokkos::parallel_reduce(2, ComputeNumberOfNonZeros{elem_indices}, num_non_zero);
-    constexpr auto num_dof_elem1 = 5 * 6;
-    constexpr auto num_dof_elem2 = 3 * 6;
+    Kokkos::parallel_reduce(2, ComputeNumberOfNonZeros{num_nodes}, num_non_zero);
+    constexpr auto num_dof_elem1 = 5U * 6U;
+    constexpr auto num_dof_elem2 = 3U * 6U;
     constexpr auto expected_num_non_zero =
         num_dof_elem1 * num_dof_elem1 + num_dof_elem2 * num_dof_elem2;
     EXPECT_EQ(num_non_zero, expected_num_non_zero);

--- a/tests/unit_tests/restruct_poc/solver/test_populate_sparse_indices.cpp
+++ b/tests/unit_tests/restruct_poc/solver/test_populate_sparse_indices.cpp
@@ -6,15 +6,13 @@
 namespace openturbine::tests {
 
 TEST(PopulateSparseIndices, SingleElement) {
-    constexpr auto num_nodes = 5;
-    constexpr auto num_dof = num_nodes * 6;
+    constexpr auto num_nodes = size_t{5U};
+    constexpr auto num_dof = num_nodes * 6U;
 
-    auto elem_indices_host =
-        Kokkos::View<Beams::ElemIndices[1], Kokkos::HostSpace>("elem_indices_host");
-    auto elem_indices = Kokkos::View<Beams::ElemIndices[1]>("elem_indices");
-    elem_indices_host(0).num_nodes = num_nodes;
-    elem_indices_host(0).node_range.first = 0;
-    Kokkos::deep_copy(elem_indices, elem_indices_host);
+    auto num_nodes_per_element = Kokkos::View<size_t[1]>("num_nodes_per_element");
+    auto num_nodes_per_element_host = Kokkos::create_mirror(num_nodes_per_element);
+    num_nodes_per_element_host(0) = num_nodes;
+    Kokkos::deep_copy(num_nodes_per_element, num_nodes_per_element_host);
 
     auto node_state_indices = Kokkos::View<size_t[1][num_nodes]>("node_state_indices");
     auto node_state_indices_host_data = std::array<size_t, num_nodes>{0U, 1U, 2U, 3U, 4U};
@@ -25,12 +23,14 @@ TEST(PopulateSparseIndices, SingleElement) {
     Kokkos::deep_copy(node_state_indices, node_state_indices_mirror);
     auto indices = Kokkos::View<int[num_dof * num_dof]>("indices");
 
-    Kokkos::parallel_for(1, PopulateSparseIndices{elem_indices, node_state_indices, indices});
+    Kokkos::parallel_for(
+        1, PopulateSparseIndices{num_nodes_per_element, node_state_indices, indices}
+    );
 
     auto indices_host = Kokkos::create_mirror(indices);
     Kokkos::deep_copy(indices_host, indices);
-    for (int row = 0; row < num_dof; ++row) {
-        for (int column = 0; column < num_dof; ++column) {
+    for (auto row = 0U; row < num_dof; ++row) {
+        for (auto column = 0U; column < num_dof; ++column) {
             ASSERT_EQ(indices_host(row * num_dof + column), column);
         }
     }
@@ -43,14 +43,11 @@ TEST(PopulateSparseIndices, TwoElements) {
     constexpr auto elem2_num_dof = elem2_num_nodes * 6U;
     constexpr auto max_num_nodes = elem1_num_nodes;
 
-    auto elem_indices_host =
-        Kokkos::View<Beams::ElemIndices[2], Kokkos::HostSpace>("elem_indices_host");
-    auto elem_indices = Kokkos::View<Beams::ElemIndices[2]>("elem_indices");
-    elem_indices_host(0).num_nodes = elem1_num_nodes;
-    elem_indices_host(0).node_range.first = 0;
-    elem_indices_host(1).num_nodes = elem2_num_nodes;
-    elem_indices_host(1).node_range.first = elem1_num_nodes;
-    Kokkos::deep_copy(elem_indices, elem_indices_host);
+    auto num_nodes_per_element = Kokkos::View<size_t[2]>("num_nodes_per_element");
+    auto num_nodes_per_element_host = Kokkos::create_mirror(num_nodes_per_element);
+    num_nodes_per_element_host(0) = elem1_num_nodes;
+    num_nodes_per_element_host(1) = elem2_num_nodes;
+    Kokkos::deep_copy(num_nodes_per_element, num_nodes_per_element_host);
 
     auto node_state_indices = Kokkos::View<size_t[2][max_num_nodes]>("node_state_indices");
     auto node_state_indices_host_data =
@@ -64,7 +61,9 @@ TEST(PopulateSparseIndices, TwoElements) {
     auto indices =
         Kokkos::View<int[elem1_num_dof * elem1_num_dof + elem2_num_dof * elem2_num_dof]>("indices");
 
-    Kokkos::parallel_for(1, PopulateSparseIndices{elem_indices, node_state_indices, indices});
+    Kokkos::parallel_for(
+        1, PopulateSparseIndices{num_nodes_per_element, node_state_indices, indices}
+    );
 
     auto indices_host = Kokkos::create_mirror(indices);
     Kokkos::deep_copy(indices_host, indices);

--- a/tests/unit_tests/restruct_poc/solver/test_populate_sparse_row_ptrs.cpp
+++ b/tests/unit_tests/restruct_poc/solver/test_populate_sparse_row_ptrs.cpp
@@ -6,16 +6,15 @@
 namespace openturbine::tests {
 
 TEST(PopulateSparseRowPtrs, SingleElement) {
-    auto elem_indices_host =
-        Kokkos::View<Beams::ElemIndices[1], Kokkos::HostSpace>("elem_indices_host");
-    auto elem_indices = Kokkos::View<Beams::ElemIndices[1]>("elem_indices");
-    elem_indices_host(0).num_nodes = 5;
-    Kokkos::deep_copy(elem_indices, elem_indices_host);
+    auto num_nodes = Kokkos::View<size_t[1]>("num_nodes");
+    auto num_nodes_host = Kokkos::create_mirror(num_nodes);
+    num_nodes_host(0) = size_t{5U};
+    Kokkos::deep_copy(num_nodes, num_nodes_host);
 
     constexpr auto num_rows = 5 * 6;
     auto row_ptrs = Kokkos::View<int[num_rows + 1]>("row_ptrs");
 
-    Kokkos::parallel_for(1, PopulateSparseRowPtrs<decltype(row_ptrs)>{elem_indices, row_ptrs});
+    Kokkos::parallel_for(1, PopulateSparseRowPtrs<decltype(row_ptrs)>{num_nodes, row_ptrs});
 
     auto row_ptrs_host = Kokkos::create_mirror(row_ptrs);
     Kokkos::deep_copy(row_ptrs_host, row_ptrs);
@@ -25,19 +24,18 @@ TEST(PopulateSparseRowPtrs, SingleElement) {
 }
 
 TEST(PopulateSparseRowPtrs, TwoElements) {
-    auto elem_indices_host =
-        Kokkos::View<Beams::ElemIndices[2], Kokkos::HostSpace>("elem_indices_host");
-    auto elem_indices = Kokkos::View<Beams::ElemIndices[2]>("elem_indices");
-    elem_indices_host(0).num_nodes = 5;
-    elem_indices_host(1).num_nodes = 3;
-    Kokkos::deep_copy(elem_indices, elem_indices_host);
+    auto num_nodes = Kokkos::View<size_t[2]>("num_nodes");
+    auto num_nodes_host = Kokkos::create_mirror(num_nodes);
+    num_nodes_host(0) = size_t{5U};
+    num_nodes_host(1) = size_t{3U};
+    Kokkos::deep_copy(num_nodes, num_nodes_host);
 
     constexpr auto elem1_rows = 5 * 6;
     constexpr auto elem2_rows = 3 * 6;
     constexpr auto num_rows = elem1_rows + elem2_rows;
     auto row_ptrs = Kokkos::View<int[num_rows + 1]>("row_ptrs");
 
-    Kokkos::parallel_for(1, PopulateSparseRowPtrs<decltype(row_ptrs)>{elem_indices, row_ptrs});
+    Kokkos::parallel_for(1, PopulateSparseRowPtrs<decltype(row_ptrs)>{num_nodes, row_ptrs});
 
     auto row_ptrs_host = Kokkos::create_mirror(row_ptrs);
     Kokkos::deep_copy(row_ptrs_host, row_ptrs);

--- a/tests/unit_tests/restruct_poc/system/test_calculate_node_forces.cpp
+++ b/tests/unit_tests/restruct_poc/system/test_calculate_node_forces.cpp
@@ -9,10 +9,8 @@
 namespace openturbine::tests {
 
 TEST(CalculateNodeForcesTests, FE_OneNodeOneQP) {
-    constexpr auto first_node = 0;
-    constexpr auto first_qp = 0;
-    constexpr auto num_nodes = 1;
-    constexpr auto num_qps = 1;
+    constexpr auto num_nodes = size_t{1U};
+    constexpr auto num_qps = size_t{1U};
 
     const auto weight = Kokkos::View<double[1][num_qps]>("weight");
     constexpr auto weight_data = std::array<double, 1>{2.};
@@ -68,9 +66,7 @@ TEST(CalculateNodeForcesTests, FE_OneNodeOneQP) {
 
     Kokkos::parallel_for(
         "CalculateNodeForces_FE", num_nodes,
-        CalculateNodeForces_FE{
-            0, first_node, first_qp, num_qps, weight, jacobian, shape_interp, shape_deriv, Fc, Fd,
-            FE}
+        CalculateNodeForces_FE{0U, num_qps, weight, jacobian, shape_interp, shape_deriv, Fc, Fd, FE}
     );
 
     constexpr auto FE_exact_data = std::array{178., 212., 246., 280., 314., 348.};
@@ -83,10 +79,8 @@ TEST(CalculateNodeForcesTests, FE_OneNodeOneQP) {
 }
 
 TEST(CalculateNodeForcesTests, FE_TwoNodesTwoQPs) {
-    constexpr auto first_node = 0;
-    constexpr auto first_qp = 0;
-    constexpr auto num_nodes = 2;
-    constexpr auto num_qps = 2;
+    constexpr auto num_nodes = size_t{2U};
+    constexpr auto num_qps = size_t{2U};
 
     const auto weight = Kokkos::View<double[1][num_qps]>("weight");
     constexpr auto weight_data = std::array{2., 3.};
@@ -142,9 +136,7 @@ TEST(CalculateNodeForcesTests, FE_TwoNodesTwoQPs) {
 
     Kokkos::parallel_for(
         "CalculateNodeForces_FE", num_nodes,
-        CalculateNodeForces_FE{
-            0, first_node, first_qp, num_qps, weight, jacobian, shape_interp, shape_deriv, Fc, Fd,
-            FE}
+        CalculateNodeForces_FE{0U, num_qps, weight, jacobian, shape_interp, shape_deriv, Fc, Fd, FE}
     );
 
     constexpr auto FE_exact_data = std::array{2870., 3076., 3282., 3488., 3694., 3900.,
@@ -158,10 +150,8 @@ TEST(CalculateNodeForcesTests, FE_TwoNodesTwoQPs) {
 }
 
 TEST(CalculateNodeForcesTests, FI_FG_OneNodeOneQP) {
-    constexpr auto first_node = 0;
-    constexpr auto first_qp = 0;
-    constexpr auto num_nodes = 1;
-    constexpr auto num_qps = 1;
+    constexpr auto num_nodes = size_t{1U};
+    constexpr auto num_qps = size_t{1U};
 
     const auto weight = Kokkos::View<double[1][num_qps]>("weight");
     constexpr auto weight_data = std::array{2.};
@@ -209,8 +199,7 @@ TEST(CalculateNodeForcesTests, FI_FG_OneNodeOneQP) {
 
     Kokkos::parallel_for(
         "CalculateNodeForces_FI_FG", num_nodes,
-        CalculateNodeForces_FI_FG{
-            0, first_node, first_qp, num_qps, weight, jacobian, shape_interp, shape_deriv, Fig, FIG}
+        CalculateNodeForces_FI_FG{0U, num_qps, weight, jacobian, shape_interp, shape_deriv, Fig, FIG}
     );
 
     constexpr auto FIG_exact_data = std::array{24., 48., 72., 96., 120., 144.};
@@ -223,10 +212,8 @@ TEST(CalculateNodeForcesTests, FI_FG_OneNodeOneQP) {
 }
 
 TEST(CalculateNodeForcesTests, FI_FG_TwoNodesTwoQP) {
-    constexpr auto first_node = 0;
-    constexpr auto first_qp = 0;
-    constexpr auto num_nodes = 2;
-    constexpr auto num_qps = 2;
+    constexpr auto num_nodes = size_t{2U};
+    constexpr auto num_qps = size_t{2U};
 
     const auto weight = Kokkos::View<double[1][num_qps]>("weight");
     constexpr auto weight_data = std::array{2., 3.};
@@ -274,8 +261,7 @@ TEST(CalculateNodeForcesTests, FI_FG_TwoNodesTwoQP) {
 
     Kokkos::parallel_for(
         "CalculateNodeForces_FI_FG", num_nodes,
-        CalculateNodeForces_FI_FG{
-            0, first_node, first_qp, num_qps, weight, jacobian, shape_interp, shape_deriv, Fig, FIG}
+        CalculateNodeForces_FI_FG{0U, num_qps, weight, jacobian, shape_interp, shape_deriv, Fig, FIG}
     );
 
     constexpr auto FIG_exact_data =

--- a/tests/unit_tests/restruct_poc/system/test_integrate_inertia_matrix.cpp
+++ b/tests/unit_tests/restruct_poc/system/test_integrate_inertia_matrix.cpp
@@ -12,8 +12,8 @@
 namespace openturbine::tests {
 
 inline void IntegrateInertiaMatrix_TestOneElementOneNodeOneQP_Muu() {
-    constexpr auto number_of_nodes = 1;
-    constexpr auto number_of_qps = 1;
+    constexpr auto number_of_nodes = size_t{1U};
+    constexpr auto number_of_qps = size_t{1U};
 
     const auto qp_weights = get_qp_weights<number_of_qps>({2.});
     const auto qp_jacobian = get_qp_jacobian<number_of_qps>({3.});
@@ -33,8 +33,7 @@ inline void IntegrateInertiaMatrix_TestOneElementOneNodeOneQP_Muu() {
 
     const auto policy = Kokkos::MDRangePolicy({0, 0}, {number_of_nodes, number_of_nodes});
     const auto integrator = IntegrateInertiaMatrixElement{
-        0,      number_of_qps, 0,  0,  qp_weights, qp_jacobian, shape_interp,
-        qp_Muu, qp_Guu,        1., 0., gbl_M};
+        0U, number_of_qps, qp_weights, qp_jacobian, shape_interp, qp_Muu, qp_Guu, 1., 0., gbl_M};
     Kokkos::parallel_for(policy, integrator);
 
     constexpr auto exact_M_data =
@@ -54,8 +53,8 @@ TEST(IntegrateInertiaMatrixTests, OneElementOneNodeOneQP_Muu) {
 }
 
 void IntegrateInertiaMatrix_TestOneElementOneNodeOneQP_Guu() {
-    constexpr auto number_of_nodes = 1;
-    constexpr auto number_of_qps = 1;
+    constexpr auto number_of_nodes = size_t{1U};
+    constexpr auto number_of_qps = size_t{1U};
 
     const auto qp_weights = get_qp_weights<number_of_qps>({2.});
     const auto qp_jacobian = get_qp_jacobian<number_of_qps>({3.});
@@ -75,8 +74,7 @@ void IntegrateInertiaMatrix_TestOneElementOneNodeOneQP_Guu() {
 
     const auto policy = Kokkos::MDRangePolicy({0, 0}, {number_of_nodes, number_of_nodes});
     const auto integrator = IntegrateInertiaMatrixElement{
-        0,      number_of_qps, 0,  0,  qp_weights, qp_jacobian, shape_interp,
-        qp_Muu, qp_Guu,        0., 1., gbl_M};
+        0U, number_of_qps, qp_weights, qp_jacobian, shape_interp, qp_Muu, qp_Guu, 0., 1., gbl_M};
     Kokkos::parallel_for(policy, integrator);
 
     constexpr auto exact_M_data =
@@ -96,8 +94,8 @@ TEST(IntegrateInertiaMatrixTests, OneElementOneNodeOneQP_Guu) {
 }
 
 void IntegrateInertiaMatrix_TestTwoElementsOneNodeOneQP() {
-    constexpr auto number_of_nodes = 1;
-    constexpr auto number_of_qps = 1;
+    constexpr auto number_of_nodes = size_t{1U};
+    constexpr auto number_of_qps = size_t{1U};
 
     const auto qp_weights = get_qp_weights<number_of_qps>({1.});
     const auto qp_jacobian = get_qp_jacobian<number_of_qps>({1.});
@@ -116,8 +114,7 @@ void IntegrateInertiaMatrix_TestTwoElementsOneNodeOneQP() {
         );
         const auto policy = Kokkos::MDRangePolicy({0, 0}, {number_of_nodes, number_of_nodes});
         const auto integrator = IntegrateInertiaMatrixElement{
-            0,      number_of_qps, 0,  0,  qp_weights, qp_jacobian, shape_interp,
-            qp_Muu, qp_Guu,        1., 0., gbl_M};
+            0U, number_of_qps, qp_weights, qp_jacobian, shape_interp, qp_Muu, qp_Guu, 1., 0., gbl_M};
         Kokkos::parallel_for(policy, integrator);
     }
 
@@ -130,8 +127,7 @@ void IntegrateInertiaMatrix_TestTwoElementsOneNodeOneQP() {
         );
         const auto policy = Kokkos::MDRangePolicy({0, 0}, {number_of_nodes, number_of_nodes});
         const auto integrator = IntegrateInertiaMatrixElement{
-            1,      number_of_qps, 1,  1,  qp_weights, qp_jacobian, shape_interp,
-            qp_Muu, qp_Guu,        1., 0., gbl_M};
+            1U, number_of_qps, qp_weights, qp_jacobian, shape_interp, qp_Muu, qp_Guu, 1., 0., gbl_M};
         Kokkos::parallel_for(policy, integrator);
     }
 
@@ -157,8 +153,8 @@ TEST(IntegrateInertiaMatrixTests, TwoElementsOneNodeOneQP) {
 }
 
 void IntegrateInertiaMatrix_TestOneElementTwoNodesOneQP() {
-    constexpr auto number_of_nodes = 2;
-    constexpr auto number_of_qps = 1;
+    constexpr auto number_of_nodes = size_t{2U};
+    constexpr auto number_of_qps = size_t{1U};
 
     const auto qp_weights = get_qp_weights<number_of_qps>({1.});
     const auto qp_jacobian = get_qp_jacobian<number_of_qps>({1.});
@@ -175,8 +171,7 @@ void IntegrateInertiaMatrix_TestOneElementTwoNodesOneQP() {
 
     const auto policy = Kokkos::MDRangePolicy({0, 0}, {number_of_nodes, number_of_nodes});
     const auto integrator = IntegrateInertiaMatrixElement{
-        0,      number_of_qps, 0,  0,  qp_weights, qp_jacobian, shape_interp,
-        qp_Muu, qp_Guu,        1., 0., gbl_M};
+        0U, number_of_qps, qp_weights, qp_jacobian, shape_interp, qp_Muu, qp_Guu, 1., 0., gbl_M};
     Kokkos::parallel_for(policy, integrator);
 
     constexpr auto exact_M_data = std::array{
@@ -206,8 +201,8 @@ TEST(IntegrateInertiaMatrixTests, OneElementTwoNodesOneQP) {
 }
 
 void IntegrateInertiaMatrix_TestOneElementOneNodeTwoQPs() {
-    constexpr auto number_of_nodes = 1;
-    constexpr auto number_of_qps = 2;
+    constexpr auto number_of_nodes = size_t{1U};
+    constexpr auto number_of_qps = size_t{2U};
 
     const auto qp_weights = get_qp_weights<number_of_qps>({9., 1.});
     const auto qp_jacobian = get_qp_jacobian<number_of_qps>({1., 4.});
@@ -230,8 +225,7 @@ void IntegrateInertiaMatrix_TestOneElementOneNodeTwoQPs() {
 
     const auto policy = Kokkos::MDRangePolicy({0, 0}, {number_of_nodes, number_of_nodes});
     const auto integrator = IntegrateInertiaMatrixElement{
-        0,      number_of_qps, 0,  0,  qp_weights, qp_jacobian, shape_interp,
-        qp_Muu, qp_Guu,        1., 0., gbl_M};
+        0U, number_of_qps, qp_weights, qp_jacobian, shape_interp, qp_Muu, qp_Guu, 1., 0., gbl_M};
     Kokkos::parallel_for(policy, integrator);
 
     constexpr auto exact_M_data =
@@ -251,8 +245,8 @@ TEST(IntegrateInertiaMatrixTests, OneElementOneNodeTwoQPs) {
 }
 
 void IntegrateInertiaMatrix_TestOneElementOneNodeOneQP_WithMultiplicationFactor() {
-    constexpr auto number_of_nodes = 1;
-    constexpr auto number_of_qps = 1;
+    constexpr auto number_of_nodes = size_t{1U};
+    constexpr auto number_of_qps = size_t{1};
 
     const auto qp_weights = get_qp_weights<number_of_qps>({1.});
     const auto qp_jacobian = get_qp_jacobian<number_of_qps>({1.});
@@ -270,8 +264,8 @@ void IntegrateInertiaMatrix_TestOneElementOneNodeOneQP_WithMultiplicationFactor(
 
     const auto policy = Kokkos::MDRangePolicy({0, 0}, {number_of_nodes, number_of_nodes});
     const auto integrator = IntegrateInertiaMatrixElement{
-        0,      number_of_qps,         0,  0,    qp_weights, qp_jacobian, shape_interp, qp_Muu,
-        qp_Guu, multiplication_factor, 0., gbl_M};
+        0U,     number_of_qps,         qp_weights, qp_jacobian, shape_interp, qp_Muu,
+        qp_Guu, multiplication_factor, 0.,         gbl_M};
     Kokkos::parallel_for(policy, integrator);
 
     constexpr auto exact_M_data =

--- a/tests/unit_tests/restruct_poc/system/test_integrate_stiffness_matrix.cpp
+++ b/tests/unit_tests/restruct_poc/system/test_integrate_stiffness_matrix.cpp
@@ -18,8 +18,8 @@ void TestIntegrateStiffnessMatrix_1Element1Node1QP(
     const Kokkos::View<const double[1][6][6]>& qp_Ouu,
     const Kokkos::View<const double[1][6][6]>& qp_Quu, const std::array<double, 36>& exact_M_data
 ) {
-    constexpr auto number_of_nodes = 1;
-    constexpr auto number_of_qps = 1;
+    constexpr auto number_of_nodes = size_t{1U};
+    constexpr auto number_of_qps = size_t{1U};
 
     const auto qp_weights = get_qp_weights<number_of_qps>({2.});
     const auto qp_jacobian = get_qp_jacobian<number_of_qps>({3.});
@@ -29,20 +29,9 @@ void TestIntegrateStiffnessMatrix_1Element1Node1QP(
     auto gbl_M = Kokkos::View<double[1][6][6]>("global_M");
 
     const auto policy = Kokkos::MDRangePolicy({0, 0}, {number_of_nodes, number_of_nodes});
-    const auto integrator = IntegrateStiffnessMatrixElement{0,
-                                                            number_of_qps,
-                                                            0,
-                                                            0,
-                                                            qp_weights,
-                                                            qp_jacobian,
-                                                            shape_interp,
-                                                            shape_interp_deriv,
-                                                            qp_Kuu,
-                                                            qp_Puu,
-                                                            qp_Cuu,
-                                                            qp_Ouu,
-                                                            qp_Quu,
-                                                            gbl_M};
+    const auto integrator = IntegrateStiffnessMatrixElement{
+        0,      number_of_qps, qp_weights, qp_jacobian, shape_interp, shape_interp_deriv,
+        qp_Kuu, qp_Puu,        qp_Cuu,     qp_Ouu,      qp_Quu,       gbl_M};
     Kokkos::parallel_for(policy, integrator);
 
     const auto exact_M = Kokkos::View<const double[1][6][6], Kokkos::HostSpace>(exact_M_data.data());
@@ -199,8 +188,8 @@ TEST(IntegrateStiffnessMatrixTests, OneElementOneNodeOneQP_Ouu) {
 }
 
 void TestIntegrateStiffnessMatrix_2Elements1Node1QP() {
-    constexpr auto number_of_nodes = 1;
-    constexpr auto number_of_qps = 1;
+    constexpr auto number_of_nodes = size_t{1U};
+    constexpr auto number_of_qps = size_t{1U};
 
     const auto qp_weights = get_qp_weights<number_of_qps>({1.});
     const auto qp_jacobian = get_qp_jacobian<number_of_qps>({1.});
@@ -223,20 +212,9 @@ void TestIntegrateStiffnessMatrix_2Elements1Node1QP() {
              00404., 00405., 00406., 00501., 00502., 00503., 00504., 00505., 00506.}
         );
         const auto policy = Kokkos::MDRangePolicy({0, 0}, {number_of_nodes, number_of_nodes});
-        const auto integrator = IntegrateStiffnessMatrixElement{0,
-                                                                number_of_qps,
-                                                                0,
-                                                                0,
-                                                                qp_weights,
-                                                                qp_jacobian,
-                                                                shape_interp,
-                                                                shape_interp_deriv,
-                                                                qp_Kuu,
-                                                                qp_Puu,
-                                                                qp_Cuu,
-                                                                qp_Ouu,
-                                                                qp_Quu,
-                                                                gbl_M};
+        const auto integrator = IntegrateStiffnessMatrixElement{
+            0,      number_of_qps, qp_weights, qp_jacobian, shape_interp, shape_interp_deriv,
+            qp_Kuu, qp_Puu,        qp_Cuu,     qp_Ouu,      qp_Quu,       gbl_M};
         Kokkos::parallel_for(policy, integrator);
     }
 
@@ -248,20 +226,9 @@ void TestIntegrateStiffnessMatrix_2Elements1Node1QP() {
              40004., 40005., 40006., 50001., 50002., 50003., 50004., 50005., 50006.}
         );
         const auto policy = Kokkos::MDRangePolicy({0, 0}, {number_of_nodes, number_of_nodes});
-        const auto integrator = IntegrateStiffnessMatrixElement{1,
-                                                                number_of_qps,
-                                                                1,
-                                                                1,
-                                                                qp_weights,
-                                                                qp_jacobian,
-                                                                shape_interp,
-                                                                shape_interp_deriv,
-                                                                qp_Kuu,
-                                                                qp_Puu,
-                                                                qp_Cuu,
-                                                                qp_Ouu,
-                                                                qp_Quu,
-                                                                gbl_M};
+        const auto integrator = IntegrateStiffnessMatrixElement{
+            1,      number_of_qps, qp_weights, qp_jacobian, shape_interp, shape_interp_deriv,
+            qp_Kuu, qp_Puu,        qp_Cuu,     qp_Ouu,      qp_Quu,       gbl_M};
         Kokkos::parallel_for(policy, integrator);
     }
 
@@ -294,8 +261,8 @@ void TestIntegrateStiffnessMatrix_1Element2Nodes1QP(
     const Kokkos::View<const double[1][6][6]>& qp_Ouu,
     const Kokkos::View<const double[1][6][6]>& qp_Quu, const std::array<double, 144>& exact_M_data
 ) {
-    constexpr auto number_of_nodes = 2;
-    constexpr auto number_of_qps = 1;
+    constexpr auto number_of_nodes = size_t{2U};
+    constexpr auto number_of_qps = size_t{1U};
 
     const auto qp_weights = get_qp_weights<number_of_qps>({1.});
     const auto qp_jacobian = get_qp_jacobian<number_of_qps>({1.});
@@ -305,20 +272,9 @@ void TestIntegrateStiffnessMatrix_1Element2Nodes1QP(
     auto gbl_M = Kokkos::View<double[1][12][12]>("global_M");
 
     const auto policy = Kokkos::MDRangePolicy({0, 0}, {number_of_nodes, number_of_nodes});
-    const auto integrator = IntegrateStiffnessMatrixElement{0,
-                                                            number_of_qps,
-                                                            0,
-                                                            0,
-                                                            qp_weights,
-                                                            qp_jacobian,
-                                                            shape_interp,
-                                                            shape_interp_deriv,
-                                                            qp_Kuu,
-                                                            qp_Puu,
-                                                            qp_Cuu,
-                                                            qp_Ouu,
-                                                            qp_Quu,
-                                                            gbl_M};
+    const auto integrator = IntegrateStiffnessMatrixElement{
+        0,      number_of_qps, qp_weights, qp_jacobian, shape_interp, shape_interp_deriv,
+        qp_Kuu, qp_Puu,        qp_Cuu,     qp_Ouu,      qp_Quu,       gbl_M};
     Kokkos::parallel_for(policy, integrator);
 
     const auto exact_M =
@@ -496,8 +452,8 @@ void TestIntegrateStiffnessMatrix_1Element1Node2QPs(
     const Kokkos::View<const double[2][6][6]>& qp_Ouu,
     const Kokkos::View<const double[2][6][6]>& qp_Quu, const std::array<double, 36>& exact_M_data
 ) {
-    constexpr auto number_of_nodes = 1;
-    constexpr auto number_of_qps = 2;
+    constexpr auto number_of_nodes = size_t{1U};
+    constexpr auto number_of_qps = size_t{2U};
 
     const auto qp_weights = get_qp_weights<number_of_qps>({1., 3.});
     const auto qp_jacobian = get_qp_jacobian<number_of_qps>({2., 4.});
@@ -507,20 +463,9 @@ void TestIntegrateStiffnessMatrix_1Element1Node2QPs(
     auto gbl_M = Kokkos::View<double[1][6][6]>("global_M");
 
     const auto policy = Kokkos::MDRangePolicy({0, 0}, {number_of_nodes, number_of_nodes});
-    const auto integrator = IntegrateStiffnessMatrixElement{0,
-                                                            number_of_qps,
-                                                            0,
-                                                            0,
-                                                            qp_weights,
-                                                            qp_jacobian,
-                                                            shape_interp,
-                                                            shape_interp_deriv,
-                                                            qp_Kuu,
-                                                            qp_Puu,
-                                                            qp_Cuu,
-                                                            qp_Ouu,
-                                                            qp_Quu,
-                                                            gbl_M};
+    const auto integrator = IntegrateStiffnessMatrixElement{
+        0,      number_of_qps, qp_weights, qp_jacobian, shape_interp, shape_interp_deriv,
+        qp_Kuu, qp_Puu,        qp_Cuu,     qp_Ouu,      qp_Quu,       gbl_M};
     Kokkos::parallel_for(policy, integrator);
 
     const auto exact_M = Kokkos::View<const double[1][6][6], Kokkos::HostSpace>(exact_M_data.data());


### PR DESCRIPTION
After recent changes, most of `ElemIndices` was unused.  Also, in many cases, only one piece of information was needed in a given location.  This simpler formation better communicates to the user what information is needed where.

In theory, it seems like it should be a hair faster than the old implementation, but any differences one way or the other are expected to be unmeasurable.