### PR TITLE
Changed the formatting CI workflow to no longer need the DoozyX action

### DIFF
--- a/.github/workflows/formatting.yaml
+++ b/.github/workflows/formatting.yaml
@@ -3,15 +3,24 @@ name: OpenTurbine-CI
 on: push
 
 jobs:
-  ClangFormat:
+  clang-format:
     runs-on: ubuntu-latest
+
     steps:
-    - name: Clone
+    - name: Checkout repository
       uses: actions/checkout@v4
-    - name: Check formatting
-      uses: DoozyX/clang-format-lint-action@v0.16.2
-      with:
-        source: './src ./tests/unit_tests'
-        exclude: '.'
-        extensions: 'cpp,hpp'
-        clangFormatVersion: 16
+
+    - name: Run clang-format
+      run: |
+        find . -regex '.*\.\(cpp\|hpp\|c\|h\)' -exec clang-format -i {} \;
+        
+    - name: Check for formatting changes
+      run: |
+        if [[ `git status --porcelain` ]]; then
+          echo "Code is not formatted. Please run clang-format."
+          git diff
+          exit 1
+        else
+          echo "Code is properly formatted."
+        fi
+

--- a/src/vendor/dylib/dylib.hpp
+++ b/src/vendor/dylib/dylib.hpp
@@ -175,19 +175,22 @@ public:
 
 #ifdef DYLIB_CPP17
     explicit dylib(const std::filesystem::path& lib_path)
-        : dylib("", lib_path.string().c_str(), no_filename_decorations) {}
+        : dylib("", lib_path.string().c_str(), no_filename_decorations) {
+    }
 
     dylib(
         const std::filesystem::path& dir_path, const std::string& lib_name,
         bool decorations = add_filename_decorations
     )
-        : dylib(dir_path.string().c_str(), lib_name.c_str(), decorations) {}
+        : dylib(dir_path.string().c_str(), lib_name.c_str(), decorations) {
+    }
 
     dylib(
         const std::filesystem::path& dir_path, const char* lib_name,
         bool decorations = add_filename_decorations
     )
-        : dylib(dir_path.string().c_str(), lib_name, decorations) {}
+        : dylib(dir_path.string().c_str(), lib_name, decorations) {
+    }
 #endif
     ///@}
 
@@ -304,7 +307,9 @@ public:
     /**
      *  @return the dynamic library handle
      */
-    native_handle_type native_handle() noexcept { return m_handle; }
+    native_handle_type native_handle() noexcept {
+        return m_handle;
+    }
 
 protected:
     native_handle_type m_handle{nullptr};


### PR DESCRIPTION
The CI action we used to check formatting broke recently.  This change should make our CI process more robust to outside changes, since it only uses the "checkout" action

Note that we are now using clang-format version 15 (vs 16 before).  This is the latest version available on the ubuntu-latest runners.  We could jump through more hoops to install a newer version, but 15 should suffice.  