### PR TITLE
Build recipes for openturbine

### DIFF
--- a/recipes/Dockerfile
+++ b/recipes/Dockerfile
@@ -1,3 +1,6 @@
+# Run this from the root of the OpenTurbine repository e.g.
+# docker build -f recipes/Dockerfile -t openturbine:latest .
+
 FROM ubuntu:latest
 
 # Use bash as the default shell

--- a/recipes/Dockerfile
+++ b/recipes/Dockerfile
@@ -17,6 +17,7 @@ RUN apt-get update -qq && \
         make \
         python3 \
         python3-pip \
+        unzip \
         wget && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
@@ -48,11 +49,12 @@ ARG CMAKE_OPTIONS="-DOpenTurbine_ENABLE_SANITIZER_ADDRESS=ON \
     -DOpenTurbine_BUILD_ROSCO_CONTROLLER=ON \
     -DCMAKE_BUILD_TYPE=Debug"
 
+ARG N_PARALLEL_JOBS=4
+
 RUN . /spack/share/spack/setup-env.sh && \
-    spack load trilinos && \
-    spack load yaml-cpp && \
-    spack load vtk && \
+    spack load cppcheck googletest trilinos vtk yaml-cpp && \
     mkdir docker-build && \
     cd docker-build && \
     cmake .. ${CMAKE_OPTIONS} && \
-    cmake --build . -j 4
+    cmake --build . -j ${N_PARALLEL_JOBS} && \
+    ctest --output-on-failure -j ${N_PARALLEL_JOBS}

--- a/recipes/Dockerfile
+++ b/recipes/Dockerfile
@@ -1,0 +1,58 @@
+FROM ubuntu:latest
+
+# Use bash as the default shell
+SHELL ["/bin/bash", "-c"]
+
+# Step 1: Install required packages and tools
+RUN apt-get update -qq && \
+    apt-get install -y \
+        build-essential \
+        clang-tidy \
+        cmake \
+        curl \
+        g++ \
+        gfortran \
+        git \
+        libcurl4-openssl-dev \
+        make \
+        python3 \
+        python3-pip \
+        wget && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+# Step 2: Get spack and install necessary libraries using it
+RUN git clone https://github.com/spack/spack.git && \
+    source spack/share/spack/setup-env.sh && \
+    spack compiler find && \
+    spack external find && \
+    spack mirror add spack-public https://mirror.spack.io && \
+    spack install googletest && \
+    spack --insecure install cppcheck && \
+    spack install yaml-cpp && \
+    spack --insecure install trilinos@16.0.0~mpi~epetra && \
+    spack --insecure install vtk~mpi~opengl2
+
+# Step 3: Set up the working directory and copy the OpenTurbine repository
+WORKDIR /projects/openturbine
+COPY . .
+
+# Step 4: Load necessary libraries and build the project
+ARG CMAKE_OPTIONS="-DOpenTurbine_ENABLE_SANITIZER_ADDRESS=ON \
+    -DOpenTurbine_ENABLE_SANITIZER_LEAK=ON \
+    -DOpenTurbine_ENABLE_SANITIZER_UNDEFINED=ON \
+    -DOpenTurbine_ENABLE_CPPCHECK=ON \
+    -DOpenTurbine_ENABLE_CLANG_TIDY=ON \
+    -DOpenTurbine_ENABLE_VTK=ON \
+    -DOpenTurbine_BUILD_OPENFAST_ADI=ON \
+    -DOpenTurbine_BUILD_ROSCO_CONTROLLER=ON \
+    -DCMAKE_BUILD_TYPE=Debug"
+
+RUN . /spack/share/spack/setup-env.sh && \
+    spack load trilinos && \
+    spack load yaml-cpp && \
+    spack load vtk && \
+    mkdir docker-build && \
+    cd docker-build && \
+    cmake .. ${CMAKE_OPTIONS} && \
+    cmake --build . -j 4

--- a/recipes/Dockerfile
+++ b/recipes/Dockerfile
@@ -42,15 +42,10 @@ WORKDIR /projects/openturbine
 COPY . .
 
 # Step 4: Load necessary libraries and build the project
-ARG CMAKE_OPTIONS="-DOpenTurbine_ENABLE_SANITIZER_ADDRESS=ON \
-    -DOpenTurbine_ENABLE_SANITIZER_LEAK=ON \
-    -DOpenTurbine_ENABLE_SANITIZER_UNDEFINED=ON \
-    -DOpenTurbine_ENABLE_CPPCHECK=ON \
-    -DOpenTurbine_ENABLE_CLANG_TIDY=ON \
-    -DOpenTurbine_ENABLE_VTK=ON \
+ARG CMAKE_OPTIONS="-DOpenTurbine_ENABLE_VTK=ON \
     -DOpenTurbine_BUILD_OPENFAST_ADI=ON \
     -DOpenTurbine_BUILD_ROSCO_CONTROLLER=ON \
-    -DCMAKE_BUILD_TYPE=Debug"
+    -DCMAKE_BUILD_TYPE=Release"
 
 ARG N_PARALLEL_JOBS=4
 

--- a/recipes/build_recipe_macos.sh
+++ b/recipes/build_recipe_macos.sh
@@ -9,19 +9,30 @@ if [ ! -d "openturbine" ]; then
 fi
 cd openturbine
 
-# Install dependencies using Spack (assumes spack is not present in the system)
+# Install dependencies using Spack
 if [ ! -d "spack" ]; then
     git clone https://github.com/spack/spack.git
 fi
 source spack/share/spack/setup-env.sh
 spack compiler find
 spack external find
-spack install googletest
-spack install llvm
-spack install cppcheck
-spack install yaml-cpp
-spack install vtk~mpi~opengl2
-spack install trilinos@master~mpi~epetra
+
+# Install required packages
+install_if_missing() {
+    if ! spack find -l "$1" | grep -q "$1"; then
+        echo "Installing $1..."
+        spack install "$1"
+    else
+        echo "$1 is already installed."
+    fi
+}
+
+install_if_missing googletest
+install_if_missing llvm
+install_if_missing cppcheck
+install_if_missing yaml-cpp
+install_if_missing "vtk~mpi~opengl2"
+install_if_missing "trilinos@16.0.0~mpi~epetra"
 
 # Load required packages
 spack load llvm

--- a/recipes/build_recipe_macos.sh
+++ b/recipes/build_recipe_macos.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+
+# Exit on error
+set -e
+
+# Clone OpenTurbine repository if not present
+if [ ! -d "openturbine" ]; then
+    git clone --recursive https://github.com/Exawind/openturbine.git
+fi
+cd openturbine
+
+# Install dependencies using Spack (assumes spack is not present in the system)
+if [ ! -d "spack" ]; then
+    git clone https://github.com/spack/spack.git
+fi
+source spack/share/spack/setup-env.sh
+spack compiler find
+spack external find
+spack install googletest
+spack install llvm
+spack install cppcheck
+spack install yaml-cpp
+spack install vtk~mpi~opengl2
+spack install trilinos@master~mpi~epetra
+
+# Load required packages
+spack load llvm
+spack load cppcheck
+spack load trilinos
+spack load googletest
+spack load yaml-cpp
+spack load vtk
+
+# Find gfortran compiler
+if ! command -v brew &> /dev/null; then
+    echo "Homebrew is not installed. Please install it first."
+    exit 1
+fi
+export FC=$(find /opt/homebrew/ -name gfortran | tr ' ' '\n' | grep "/gcc/.*gfortran")
+
+# Build OpenTurbine with following options - modify as needed
+BUILD_TYPE="Release" # Release, Debug, RelWithDebInfo
+CXX_COMPILER="clang++" # g++, clang++
+BUILD_EXTERNAL="all" # all, none
+
+mkdir -p build
+cd build
+cmake .. \
+  -DOpenTurbine_ENABLE_SANITIZER_ADDRESS=$([[ "$BUILD_EXTERNAL" == "none" ]] && echo "ON" || echo "OFF") \
+  -DOpenTurbine_ENABLE_SANITIZER_UNDEFINED=$([[ "$BUILD_EXTERNAL" == "none" ]] && echo "ON" || echo "OFF") \
+  -DOpenTurbine_ENABLE_CPPCHECK=ON \
+  -DOpenTurbine_ENABLE_CLANG_TIDY=ON \
+  -DOpenTurbine_ENABLE_VTK=ON \
+  -DOpenTurbine_BUILD_OPENFAST_ADI=$([[ "$BUILD_EXTERNAL" == "all" ]] && echo "ON" || echo "OFF") \
+  -DOpenTurbine_BUILD_ROSCO_CONTROLLER=$([[ "$BUILD_EXTERNAL" == "all" ]] && echo "ON" || echo "OFF") \
+  -DCMAKE_CXX_COMPILER="$CXX_COMPILER" \
+  -DCMAKE_BUILD_TYPE="$BUILD_TYPE"
+
+cmake --build .
+
+# Run tests
+ctest --output-on-failure

--- a/recipes/build_recipe_macos.sh
+++ b/recipes/build_recipe_macos.sh
@@ -1,23 +1,30 @@
 #!/bin/bash
 
+# -----------------------------------------------------------------------------
+# Run this from the root of the OpenTurbine repository with the following arguments:
+# ./recipes/build_recipe_macos.sh <path_to_openturbine_root> <path_to_spack_root>
+# -----------------------------------------------------------------------------
+
 # Exit on error
 set -e
 
-# Clone OpenTurbine repository if not present
-if [ ! -d "openturbine" ]; then
-    git clone --recursive https://github.com/Exawind/openturbine.git
+# Clone OpenTurbine repository if not present in the provided path
+openturbine_path=$(dirname "$1") # Get the directory of the provided path
+if [ ! -d "$openturbine_path/openturbine" ]; then
+    git clone --recursive https://github.com/Exawind/openturbine.git $openturbine_path/openturbine
 fi
-cd openturbine
+cd $openturbine_path/openturbine
 
-# Install dependencies using Spack
-if [ ! -d "spack" ]; then
-    git clone https://github.com/spack/spack.git
+# Install Spack if not present in the provided path
+spack_path=$(dirname "$2") # Get the directory of the provided path
+if [ ! -d "$spack_path/spack" ]; then
+    git clone https://github.com/spack/spack.git $spack_path/spack
 fi
-source spack/share/spack/setup-env.sh
+source $spack_path/spack/share/spack/setup-env.sh
 spack compiler find
 spack external find
 
-# Install required packages
+# Install required packages using Spack if not present
 install_if_missing() {
     if ! spack find -l "$1" | grep -q "$1"; then
         echo "Installing $1..."

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -19,7 +19,7 @@ target_link_libraries(openturbine_library PRIVATE
 target_link_system_libraries(openturbine_library PRIVATE
   KokkosKernels::kokkoskernels
   Amesos2::amesos2
-  yaml-cpp
+  yaml-cpp::yaml-cpp
   ${FS_LIB}
 )
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -16,10 +16,16 @@ target_link_libraries(openturbine_library PRIVATE
 )
 
 # Link system libraries
+if(TARGET yaml-cpp::yaml-cpp)
+  set(YAML_CPP_TARGET yaml-cpp::yaml-cpp)
+else()
+  set(YAML_CPP_TARGET yaml-cpp)
+endif()
+
 target_link_system_libraries(openturbine_library PRIVATE
   KokkosKernels::kokkoskernels
   Amesos2::amesos2
-  yaml-cpp::yaml-cpp
+  ${YAML_CPP_TARGET}
   ${FS_LIB}
 )
 

--- a/tests/unit_tests/CMakeLists.txt
+++ b/tests/unit_tests/CMakeLists.txt
@@ -21,10 +21,16 @@ target_link_libraries(openturbine_unit_tests PRIVATE
 )
 
 # Link system libraries and dependencies
+if(TARGET yaml-cpp::yaml-cpp)
+  set(YAML_CPP_TARGET yaml-cpp::yaml-cpp)
+else()
+  set(YAML_CPP_TARGET yaml-cpp)
+endif()
+
 target_link_system_libraries(openturbine_unit_tests PRIVATE
   KokkosKernels::kokkoskernels
   Amesos2::amesos2
-  yaml-cpp::yaml-cpp
+  ${YAML_CPP_TARGET}
   GTest::gtest
   GTest::gtest_main
 )

--- a/tests/unit_tests/CMakeLists.txt
+++ b/tests/unit_tests/CMakeLists.txt
@@ -24,7 +24,7 @@ target_link_libraries(openturbine_unit_tests PRIVATE
 target_link_system_libraries(openturbine_unit_tests PRIVATE
   KokkosKernels::kokkoskernels
   Amesos2::amesos2
-  yaml-cpp
+  yaml-cpp::yaml-cpp
   GTest::gtest
   GTest::gtest_main
 )


### PR DESCRIPTION
This pull request introduces a `recipes` directory with two introductory formulas to streamline the build process for OpenTurbine: a build recipe for macOS (`build_recipe_macos.sh`) and a `Dockerfile` for containerized builds. 

- The macOS script automates the installation of dependencies using `Spack`, sets up the build environment, and compiles OpenTurbine with configurable options
- The Dockerfile creates a Ubuntu-based container that installs necessary tools, uses `Spack` to manage dependencies, and builds OpenTurbine with sanitizers and additional features enabled.

These additions aim to lower the barrier to entry for contributing to OpenTurbine, making it easier for developers to set up and contribute to the project.