### PR TITLE
Added VTK to CI script for MacOS

### DIFF
--- a/.github/workflows/correctness-linux.yaml
+++ b/.github/workflows/correctness-linux.yaml
@@ -27,11 +27,10 @@ jobs:
         git clone https://github.com/spack/spack.git
         source spack/share/spack/setup-env.sh
         spack compiler find
-        spack external find
         spack install googletest
         spack install cppcheck
         spack install yaml-cpp
-        spack install trilinos@master~mpi~epetra+basker
+        spack install trilinos@master~mpi~epetra
     - name: Clone
       uses: actions/checkout@v4
       with:

--- a/.github/workflows/correctness-macos.yaml
+++ b/.github/workflows/correctness-macos.yaml
@@ -31,7 +31,8 @@ jobs:
         spack install llvm
         spack install cppcheck
         spack install yaml-cpp
-        spack install trilinos@master~mpi~epetra+basker
+        spack install vtk~mpi~opengl2
+        spack install trilinos@master~mpi~epetra
     - name: Clone
       uses: actions/checkout@v4
       with:
@@ -45,6 +46,7 @@ jobs:
         spack load trilinos
         spack load googletest
         spack load yaml-cpp
+        spack load vtk
         cd openturbine
         mkdir build
         cd build
@@ -53,6 +55,7 @@ jobs:
           -DOpenTurbine_ENABLE_SANITIZER_UNDEFINED=ON \
           -DOpenTurbine_ENABLE_CPPCHECK=ON \
           -DOpenTurbine_ENABLE_CLANG_TIDY=ON \
+          -DOpenTurbine_ENABLE_VTK=ON \
           -DCMAKE_CXX_COMPILER=${{ matrix.compiler }} \
           -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
         cmake --build .

--- a/tests/unit_tests/regression/test_rotor.cpp
+++ b/tests/unit_tests/regression/test_rotor.cpp
@@ -156,12 +156,16 @@ TEST(RotorTest, IEA15Rotor) {
     );
 
     // Remove output directory for writing step data
-    std::filesystem::remove_all("steps");
-    std::filesystem::create_directory("steps");
-
-    // Write quadrature point global positions to file and VTK
     if (write_output) {
 #ifdef OpenTurbine_ENABLE_VTK
+        try {
+            std::filesystem::remove_all("steps");
+        } catch (...) {
+            std::cout << "Did not remove steps folder\n";
+        }
+        std::filesystem::create_directory("steps");
+
+        // Write quadrature point global positions to file and VTK
         // Write vtk visualization file
         BeamsWriteVTK(beams, "steps/step_0000.vtu");
 #endif
@@ -312,12 +316,16 @@ TEST(RotorTest, IEA15RotorHub) {
     );
 
     // Remove output directory for writing step data
-    std::filesystem::remove_all("steps");
-    std::filesystem::create_directory("steps");
-
-    // Write quadrature point global positions to file and VTK
     if (write_output) {
 #ifdef OpenTurbine_ENABLE_VTK
+        try {
+            std::filesystem::remove_all("steps");
+        } catch (...) {
+            std::cout << "Did not remove steps folder\n";
+        }
+        std::filesystem::create_directory("steps");
+
+        // Write quadrature point global positions to file and VTK
         // Write vtk visualization file
         BeamsWriteVTK(beams, "steps/step_0000.vtu");
 #endif
@@ -495,12 +503,16 @@ TEST(RotorTest, IEA15RotorController) {
     );
 
     // Remove output directory for writing step data
-    std::filesystem::remove_all("steps");
-    std::filesystem::create_directory("steps");
-
-    // Write quadrature point global positions to file and VTK
     if (write_output) {
 #ifdef OpenTurbine_ENABLE_VTK
+        try {
+            std::filesystem::remove_all("steps");
+        } catch (...) {
+            std::cout << "Did not remove steps folder\n";
+        }
+        std::filesystem::create_directory("steps");
+
+        // Write quadrature point global positions to file and VTK
         // Write vtk visualization file
         BeamsWriteVTK(beams, "steps/step_0000.vtu");
 #endif


### PR DESCRIPTION
VTK is only added for MacOS because the Linux CI runners run out of hard drive space when installing VTK.  

I also removed Basker from the Trilinos builds, since it is no longer used for CPU runs.  