### PR TITLE
The clang-tidy congnitive complexity check no longer expands macros.

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -21,6 +21,8 @@ Checks: "bugprone*,
          -bugprone-easily-swappable-parameters,
          -readability-named-parameter,
 "
+CheckOptions:
+  readability-function-cognitive-complexity.IgnoreMacros: 'true'
 WarningsAsErrors: ''
 HeaderFilterRegex: '.*'
 FormatStyle:     none

--- a/tests/unit_tests/system/test_calculate.hpp
+++ b/tests/unit_tests/system/test_calculate.hpp
@@ -44,7 +44,6 @@ inline void CompareWithExpected(
     }
 }
 
-// NOLINTBEGIN(readability-function-cognitive-complexity)
 inline void CompareWithExpected(
     const Kokkos::View<const double*****>::host_mirror_type& result,
     const Kokkos::View<const double*****, Kokkos::HostSpace>& expected
@@ -61,5 +60,4 @@ inline void CompareWithExpected(
         }
     }
 }
-// NOLINTEND(readability-function-cognitive-complexity)
 }  // namespace openturbine::tests


### PR DESCRIPTION
This change should get rid of warnings about the complexity of code in our unit tests when working with the GTest macros.