### PR TITLE
Reduces scratch memory reserved for integrating stiffness matrix

### DIFF
--- a/src/step/assemble_stiffness_matrix.hpp
+++ b/src/step/assemble_stiffness_matrix.hpp
@@ -13,7 +13,7 @@ inline void AssembleStiffnessMatrix(const Beams& beams) {
     auto range_policy = Kokkos::TeamPolicy<>(static_cast<int>(beams.num_elems), Kokkos::AUTO());
     auto smem = 5 * Kokkos::View<double* [6][6]>::shmem_size(beams.max_elem_qps) +
                 2 * Kokkos::View<double*>::shmem_size(beams.max_elem_qps) +
-                2 * Kokkos::View<double**>::shmem_size(beams.max_elem_qps, beams.max_elem_qps);
+                2 * Kokkos::View<double**>::shmem_size(beams.max_elem_nodes, beams.max_elem_qps);
     range_policy.set_scratch_size(1, Kokkos::PerTeam(smem));
     Kokkos::parallel_for(
         "IntegrateStiffnessMatrix", range_policy,


### PR DESCRIPTION
We were accidentally reserving num_qps number of elements instead of num_nodes.