### PR TITLE
Adds additional CI lines for building external codes where sanitizers are turned off

### DIFF
--- a/.github/workflows/correctness-linux.yaml
+++ b/.github/workflows/correctness-linux.yaml
@@ -14,6 +14,7 @@ jobs:
       matrix:
         compiler: [g++, clang++]
         build_type: [Release, Debug]
+        build_external: [all, none]
     steps:
     - name: Cache install Dependencies
       id: cache-dependencies
@@ -47,13 +48,13 @@ jobs:
         mkdir build
         cd build
         cmake .. \
-          -DOpenTurbine_ENABLE_SANITIZER_ADDRESS=ON \
-          -DOpenTurbine_ENABLE_SANITIZER_LEAK=ON \
-          -DOpenTurbine_ENABLE_SANITIZER_UNDEFINED=ON \
+          -DOpenTurbine_ENABLE_SANITIZER_ADDRESS=${{ matrix.build_external == 'none' }} \
+          -DOpenTurbine_ENABLE_SANITIZER_LEAK=${{ matrix.build_external == 'none' }} \
+          -DOpenTurbine_ENABLE_SANITIZER_UNDEFINED=${{ matrix.build_external == 'none' }} \
           -DOpenTurbine_ENABLE_CPPCHECK=ON \
           -DOpenTurbine_ENABLE_CLANG_TIDY=ON \
-          -DOpenTurbine_BUILD_OPENFAST_ADI=ON \
-          -DOpenTurbine_BUILD_ROSCO_CONTROLLER=ON \
+          -DOpenTurbine_BUILD_OPENFAST_ADI=${{ matrix.build_external == 'all' }} \
+          -DOpenTurbine_BUILD_ROSCO_CONTROLLER=${{ matrix.build_external == 'all' }} \
           -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
         cmake --build .
         ctest --output-on-failure

--- a/.github/workflows/correctness-macos.yaml
+++ b/.github/workflows/correctness-macos.yaml
@@ -13,6 +13,7 @@ jobs:
       matrix:
         compiler: [g++, clang++]
         build_type: [Release, Debug]
+        build_external: [all, none]
     steps:
     - name: Cache install Dependencies
       id: cache-dependencies
@@ -53,13 +54,13 @@ jobs:
         mkdir build
         cd build
         cmake .. \
-          -DOpenTurbine_ENABLE_SANITIZER_ADDRESS=ON \
-          -DOpenTurbine_ENABLE_SANITIZER_UNDEFINED=ON \
+          -DOpenTurbine_ENABLE_SANITIZER_ADDRESS=${{ matrix.build_external == 'none' }} \
+          -DOpenTurbine_ENABLE_SANITIZER_UNDEFINED=${{ matrix.build_external == 'none' }} \
           -DOpenTurbine_ENABLE_CPPCHECK=ON \
           -DOpenTurbine_ENABLE_CLANG_TIDY=ON \
           -DOpenTurbine_ENABLE_VTK=ON \
-          -DOpenTurbine_BUILD_OPENFAST_ADI=ON \
-          -DOpenTurbine_BUILD_ROSCO_CONTROLLER=ON \
+          -DOpenTurbine_BUILD_OPENFAST_ADI=${{ matrix.build_external == 'all' }} \
+          -DOpenTurbine_BUILD_ROSCO_CONTROLLER=${{ matrix.build_external == 'all' }} \
           -DCMAKE_CXX_COMPILER=${{ matrix.compiler }} \
           -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
         cmake --build .


### PR DESCRIPTION
This provides the best of both worlds - we get full sanitizer checks when testing our code while not holding external libraries to the same standards.  