### PR TITLE
Fuse node loops for matrix integration, exposing more parallelism on GPUs

### DIFF
--- a/src/system/integrate_stiffness_matrix.hpp
+++ b/src/system/integrate_stiffness_matrix.hpp
@@ -20,62 +20,59 @@ struct IntegrateStiffnessMatrixElement {
     Kokkos::View<double*** [6][6]> gbl_M_;
 
     KOKKOS_FUNCTION
-    void operator()(size_t i_index) const {
+    void operator()(size_t ij_index) const {
         using simd_type = Kokkos::Experimental::native_simd<double>;
         using mask_type = Kokkos::Experimental::native_simd_mask<double>;
         using tag_type = Kokkos::Experimental::element_aligned_tag;
         constexpr auto width = simd_type::size();
-        for (auto j_index = 0U; j_index < num_nodes; j_index += width) {
-            auto mask = mask_type([j_index, num_nodes = this->num_nodes](size_t lane) {
-                return j_index + lane < num_nodes;
-            });
-            auto local_M_data = Kokkos::Array<simd_type, 36>{};
-            const auto local_M = Kokkos::View<simd_type[6][6]>(local_M_data.data());
-            for (auto k = 0U; k < num_qps; ++k) {
-                const auto w = qp_weight_(k);
-                const auto jacobian = qp_jacobian_(k);
-                const auto phi_i = shape_interp_(i_index, k);
-                auto phi_j = simd_type{};
-                Kokkos::Experimental::where(mask, phi_j)
-                    .copy_from(&shape_interp_(j_index, k), tag_type());
-                const auto phi_prime_i = shape_deriv_(i_index, k);
-                auto phi_prime_j = simd_type{};
-                Kokkos::Experimental::where(mask, phi_prime_j)
-                    .copy_from(&shape_deriv_(j_index, k), tag_type());
-                const auto K = w * phi_i * phi_j * jacobian;
-                const auto P = w * (phi_i * phi_prime_j);
-                const auto C = w * (phi_prime_i * phi_prime_j / jacobian);
-                const auto O = w * (phi_prime_i * phi_j);
-                for (auto m = 0U; m < 6U; ++m) {
-                    local_M(m, 0) += K * (qp_Kuu_(k, m, 0) + qp_Quu_(k, m, 0)) +
-                                     P * qp_Puu_(k, m, 0) + C * qp_Cuu_(k, m, 0) +
-                                     O * qp_Ouu_(k, m, 0);
-                    local_M(m, 1) += K * (qp_Kuu_(k, m, 1) + qp_Quu_(k, m, 1)) +
-                                     P * qp_Puu_(k, m, 1) + C * qp_Cuu_(k, m, 1) +
-                                     O * qp_Ouu_(k, m, 1);
-                    local_M(m, 2) += K * (qp_Kuu_(k, m, 2) + qp_Quu_(k, m, 2)) +
-                                     P * qp_Puu_(k, m, 2) + C * qp_Cuu_(k, m, 2) +
-                                     O * qp_Ouu_(k, m, 2);
-                    local_M(m, 3) += K * (qp_Kuu_(k, m, 3) + qp_Quu_(k, m, 3)) +
-                                     P * qp_Puu_(k, m, 3) + C * qp_Cuu_(k, m, 3) +
-                                     O * qp_Ouu_(k, m, 3);
-                    local_M(m, 4) += K * (qp_Kuu_(k, m, 4) + qp_Quu_(k, m, 4)) +
-                                     P * qp_Puu_(k, m, 4) + C * qp_Cuu_(k, m, 4) +
-                                     O * qp_Ouu_(k, m, 4);
-                    local_M(m, 5) += K * (qp_Kuu_(k, m, 5) + qp_Quu_(k, m, 5)) +
-                                     P * qp_Puu_(k, m, 5) + C * qp_Cuu_(k, m, 5) +
-                                     O * qp_Ouu_(k, m, 5);
-                }
+        const auto extra_component = num_nodes % width == 0U ? 0U : 1U;
+        const auto simd_nodes = num_nodes / width + extra_component;
+        const auto i_index = ij_index / simd_nodes;
+        const auto j_index = (ij_index % simd_nodes) * width;
+
+        auto mask = mask_type([j_index, num_nodes = this->num_nodes](size_t lane) {
+            return j_index + lane < num_nodes;
+        });
+        auto local_M_data = Kokkos::Array<simd_type, 36>{};
+        const auto local_M = Kokkos::View<simd_type[6][6]>(local_M_data.data());
+        for (auto k = 0U; k < num_qps; ++k) {
+            const auto w = qp_weight_(k);
+            const auto jacobian = qp_jacobian_(k);
+            const auto phi_i = shape_interp_(i_index, k);
+            auto phi_j = simd_type{};
+            Kokkos::Experimental::where(mask, phi_j)
+                .copy_from(&shape_interp_(j_index, k), tag_type());
+            const auto phi_prime_i = shape_deriv_(i_index, k);
+            auto phi_prime_j = simd_type{};
+            Kokkos::Experimental::where(mask, phi_prime_j)
+                .copy_from(&shape_deriv_(j_index, k), tag_type());
+            const auto K = w * phi_i * phi_j * jacobian;
+            const auto P = w * (phi_i * phi_prime_j);
+            const auto C = w * (phi_prime_i * phi_prime_j / jacobian);
+            const auto O = w * (phi_prime_i * phi_j);
+            for (auto m = 0U; m < 6U; ++m) {
+                local_M(m, 0) += K * (qp_Kuu_(k, m, 0) + qp_Quu_(k, m, 0)) + P * qp_Puu_(k, m, 0) +
+                                 C * qp_Cuu_(k, m, 0) + O * qp_Ouu_(k, m, 0);
+                local_M(m, 1) += K * (qp_Kuu_(k, m, 1) + qp_Quu_(k, m, 1)) + P * qp_Puu_(k, m, 1) +
+                                 C * qp_Cuu_(k, m, 1) + O * qp_Ouu_(k, m, 1);
+                local_M(m, 2) += K * (qp_Kuu_(k, m, 2) + qp_Quu_(k, m, 2)) + P * qp_Puu_(k, m, 2) +
+                                 C * qp_Cuu_(k, m, 2) + O * qp_Ouu_(k, m, 2);
+                local_M(m, 3) += K * (qp_Kuu_(k, m, 3) + qp_Quu_(k, m, 3)) + P * qp_Puu_(k, m, 3) +
+                                 C * qp_Cuu_(k, m, 3) + O * qp_Ouu_(k, m, 3);
+                local_M(m, 4) += K * (qp_Kuu_(k, m, 4) + qp_Quu_(k, m, 4)) + P * qp_Puu_(k, m, 4) +
+                                 C * qp_Cuu_(k, m, 4) + O * qp_Ouu_(k, m, 4);
+                local_M(m, 5) += K * (qp_Kuu_(k, m, 5) + qp_Quu_(k, m, 5)) + P * qp_Puu_(k, m, 5) +
+                                 C * qp_Cuu_(k, m, 5) + O * qp_Ouu_(k, m, 5);
             }
-            for (auto lane = 0U; lane < width && mask[lane]; ++lane) {
-                for (auto m = 0U; m < 6U; ++m) {
-                    gbl_M_(i_elem, i_index, j_index + lane, m, 0) = local_M(m, 0)[lane];
-                    gbl_M_(i_elem, i_index, j_index + lane, m, 1) = local_M(m, 1)[lane];
-                    gbl_M_(i_elem, i_index, j_index + lane, m, 2) = local_M(m, 2)[lane];
-                    gbl_M_(i_elem, i_index, j_index + lane, m, 3) = local_M(m, 3)[lane];
-                    gbl_M_(i_elem, i_index, j_index + lane, m, 4) = local_M(m, 4)[lane];
-                    gbl_M_(i_elem, i_index, j_index + lane, m, 5) = local_M(m, 5)[lane];
-                }
+        }
+        for (auto lane = 0U; lane < width && mask[lane]; ++lane) {
+            for (auto m = 0U; m < 6U; ++m) {
+                gbl_M_(i_elem, i_index, j_index + lane, m, 0) = local_M(m, 0)[lane];
+                gbl_M_(i_elem, i_index, j_index + lane, m, 1) = local_M(m, 1)[lane];
+                gbl_M_(i_elem, i_index, j_index + lane, m, 2) = local_M(m, 2)[lane];
+                gbl_M_(i_elem, i_index, j_index + lane, m, 3) = local_M(m, 3)[lane];
+                gbl_M_(i_elem, i_index, j_index + lane, m, 4) = local_M(m, 4)[lane];
+                gbl_M_(i_elem, i_index, j_index + lane, m, 5) = local_M(m, 5)[lane];
             }
         }
     }
@@ -97,9 +94,13 @@ struct IntegrateStiffnessMatrix {
 
     KOKKOS_FUNCTION
     void operator()(Kokkos::TeamPolicy<>::member_type member) const {
+        using simd_type = Kokkos::Experimental::native_simd<double>;
         const auto i_elem = static_cast<size_t>(member.league_rank());
         const auto num_nodes = num_nodes_per_element(i_elem);
         const auto num_qps = num_qps_per_element(i_elem);
+        constexpr auto width = simd_type::size();
+        const auto extra_component = num_nodes % width == 0U ? 0U : 1U;
+        const auto simd_nodes = num_nodes / width + extra_component;
 
         const auto shape_interp =
             Kokkos::View<double**, Kokkos::LayoutLeft>(member.team_scratch(1), num_nodes, num_qps);
@@ -134,7 +135,7 @@ struct IntegrateStiffnessMatrix {
         });
         member.team_barrier();
 
-        const auto node_range = Kokkos::TeamThreadRange(member, num_nodes);
+        const auto node_range = Kokkos::TeamThreadRange(member, num_nodes * simd_nodes);
         const auto element_integrator = IntegrateStiffnessMatrixElement{
             i_elem, num_nodes, num_qps, qp_weight, qp_jacobian, shape_interp, shape_deriv,
             qp_Kuu, qp_Puu,    qp_Cuu,  qp_Ouu,    qp_Quu,      gbl_M_};

--- a/tests/unit_tests/system/test_integrate_inertia_matrix.cpp
+++ b/tests/unit_tests/system/test_integrate_inertia_matrix.cpp
@@ -11,6 +11,7 @@ namespace openturbine::tests {
 
 inline void IntegrateInertiaMatrix_TestOneElementOneNodeOneQP_Muu() {
     constexpr auto number_of_nodes = size_t{1U};
+    constexpr auto number_of_simd_nodes = size_t{1U};
     constexpr auto number_of_qps = size_t{1U};
 
     const auto qp_weights = get_qp_weights<number_of_qps>({2.});
@@ -29,7 +30,7 @@ inline void IntegrateInertiaMatrix_TestOneElementOneNodeOneQP_Muu() {
 
     const auto gbl_M = Kokkos::View<double[1][1][1][6][6]>("global_M");
 
-    const auto policy = Kokkos::RangePolicy(0, number_of_nodes);
+    const auto policy = Kokkos::RangePolicy(0, number_of_nodes * number_of_simd_nodes);
     const auto integrator = IntegrateInertiaMatrixElement{
         0U,           number_of_nodes, number_of_qps, qp_weights, qp_jacobian,
         shape_interp, qp_Muu,          qp_Guu,        1.,         0.,
@@ -56,6 +57,7 @@ TEST(IntegrateInertiaMatrixTests, OneElementOneNodeOneQP_Muu) {
 
 void IntegrateInertiaMatrix_TestOneElementOneNodeOneQP_Guu() {
     constexpr auto number_of_nodes = size_t{1U};
+    constexpr auto number_of_simd_nodes = size_t{1U};
     constexpr auto number_of_qps = size_t{1U};
 
     const auto qp_weights = get_qp_weights<number_of_qps>({2.});
@@ -74,7 +76,7 @@ void IntegrateInertiaMatrix_TestOneElementOneNodeOneQP_Guu() {
 
     const auto gbl_M = Kokkos::View<double[1][1][1][6][6]>("global_M");
 
-    const auto policy = Kokkos::RangePolicy(0, number_of_nodes);
+    const auto policy = Kokkos::RangePolicy(0, number_of_nodes * number_of_simd_nodes);
     const auto integrator = IntegrateInertiaMatrixElement{
         0U,           number_of_nodes, number_of_qps, qp_weights, qp_jacobian,
         shape_interp, qp_Muu,          qp_Guu,        0.,         1.,
@@ -100,6 +102,7 @@ TEST(IntegrateInertiaMatrixTests, OneElementOneNodeOneQP_Guu) {
 
 void IntegrateInertiaMatrix_TestTwoElementsOneNodeOneQP() {
     constexpr auto number_of_nodes = size_t{1U};
+    constexpr auto number_of_simd_nodes = size_t{1U};
     constexpr auto number_of_qps = size_t{1U};
 
     const auto qp_weights = get_qp_weights<number_of_qps>({1.});
@@ -117,7 +120,7 @@ void IntegrateInertiaMatrix_TestTwoElementsOneNodeOneQP() {
              00301., 00302., 00303., 00304., 00305., 00306., 00401., 00402., 00403.,
              00404., 00405., 00406., 00501., 00502., 00503., 00504., 00505., 00506.}
         );
-        const auto policy = Kokkos::RangePolicy(0, number_of_nodes);
+        const auto policy = Kokkos::RangePolicy(0, number_of_nodes * number_of_simd_nodes);
         const auto integrator = IntegrateInertiaMatrixElement{
             0U,           number_of_nodes, number_of_qps, qp_weights, qp_jacobian,
             shape_interp, qp_Muu,          qp_Guu,        1.,         0.,
@@ -132,7 +135,7 @@ void IntegrateInertiaMatrix_TestTwoElementsOneNodeOneQP() {
              30001., 30002., 30003., 30004., 30005., 30006., 40001., 40002., 40003.,
              40004., 40005., 40006., 50001., 50002., 50003., 50004., 50005., 50006.}
         );
-        const auto policy = Kokkos::RangePolicy(0, number_of_nodes);
+        const auto policy = Kokkos::RangePolicy(0, number_of_nodes * number_of_simd_nodes);
         const auto integrator = IntegrateInertiaMatrixElement{
             1U,           number_of_nodes, number_of_qps, qp_weights, qp_jacobian,
             shape_interp, qp_Muu,          qp_Guu,        1.,         0.,
@@ -164,6 +167,8 @@ TEST(IntegrateInertiaMatrixTests, TwoElementsOneNodeOneQP) {
 
 void IntegrateInertiaMatrix_TestOneElementTwoNodesOneQP() {
     constexpr auto number_of_nodes = size_t{2U};
+    constexpr auto simd_width = Kokkos::Experimental::native_simd<double>::size();
+    constexpr auto number_of_simd_nodes = (simd_width == 1) ? size_t{2U} : size_t{1U};
     constexpr auto number_of_qps = size_t{1U};
 
     const auto qp_weights = get_qp_weights<number_of_qps>({1.});
@@ -179,7 +184,7 @@ void IntegrateInertiaMatrix_TestOneElementTwoNodesOneQP() {
 
     const auto gbl_M = Kokkos::View<double[1][2][2][6][6]>("global_M");
 
-    const auto policy = Kokkos::RangePolicy(0, number_of_nodes);
+    const auto policy = Kokkos::RangePolicy(0, number_of_nodes * number_of_simd_nodes);
     const auto integrator = IntegrateInertiaMatrixElement{
         0U,           number_of_nodes, number_of_qps, qp_weights, qp_jacobian,
         shape_interp, qp_Muu,          qp_Guu,        1.,         0.,
@@ -214,6 +219,7 @@ TEST(IntegrateInertiaMatrixTests, OneElementTwoNodesOneQP) {
 
 void IntegrateInertiaMatrix_TestOneElementOneNodeTwoQPs() {
     constexpr auto number_of_nodes = size_t{1U};
+    constexpr auto number_of_simd_nodes = size_t{1U};
     constexpr auto number_of_qps = size_t{2U};
 
     const auto qp_weights = get_qp_weights<number_of_qps>({9., 1.});
@@ -235,7 +241,7 @@ void IntegrateInertiaMatrix_TestOneElementOneNodeTwoQPs() {
 
     const auto gbl_M = Kokkos::View<double[1][1][1][6][6]>("global_M");
 
-    const auto policy = Kokkos::RangePolicy(0, number_of_nodes);
+    const auto policy = Kokkos::RangePolicy(0, number_of_nodes * number_of_simd_nodes);
     const auto integrator = IntegrateInertiaMatrixElement{
         0U,           number_of_nodes, number_of_qps, qp_weights, qp_jacobian,
         shape_interp, qp_Muu,          qp_Guu,        1.,         0.,
@@ -261,6 +267,7 @@ TEST(IntegrateInertiaMatrixTests, OneElementOneNodeTwoQPs) {
 
 void IntegrateInertiaMatrix_TestOneElementOneNodeOneQP_WithMultiplicationFactor() {
     constexpr auto number_of_nodes = size_t{1U};
+    constexpr auto number_of_simd_nodes = size_t{1U};
     constexpr auto number_of_qps = size_t{1};
 
     const auto qp_weights = get_qp_weights<number_of_qps>({1.});
@@ -277,7 +284,7 @@ void IntegrateInertiaMatrix_TestOneElementOneNodeOneQP_WithMultiplicationFactor(
 
     const auto gbl_M = Kokkos::View<double[1][1][1][6][6]>("global_M");
 
-    const auto policy = Kokkos::RangePolicy(0, number_of_nodes);
+    const auto policy = Kokkos::RangePolicy(0, number_of_nodes * number_of_simd_nodes);
     const auto integrator = IntegrateInertiaMatrixElement{
         0U,     number_of_nodes, number_of_qps,         qp_weights, qp_jacobian, shape_interp,
         qp_Muu, qp_Guu,          multiplication_factor, 0.,         gbl_M};

--- a/tests/unit_tests/system/test_integrate_stiffness_matrix.cpp
+++ b/tests/unit_tests/system/test_integrate_stiffness_matrix.cpp
@@ -17,6 +17,7 @@ void TestIntegrateStiffnessMatrix_1Element1Node1QP(
     const Kokkos::View<const double[1][6][6]>& qp_Quu, const std::array<double, 36>& exact_M_data
 ) {
     constexpr auto number_of_nodes = size_t{1U};
+    constexpr auto number_of_simd_nodes = size_t{1U};
     constexpr auto number_of_qps = size_t{1U};
 
     const auto qp_weights = get_qp_weights<number_of_qps>({2.});
@@ -26,7 +27,7 @@ void TestIntegrateStiffnessMatrix_1Element1Node1QP(
 
     auto gbl_M = Kokkos::View<double[1][1][1][6][6]>("global_M");
 
-    const auto policy = Kokkos::RangePolicy(0, number_of_nodes);
+    const auto policy = Kokkos::RangePolicy(0, number_of_nodes * number_of_simd_nodes);
     const auto integrator = IntegrateStiffnessMatrixElement{0U,
                                                             number_of_nodes,
                                                             number_of_qps,
@@ -198,6 +199,7 @@ TEST(IntegrateStiffnessMatrixTests, OneElementOneNodeOneQP_Ouu) {
 
 void TestIntegrateStiffnessMatrix_2Elements1Node1QP() {
     constexpr auto number_of_nodes = size_t{1U};
+    constexpr auto number_of_simd_nodes = size_t{1U};
     constexpr auto number_of_qps = size_t{1U};
 
     const auto qp_weights = get_qp_weights<number_of_qps>({1.});
@@ -220,7 +222,7 @@ void TestIntegrateStiffnessMatrix_2Elements1Node1QP() {
              00301., 00302., 00303., 00304., 00305., 00306., 00401., 00402., 00403.,
              00404., 00405., 00406., 00501., 00502., 00503., 00504., 00505., 00506.}
         );
-        const auto policy = Kokkos::RangePolicy(0, number_of_nodes);
+        const auto policy = Kokkos::RangePolicy(0, number_of_nodes * number_of_simd_nodes);
         const auto integrator = IntegrateStiffnessMatrixElement{0U,
                                                                 number_of_nodes,
                                                                 number_of_qps,
@@ -244,7 +246,7 @@ void TestIntegrateStiffnessMatrix_2Elements1Node1QP() {
              30001., 30002., 30003., 30004., 30005., 30006., 40001., 40002., 40003.,
              40004., 40005., 40006., 50001., 50002., 50003., 50004., 50005., 50006.}
         );
-        const auto policy = Kokkos::RangePolicy(0, number_of_nodes);
+        const auto policy = Kokkos::RangePolicy(0, number_of_nodes * number_of_simd_nodes);
         const auto integrator = IntegrateStiffnessMatrixElement{1U,
                                                                 number_of_nodes,
                                                                 number_of_qps,
@@ -292,6 +294,8 @@ void TestIntegrateStiffnessMatrix_1Element2Nodes1QP(
     const Kokkos::View<const double[1][6][6]>& qp_Quu, const std::array<double, 144>& exact_M_data
 ) {
     constexpr auto number_of_nodes = size_t{2U};
+    constexpr auto simd_width = Kokkos::Experimental::native_simd<double>::size();
+    constexpr auto number_of_simd_nodes = (simd_width == 1) ? size_t{2U} : size_t{1U};
     constexpr auto number_of_qps = size_t{1U};
 
     const auto qp_weights = get_qp_weights<number_of_qps>({1.});
@@ -301,7 +305,7 @@ void TestIntegrateStiffnessMatrix_1Element2Nodes1QP(
 
     auto gbl_M = Kokkos::View<double[1][2][2][6][6]>("global_M");
 
-    const auto policy = Kokkos::RangePolicy(0, number_of_nodes);
+    const auto policy = Kokkos::RangePolicy(0, number_of_nodes * number_of_simd_nodes);
     const auto integrator = IntegrateStiffnessMatrixElement{0U,
                                                             number_of_nodes,
                                                             number_of_qps,
@@ -481,6 +485,7 @@ void TestIntegrateStiffnessMatrix_1Element1Node2QPs(
     const Kokkos::View<const double[2][6][6]>& qp_Quu, const std::array<double, 36>& exact_M_data
 ) {
     constexpr auto number_of_nodes = size_t{1U};
+    constexpr auto number_of_simd_nodes = size_t{1U};
     constexpr auto number_of_qps = size_t{2U};
 
     const auto qp_weights = get_qp_weights<number_of_qps>({1., 3.});
@@ -490,7 +495,7 @@ void TestIntegrateStiffnessMatrix_1Element1Node2QPs(
 
     auto gbl_M = Kokkos::View<double[1][1][1][6][6]>("global_M");
 
-    const auto policy = Kokkos::RangePolicy(0, number_of_nodes);
+    const auto policy = Kokkos::RangePolicy(0, number_of_nodes * number_of_simd_nodes);
     const auto integrator = IntegrateStiffnessMatrixElement{0U,
                                                             number_of_nodes,
                                                             number_of_qps,


### PR DESCRIPTION
The result is a 4-5x speed up of those kernels on GPU and a 20%+ speed up overall of the 10s IEA15RotorHub problem.

This potentially creates a pattern that we can use for other middle loops that can be SIMD-ified or else have more parallelism exposed for GPU work.