### PR TITLE
Added initial data structures and algorithms to support different element types

### DIFF
--- a/src/beams/beams.hpp
+++ b/src/beams/beams.hpp
@@ -156,8 +156,8 @@ struct Beams {
           // Shape Function data
           shape_interp("shape_interp", num_elems, max_elem_nodes, max_elem_qps),
           shape_deriv("deriv_interp", num_elems, max_elem_nodes, max_elem_qps) {
-    Kokkos::deep_copy(element_freedom_signature, FreedomSignature::AllComponents);
-}
+        Kokkos::deep_copy(element_freedom_signature, FreedomSignature::AllComponents);
+    }
 };
 
 }  // namespace openturbine

--- a/src/beams/beams.hpp
+++ b/src/beams/beams.hpp
@@ -2,6 +2,7 @@
 
 #include <Kokkos_Core.hpp>
 
+#include "src/dof_management/freedom_signature.hpp"
 #include "src/types.hpp"
 
 namespace openturbine {
@@ -26,6 +27,9 @@ struct Beams {
     Kokkos::View<size_t*> num_nodes_per_element;
     Kokkos::View<size_t*> num_qps_per_element;
     Kokkos::View<size_t**> node_state_indices;  // State row index for each node
+    Kokkos::View<FreedomSignature**> element_freedom_signature;
+    Kokkos::View<size_t** [7]> element_freedom_table;
+
 
     View_3 gravity;
 
@@ -95,6 +99,8 @@ struct Beams {
           num_nodes_per_element("num_nodes_per_element", num_elems),
           num_qps_per_element("num_qps_per_element", num_elems),
           node_state_indices("node_state_indices", num_elems, max_elem_nodes),
+          element_freedom_signature("element_freedom_signature", num_elems, max_elem_nodes),
+          element_freedom_table("element_freedom_table", num_elems, max_elem_nodes),
           gravity("gravity"),
           // Node Data
           node_x0("node_x0", num_elems, max_elem_nodes),
@@ -150,7 +156,9 @@ struct Beams {
           inertia_matrix_terms("inertia_matrix_terms", num_elems, max_elem_nodes, max_elem_nodes),
           // Shape Function data
           shape_interp("shape_interp", num_elems, max_elem_nodes, max_elem_qps),
-          shape_deriv("deriv_interp", num_elems, max_elem_nodes, max_elem_qps) {}
+          shape_deriv("deriv_interp", num_elems, max_elem_nodes, max_elem_qps) {
+    Kokkos::deep_copy(element_freedom_signature, FreedomSignature::AllComponents);
+}
 };
 
 }  // namespace openturbine

--- a/src/beams/beams.hpp
+++ b/src/beams/beams.hpp
@@ -30,7 +30,6 @@ struct Beams {
     Kokkos::View<FreedomSignature**> element_freedom_signature;
     Kokkos::View<size_t** [7]> element_freedom_table;
 
-
     View_3 gravity;
 
     // Node-based data

--- a/src/beams/beams.hpp
+++ b/src/beams/beams.hpp
@@ -28,7 +28,7 @@ struct Beams {
     Kokkos::View<size_t*> num_qps_per_element;
     Kokkos::View<size_t**> node_state_indices;  // State row index for each node
     Kokkos::View<FreedomSignature**> element_freedom_signature;
-    Kokkos::View<size_t** [7]> element_freedom_table;
+    Kokkos::View<size_t** [6]> element_freedom_table;
 
     View_3 gravity;
 

--- a/src/beams/create_beams.hpp
+++ b/src/beams/create_beams.hpp
@@ -19,6 +19,7 @@ inline Beams CreateBeams(const BeamsInput& beams_input) {
     auto host_num_nodes_per_element = Kokkos::create_mirror(beams.num_nodes_per_element);
     auto host_num_qps_per_element = Kokkos::create_mirror(beams.num_qps_per_element);
     auto host_node_state_indices = Kokkos::create_mirror(beams.node_state_indices);
+    auto host_element_freedom_table = Kokkos::create_mirror(beams.element_freedom_table);
     auto host_node_x0 = Kokkos::create_mirror(beams.node_x0);
     auto host_node_u = Kokkos::create_mirror(beams.node_u);
     auto host_node_u_dot = Kokkos::create_mirror(beams.node_u_dot);
@@ -48,6 +49,9 @@ inline Beams CreateBeams(const BeamsInput& beams_input) {
         for (size_t j = 0; j < num_nodes; ++j) {
             host_node_state_indices(i, j) =
                 static_cast<size_t>(beams_input.elements[i].nodes[j].node.ID);
+            for (size_t k = 0; k < num_nodes; ++k) {
+                host_element_freedom_table(i, j, k) = host_node_state_indices(i, j) + k;
+            }
         }
 
         // Populate views for this element
@@ -76,6 +80,7 @@ inline Beams CreateBeams(const BeamsInput& beams_input) {
     Kokkos::deep_copy(beams.num_nodes_per_element, host_num_nodes_per_element);
     Kokkos::deep_copy(beams.num_qps_per_element, host_num_qps_per_element);
     Kokkos::deep_copy(beams.node_state_indices, host_node_state_indices);
+    Kokkos::deep_copy(beams.element_freedom_table, host_element_freedom_table);
     Kokkos::deep_copy(beams.node_x0, host_node_x0);
     Kokkos::deep_copy(beams.node_u, host_node_u);
     Kokkos::deep_copy(beams.node_u_dot, host_node_u_dot);

--- a/src/beams/create_beams.hpp
+++ b/src/beams/create_beams.hpp
@@ -19,7 +19,6 @@ inline Beams CreateBeams(const BeamsInput& beams_input) {
     auto host_num_nodes_per_element = Kokkos::create_mirror(beams.num_nodes_per_element);
     auto host_num_qps_per_element = Kokkos::create_mirror(beams.num_qps_per_element);
     auto host_node_state_indices = Kokkos::create_mirror(beams.node_state_indices);
-    auto host_element_freedom_table = Kokkos::create_mirror(beams.element_freedom_table);
     auto host_node_x0 = Kokkos::create_mirror(beams.node_x0);
     auto host_node_u = Kokkos::create_mirror(beams.node_u);
     auto host_node_u_dot = Kokkos::create_mirror(beams.node_u_dot);
@@ -49,9 +48,6 @@ inline Beams CreateBeams(const BeamsInput& beams_input) {
         for (size_t j = 0; j < num_nodes; ++j) {
             host_node_state_indices(i, j) =
                 static_cast<size_t>(beams_input.elements[i].nodes[j].node.ID);
-            for (size_t k = 0; k < num_nodes; ++k) {
-                host_element_freedom_table(i, j, k) = host_node_state_indices(i, j) + k;
-            }
         }
 
         // Populate views for this element
@@ -80,7 +76,6 @@ inline Beams CreateBeams(const BeamsInput& beams_input) {
     Kokkos::deep_copy(beams.num_nodes_per_element, host_num_nodes_per_element);
     Kokkos::deep_copy(beams.num_qps_per_element, host_num_qps_per_element);
     Kokkos::deep_copy(beams.node_state_indices, host_node_state_indices);
-    Kokkos::deep_copy(beams.element_freedom_table, host_element_freedom_table);
     Kokkos::deep_copy(beams.node_x0, host_node_x0);
     Kokkos::deep_copy(beams.node_u, host_node_u);
     Kokkos::deep_copy(beams.node_u_dot, host_node_u_dot);

--- a/src/dof_management/assemble_node_freedom_allocation_table.hpp
+++ b/src/dof_management/assemble_node_freedom_allocation_table.hpp
@@ -10,17 +10,21 @@
 namespace openturbine {
 
 inline void assemble_node_freedom_allocation_table(State& state, const Beams& beams) {
-    Kokkos::parallel_for("Assemble Node Freedom Map Table", 1, KOKKOS_LAMBDA(size_t) {
-        for(auto i = 0U; i < beams.num_elems; ++i) {
-            const auto num_nodes = beams.num_nodes_per_element(i);
-            for(auto j = 0U; j < num_nodes; ++j) {
-                const auto node_index = beams.node_state_indices(i, j);
-                const auto current_signature = state.node_freedom_allocation_table(node_index);
-                const auto contributed_signature = beams.element_freedom_signature(i, j);
-                state.node_freedom_allocation_table(node_index) = current_signature | contributed_signature;
+    Kokkos::parallel_for(
+        "Assemble Node Freedom Map Table", 1,
+        KOKKOS_LAMBDA(size_t) {
+            for (auto i = 0U; i < beams.num_elems; ++i) {
+                const auto num_nodes = beams.num_nodes_per_element(i);
+                for (auto j = 0U; j < num_nodes; ++j) {
+                    const auto node_index = beams.node_state_indices(i, j);
+                    const auto current_signature = state.node_freedom_allocation_table(node_index);
+                    const auto contributed_signature = beams.element_freedom_signature(i, j);
+                    state.node_freedom_allocation_table(node_index) =
+                        current_signature | contributed_signature;
+                }
             }
         }
-    });
+    );
 }
 
-}
+}  // namespace openturbine

--- a/src/dof_management/assemble_node_freedom_allocation_table.hpp
+++ b/src/dof_management/assemble_node_freedom_allocation_table.hpp
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <Kokkos_Core.hpp>
+
+#include "freedom_signature.hpp"
+
+#include "src/beams/beams.hpp"
+#include "src/state/state.hpp"
+
+namespace openturbine {
+
+inline void assemble_node_freedom_allocation_table(State& state, const Beams& beams) {
+    Kokkos::parallel_for("Assemble Node Freedom Map Table", 1, KOKKOS_LAMBDA(size_t) {
+        for(auto i = 0U; i < beams.num_elems; ++i) {
+            const auto num_nodes = beams.num_nodes_per_element(i);
+            for(auto j = 0U; j < num_nodes; ++j) {
+                const auto node_index = beams.node_state_indices(i, j);
+                const auto current_signature = state.node_freedom_allocation_table(node_index);
+                const auto contributed_signature = beams.element_freedom_signature(i, j);
+                state.node_freedom_allocation_table(node_index) = current_signature | contributed_signature;
+            }
+        }
+    });
+}
+
+}

--- a/src/dof_management/compute_node_freedom_map_table.hpp
+++ b/src/dof_management/compute_node_freedom_map_table.hpp
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <Kokkos_Core.hpp>
+
+#include "freedom_signature.hpp"
+
+#include "src/beams/beams.hpp"
+#include "src/state/state.hpp"
+
+namespace openturbine {
+
+inline void compute_node_freedom_map_table(State& state) {
+    Kokkos::parallel_for("Compute Node Freedom Map Table", 1, KOKKOS_LAMBDA(size_t) {
+        state.node_freedom_map_table(0) = 0U;
+        for(auto i = 1U; i < state.num_system_nodes; ++i) {
+            const auto num_dof = count_active_dofs(state.node_freedom_allocation_table(i-1));
+            state.node_freedom_map_table(i) = state.node_freedom_map_table(i-1) + num_dof;
+        }
+    });
+}
+
+}

--- a/src/dof_management/compute_node_freedom_map_table.hpp
+++ b/src/dof_management/compute_node_freedom_map_table.hpp
@@ -10,13 +10,16 @@
 namespace openturbine {
 
 inline void compute_node_freedom_map_table(State& state) {
-    Kokkos::parallel_for("Compute Node Freedom Map Table", 1, KOKKOS_LAMBDA(size_t) {
-        state.node_freedom_map_table(0) = 0U;
-        for(auto i = 1U; i < state.num_system_nodes; ++i) {
-            const auto num_dof = count_active_dofs(state.node_freedom_allocation_table(i-1));
-            state.node_freedom_map_table(i) = state.node_freedom_map_table(i-1) + num_dof;
+    Kokkos::parallel_for(
+        "Compute Node Freedom Map Table", 1,
+        KOKKOS_LAMBDA(size_t) {
+            state.node_freedom_map_table(0) = 0U;
+            for (auto i = 1U; i < state.num_system_nodes; ++i) {
+                const auto num_dof = count_active_dofs(state.node_freedom_allocation_table(i - 1));
+                state.node_freedom_map_table(i) = state.node_freedom_map_table(i - 1) + num_dof;
+            }
         }
-    });
+    );
 }
 
-}
+}  // namespace openturbine

--- a/src/dof_management/create_element_freedom_table.hpp
+++ b/src/dof_management/create_element_freedom_table.hpp
@@ -17,7 +17,7 @@ inline void create_element_freedom_table(Beams& beams, const State& state) {
                 const auto num_nodes = beams.num_nodes_per_element(i);
                 for (auto j = 0U; j < num_nodes; ++j) {
                     const auto node_index = beams.node_state_indices(i, j);
-                    for (auto k = 0U; k < 7U; ++k) {
+                    for (auto k = 0U; k < 6U; ++k) {
                         beams.element_freedom_table(i, j, k) =
                             state.node_freedom_map_table(node_index) + k;
                     }

--- a/src/dof_management/create_element_freedom_table.hpp
+++ b/src/dof_management/create_element_freedom_table.hpp
@@ -10,17 +10,21 @@
 namespace openturbine {
 
 inline void create_element_freedom_table(Beams& beams, const State& state) {
-    Kokkos::parallel_for("Create Element Freedom Table", 1, KOKKOS_LAMBDA(size_t) {
-        for(auto i = 0U; i < beams.num_elems; ++i) {
-            const auto num_nodes = beams.num_nodes_per_element(i);
-            for(auto j = 0U; j < num_nodes; ++j) {
-                const auto node_index = beams.node_state_indices(i, j);
-                for(auto k = 0U; k < 7U; ++k) {
-                    beams.element_freedom_table(i, j, k) = state.node_freedom_map_table(node_index) + k;
+    Kokkos::parallel_for(
+        "Create Element Freedom Table", 1,
+        KOKKOS_LAMBDA(size_t) {
+            for (auto i = 0U; i < beams.num_elems; ++i) {
+                const auto num_nodes = beams.num_nodes_per_element(i);
+                for (auto j = 0U; j < num_nodes; ++j) {
+                    const auto node_index = beams.node_state_indices(i, j);
+                    for (auto k = 0U; k < 7U; ++k) {
+                        beams.element_freedom_table(i, j, k) =
+                            state.node_freedom_map_table(node_index) + k;
+                    }
                 }
             }
         }
-    });
+    );
 }
 
-}
+}  // namespace openturbine

--- a/src/dof_management/create_element_freedom_table.hpp
+++ b/src/dof_management/create_element_freedom_table.hpp
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <Kokkos_Core.hpp>
+
+#include "freedom_signature.hpp"
+
+#include "src/beams/beams.hpp"
+#include "src/state/state.hpp"
+
+namespace openturbine {
+
+inline void create_element_freedom_table(Beams& beams, const State& state) {
+    Kokkos::parallel_for("Create Element Freedom Table", 1, KOKKOS_LAMBDA(size_t) {
+        for(auto i = 0U; i < beams.num_elems; ++i) {
+            const auto num_nodes = beams.num_nodes_per_element(i);
+            for(auto j = 0U; j < num_nodes; ++j) {
+                const auto node_index = beams.node_state_indices(i, j);
+                for(auto k = 0U; k < 7U; ++k) {
+                    beams.element_freedom_table(i, j, k) = state.node_freedom_map_table(node_index) + k;
+                }
+            }
+        }
+    });
+}
+
+}

--- a/src/dof_management/freedom_signature.hpp
+++ b/src/dof_management/freedom_signature.hpp
@@ -7,9 +7,9 @@
 namespace openturbine {
 
 enum class FreedomSignature : std::uint8_t {
-    AllComponents = 0b01111111,
-    JustPosition = 0b01110000,
-    JustRotation = 0b00001111,
+    AllComponents = 0b00111111,
+    JustPosition = 0b00111000,
+    JustRotation = 0b00000111,
     NoComponents = 0b00000000
 };
 

--- a/src/dof_management/freedom_signature.hpp
+++ b/src/dof_management/freedom_signature.hpp
@@ -10,6 +10,7 @@ enum class FreedomSignature : std::uint8_t {
     AllComponents = 0b01111111,
     JustPosition = 0b01110000,
     JustRotation = 0b00001111,
+    NoComponents = 0b00000000
 };
 
 KOKKOS_INLINE_FUNCTION

--- a/src/dof_management/freedom_signature.hpp
+++ b/src/dof_management/freedom_signature.hpp
@@ -1,0 +1,33 @@
+#pragma once
+
+#include <type_traits>
+
+#include <Kokkos_Core.hpp>
+
+namespace openturbine {
+
+enum class FreedomSignature : std::uint8_t {
+    AllComponents = 0b01111111,
+    JustPosition = 0b01110000,
+    JustRotation = 0b00001111,
+};
+
+KOKKOS_INLINE_FUNCTION
+FreedomSignature operator|(FreedomSignature x, FreedomSignature y) {
+    using T = std::underlying_type_t<FreedomSignature>;
+    return static_cast<FreedomSignature>(static_cast<T>(x) | static_cast<T>(y));
+}
+
+KOKKOS_INLINE_FUNCTION
+size_t count_active_dofs(FreedomSignature x) {
+    using T = std::underlying_type_t<FreedomSignature>;
+    auto count = 0ul;
+    constexpr auto zero = T{0};
+    constexpr auto one = T{1};
+    for(auto value = static_cast<T>(x); value > zero; value = value >> 1) {
+        count += value & one;
+    }
+    return count;
+}
+
+}

--- a/src/dof_management/freedom_signature.hpp
+++ b/src/dof_management/freedom_signature.hpp
@@ -22,13 +22,13 @@ FreedomSignature operator|(FreedomSignature x, FreedomSignature y) {
 KOKKOS_INLINE_FUNCTION
 size_t count_active_dofs(FreedomSignature x) {
     using T = std::underlying_type_t<FreedomSignature>;
-    auto count = 0ul;
+    auto count = 0UL;
     constexpr auto zero = T{0};
     constexpr auto one = T{1};
-    for(auto value = static_cast<T>(x); value > zero; value = value >> 1) {
+    for (auto value = static_cast<T>(x); value > zero; value = value >> 1) {
         count += value & one;
     }
     return count;
 }
 
-}
+}  // namespace openturbine

--- a/src/state/state.hpp
+++ b/src/state/state.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "src/dof_management/freedom_signature.hpp"
 #include "src/types.hpp"
 
 namespace openturbine {
@@ -10,6 +11,9 @@ namespace openturbine {
 struct State {
     size_t num_system_nodes;  //< Number of system nodes
     Kokkos::View<size_t*> ID;
+    Kokkos::View<FreedomSignature*> node_freedom_allocation_table;
+    Kokkos::View<size_t*> node_freedom_map_table;
+
     View_Nx7 x0;       //< Initial global position/rotation
     View_Nx7 x;        //< Current global position/rotation
     View_Nx6 q_delta;  //< Displacement increment
@@ -23,6 +27,8 @@ struct State {
     explicit State(size_t num_system_nodes_)
         : num_system_nodes(num_system_nodes_),
           ID("ID", num_system_nodes),
+          node_freedom_allocation_table("node_freedom_allocation_table", num_system_nodes),
+          node_freedom_map_table("node_freedom_map_table", num_system_nodes),
           x0("x0", num_system_nodes),
           x("x", num_system_nodes),
           q_delta("q_delta", num_system_nodes),

--- a/tests/unit_tests/CMakeLists.txt
+++ b/tests/unit_tests/CMakeLists.txt
@@ -3,6 +3,7 @@ add_executable(openturbine_unit_tests)
 
 # Add subdirectories for additional components
 add_subdirectory(beams)
+add_subdirectory(dof_management)
 add_subdirectory(math)
 add_subdirectory(model)
 add_subdirectory(solver)

--- a/tests/unit_tests/dof_management/CMakeLists.txt
+++ b/tests/unit_tests/dof_management/CMakeLists.txt
@@ -2,5 +2,8 @@
 target_sources(
     openturbine_unit_tests
     PRIVATE
+    test_assemble_node_freedom_allocation_table.cpp
+    test_compute_node_freedom_map_table.cpp
+    test_create_element_freedom_table.cpp
     test_freedom_signature.cpp
 )

--- a/tests/unit_tests/dof_management/CMakeLists.txt
+++ b/tests/unit_tests/dof_management/CMakeLists.txt
@@ -1,0 +1,6 @@
+# Specify the source files for the unit test executable
+target_sources(
+    openturbine_unit_tests
+    PRIVATE
+    test_freedom_signature.cpp
+)

--- a/tests/unit_tests/dof_management/test_assemble_node_freedom_allocation_table.cpp
+++ b/tests/unit_tests/dof_management/test_assemble_node_freedom_allocation_table.cpp
@@ -1,0 +1,62 @@
+#include <gtest/gtest.h>
+
+#include "src/dof_management/assemble_node_freedom_allocation_table.hpp"
+
+namespace openturbine::tests {
+
+TEST(TestAssembleNodeFreedomAllocationTable, OneBeamOneNode) {
+    auto state = State(1U);
+
+    auto beams = Beams(1U, 1U, 1U);
+    Kokkos::deep_copy(beams.node_state_indices, 0U);
+    Kokkos::deep_copy(beams.num_nodes_per_element, 1U);
+
+    assemble_node_freedom_allocation_table(state, beams);
+
+    const auto host_node_freedom_allocation_table = Kokkos::create_mirror(state.node_freedom_allocation_table);
+    Kokkos::deep_copy(host_node_freedom_allocation_table, state.node_freedom_allocation_table);
+
+    EXPECT_EQ(host_node_freedom_allocation_table(0), FreedomSignature::AllComponents);
+}
+
+TEST(TestAssembleNodeFreedomAllocationTable, OneBeamTwoNodes) {
+    auto state = State(2U);
+
+    auto beams = Beams(1U, 2U, 1U);
+    constexpr auto host_node_state_indices_data = std::array{0UL, 1UL};
+    const auto host_node_state_indices = Kokkos::View<size_t[1][2], Kokkos::HostSpace>::const_type(host_node_state_indices_data.data());
+    const auto mirror_node_state_indices = Kokkos::create_mirror(beams.node_state_indices);
+    Kokkos::deep_copy(mirror_node_state_indices, host_node_state_indices);
+    Kokkos::deep_copy(beams.node_state_indices, mirror_node_state_indices);
+    Kokkos::deep_copy(beams.num_nodes_per_element, 2U);
+
+    assemble_node_freedom_allocation_table(state, beams);
+
+    const auto host_node_freedom_allocation_table = Kokkos::create_mirror(state.node_freedom_allocation_table);
+    Kokkos::deep_copy(host_node_freedom_allocation_table, state.node_freedom_allocation_table);
+
+    EXPECT_EQ(host_node_freedom_allocation_table(0), FreedomSignature::AllComponents);
+    EXPECT_EQ(host_node_freedom_allocation_table(1), FreedomSignature::AllComponents);
+}
+
+TEST(TestAssembleNodeFreedomAllocationTable, TwoBeamsOneNode) {
+    auto state = State(2U);
+
+    auto beams = Beams(2U, 1U, 1U);
+    constexpr auto host_node_state_indices_data = std::array{0UL, 1UL};
+    const auto host_node_state_indices = Kokkos::View<size_t[2][1], Kokkos::HostSpace>::const_type(host_node_state_indices_data.data());
+    const auto mirror_node_state_indices = Kokkos::create_mirror(beams.node_state_indices);
+    Kokkos::deep_copy(mirror_node_state_indices, host_node_state_indices);
+    Kokkos::deep_copy(beams.node_state_indices, mirror_node_state_indices);
+    Kokkos::deep_copy(beams.num_nodes_per_element, 1U);
+
+    assemble_node_freedom_allocation_table(state, beams);
+
+    const auto host_node_freedom_allocation_table = Kokkos::create_mirror(state.node_freedom_allocation_table);
+    Kokkos::deep_copy(host_node_freedom_allocation_table, state.node_freedom_allocation_table);
+
+    EXPECT_EQ(host_node_freedom_allocation_table(0), FreedomSignature::AllComponents);
+    EXPECT_EQ(host_node_freedom_allocation_table(1), FreedomSignature::AllComponents);
+}
+
+}  // namespace openturbine::tests

--- a/tests/unit_tests/dof_management/test_assemble_node_freedom_allocation_table.cpp
+++ b/tests/unit_tests/dof_management/test_assemble_node_freedom_allocation_table.cpp
@@ -13,7 +13,8 @@ TEST(TestAssembleNodeFreedomAllocationTable, OneBeamOneNode) {
 
     assemble_node_freedom_allocation_table(state, beams);
 
-    const auto host_node_freedom_allocation_table = Kokkos::create_mirror(state.node_freedom_allocation_table);
+    const auto host_node_freedom_allocation_table =
+        Kokkos::create_mirror(state.node_freedom_allocation_table);
     Kokkos::deep_copy(host_node_freedom_allocation_table, state.node_freedom_allocation_table);
 
     EXPECT_EQ(host_node_freedom_allocation_table(0), FreedomSignature::AllComponents);
@@ -24,7 +25,9 @@ TEST(TestAssembleNodeFreedomAllocationTable, OneBeamTwoNodes) {
 
     auto beams = Beams(1U, 2U, 1U);
     constexpr auto host_node_state_indices_data = std::array{0UL, 1UL};
-    const auto host_node_state_indices = Kokkos::View<size_t[1][2], Kokkos::HostSpace>::const_type(host_node_state_indices_data.data());
+    const auto host_node_state_indices =
+        Kokkos::View<size_t[1][2], Kokkos::HostSpace>::const_type(host_node_state_indices_data.data()
+        );
     const auto mirror_node_state_indices = Kokkos::create_mirror(beams.node_state_indices);
     Kokkos::deep_copy(mirror_node_state_indices, host_node_state_indices);
     Kokkos::deep_copy(beams.node_state_indices, mirror_node_state_indices);
@@ -32,7 +35,8 @@ TEST(TestAssembleNodeFreedomAllocationTable, OneBeamTwoNodes) {
 
     assemble_node_freedom_allocation_table(state, beams);
 
-    const auto host_node_freedom_allocation_table = Kokkos::create_mirror(state.node_freedom_allocation_table);
+    const auto host_node_freedom_allocation_table =
+        Kokkos::create_mirror(state.node_freedom_allocation_table);
     Kokkos::deep_copy(host_node_freedom_allocation_table, state.node_freedom_allocation_table);
 
     EXPECT_EQ(host_node_freedom_allocation_table(0), FreedomSignature::AllComponents);
@@ -44,7 +48,9 @@ TEST(TestAssembleNodeFreedomAllocationTable, TwoBeamsOneNode) {
 
     auto beams = Beams(2U, 1U, 1U);
     constexpr auto host_node_state_indices_data = std::array{0UL, 1UL};
-    const auto host_node_state_indices = Kokkos::View<size_t[2][1], Kokkos::HostSpace>::const_type(host_node_state_indices_data.data());
+    const auto host_node_state_indices =
+        Kokkos::View<size_t[2][1], Kokkos::HostSpace>::const_type(host_node_state_indices_data.data()
+        );
     const auto mirror_node_state_indices = Kokkos::create_mirror(beams.node_state_indices);
     Kokkos::deep_copy(mirror_node_state_indices, host_node_state_indices);
     Kokkos::deep_copy(beams.node_state_indices, mirror_node_state_indices);
@@ -52,7 +58,8 @@ TEST(TestAssembleNodeFreedomAllocationTable, TwoBeamsOneNode) {
 
     assemble_node_freedom_allocation_table(state, beams);
 
-    const auto host_node_freedom_allocation_table = Kokkos::create_mirror(state.node_freedom_allocation_table);
+    const auto host_node_freedom_allocation_table =
+        Kokkos::create_mirror(state.node_freedom_allocation_table);
     Kokkos::deep_copy(host_node_freedom_allocation_table, state.node_freedom_allocation_table);
 
     EXPECT_EQ(host_node_freedom_allocation_table(0), FreedomSignature::AllComponents);

--- a/tests/unit_tests/dof_management/test_compute_node_freedom_map_table.cpp
+++ b/tests/unit_tests/dof_management/test_compute_node_freedom_map_table.cpp
@@ -1,0 +1,38 @@
+#include <gtest/gtest.h>
+
+#include "src/dof_management/compute_node_freedom_map_table.hpp"
+
+namespace openturbine::tests {
+
+TEST(TestAssembleNodeFreedomMapTable, OneNode) {
+    auto state = State(1U);
+    Kokkos::deep_copy(state.node_freedom_allocation_table, FreedomSignature::AllComponents);
+
+    compute_node_freedom_map_table(state);
+
+    const auto host_node_freedom_map_table = Kokkos::create_mirror(state.node_freedom_map_table);
+    Kokkos::deep_copy(host_node_freedom_map_table, state.node_freedom_map_table);
+
+    EXPECT_EQ(host_node_freedom_map_table(0), 0);
+}
+
+TEST(TestAssembleNodeFreedomMapTable, FourNodes) {
+    auto state = State(4U);
+    constexpr auto host_node_freedom_allocation_table_data = std::array{FreedomSignature::AllComponents, FreedomSignature::JustPosition, FreedomSignature::JustRotation, FreedomSignature::NoComponents};
+    const auto host_node_freedom_allocation_table = Kokkos::View<FreedomSignature[4], Kokkos::HostSpace>::const_type(host_node_freedom_allocation_table_data.data());
+    const auto mirror_node_freedom_allocation_table = Kokkos::create_mirror(state.node_freedom_allocation_table);
+    Kokkos::deep_copy(mirror_node_freedom_allocation_table, host_node_freedom_allocation_table);
+    Kokkos::deep_copy(state.node_freedom_allocation_table, mirror_node_freedom_allocation_table);
+
+    compute_node_freedom_map_table(state);
+
+    const auto host_node_freedom_map_table = Kokkos::create_mirror(state.node_freedom_map_table);
+    Kokkos::deep_copy(host_node_freedom_map_table, state.node_freedom_map_table);
+
+    EXPECT_EQ(host_node_freedom_map_table(0), 0);
+    EXPECT_EQ(host_node_freedom_map_table(1), 7);
+    EXPECT_EQ(host_node_freedom_map_table(2), 10);
+    EXPECT_EQ(host_node_freedom_map_table(3), 14);
+}
+
+}  // namespace openturbine::tests

--- a/tests/unit_tests/dof_management/test_compute_node_freedom_map_table.cpp
+++ b/tests/unit_tests/dof_management/test_compute_node_freedom_map_table.cpp
@@ -18,9 +18,16 @@ TEST(TestAssembleNodeFreedomMapTable, OneNode) {
 
 TEST(TestAssembleNodeFreedomMapTable, FourNodes) {
     auto state = State(4U);
-    constexpr auto host_node_freedom_allocation_table_data = std::array{FreedomSignature::AllComponents, FreedomSignature::JustPosition, FreedomSignature::JustRotation, FreedomSignature::NoComponents};
-    const auto host_node_freedom_allocation_table = Kokkos::View<FreedomSignature[4], Kokkos::HostSpace>::const_type(host_node_freedom_allocation_table_data.data());
-    const auto mirror_node_freedom_allocation_table = Kokkos::create_mirror(state.node_freedom_allocation_table);
+    constexpr auto host_node_freedom_allocation_table_data = std::array{
+        FreedomSignature::AllComponents, FreedomSignature::JustPosition,
+        FreedomSignature::JustRotation, FreedomSignature::NoComponents
+    };
+    const auto host_node_freedom_allocation_table =
+        Kokkos::View<FreedomSignature[4], Kokkos::HostSpace>::const_type(
+            host_node_freedom_allocation_table_data.data()
+        );
+    const auto mirror_node_freedom_allocation_table =
+        Kokkos::create_mirror(state.node_freedom_allocation_table);
     Kokkos::deep_copy(mirror_node_freedom_allocation_table, host_node_freedom_allocation_table);
     Kokkos::deep_copy(state.node_freedom_allocation_table, mirror_node_freedom_allocation_table);
 

--- a/tests/unit_tests/dof_management/test_compute_node_freedom_map_table.cpp
+++ b/tests/unit_tests/dof_management/test_compute_node_freedom_map_table.cpp
@@ -4,7 +4,7 @@
 
 namespace openturbine::tests {
 
-TEST(TestAssembleNodeFreedomMapTable, OneNode) {
+TEST(TestComputeNodeFreedomMapTable, OneNode) {
     auto state = State(1U);
     Kokkos::deep_copy(state.node_freedom_allocation_table, FreedomSignature::AllComponents);
 
@@ -16,7 +16,7 @@ TEST(TestAssembleNodeFreedomMapTable, OneNode) {
     EXPECT_EQ(host_node_freedom_map_table(0), 0);
 }
 
-TEST(TestAssembleNodeFreedomMapTable, FourNodes) {
+TEST(TestComputeNodeFreedomMapTable, FourNodes) {
     auto state = State(4U);
     constexpr auto host_node_freedom_allocation_table_data = std::array{
         FreedomSignature::AllComponents, FreedomSignature::JustPosition,
@@ -37,9 +37,9 @@ TEST(TestAssembleNodeFreedomMapTable, FourNodes) {
     Kokkos::deep_copy(host_node_freedom_map_table, state.node_freedom_map_table);
 
     EXPECT_EQ(host_node_freedom_map_table(0), 0);
-    EXPECT_EQ(host_node_freedom_map_table(1), 7);
-    EXPECT_EQ(host_node_freedom_map_table(2), 10);
-    EXPECT_EQ(host_node_freedom_map_table(3), 14);
+    EXPECT_EQ(host_node_freedom_map_table(1), 6);
+    EXPECT_EQ(host_node_freedom_map_table(2), 9);
+    EXPECT_EQ(host_node_freedom_map_table(3), 12);
 }
 
 }  // namespace openturbine::tests

--- a/tests/unit_tests/dof_management/test_create_element_freedom_table.cpp
+++ b/tests/unit_tests/dof_management/test_create_element_freedom_table.cpp
@@ -88,4 +88,81 @@ TEST(TestCreateElementFreedomTable, TwoBeamsOneNode) {
     }
 }
 
+TEST(TestCreateElementFreedomTable, TwoBeamsTwoNodesShared) {
+    auto state = State(3U);
+    constexpr auto host_node_freedom_map_table_data = std::array{0UL, 6UL, 12UL};
+    const auto host_node_freedom_map_table = Kokkos::View<size_t[3], Kokkos::HostSpace>::const_type(
+        host_node_freedom_map_table_data.data()
+    );
+    const auto mirror_node_freedom_map_table = Kokkos::create_mirror(state.node_freedom_map_table);
+    Kokkos::deep_copy(mirror_node_freedom_map_table, host_node_freedom_map_table);
+    Kokkos::deep_copy(state.node_freedom_map_table, mirror_node_freedom_map_table);
+
+    auto beams = Beams(2U, 2U, 1U);
+    constexpr auto host_node_state_indices_data = std::array{0UL, 1UL, 1UL, 2UL};
+    const auto host_node_state_indices =
+        Kokkos::View<size_t[2][2], Kokkos::HostSpace>::const_type(host_node_state_indices_data.data()
+        );
+    const auto mirror_node_state_indices = Kokkos::create_mirror(beams.node_state_indices);
+    Kokkos::deep_copy(mirror_node_state_indices, host_node_state_indices);
+    Kokkos::deep_copy(beams.node_state_indices, mirror_node_state_indices);
+    Kokkos::deep_copy(beams.num_nodes_per_element, 2U);
+
+    create_element_freedom_table(beams, state);
+
+    const auto host_element_freedom_table = Kokkos::create_mirror(beams.element_freedom_table);
+    Kokkos::deep_copy(host_element_freedom_table, beams.element_freedom_table);
+
+    for (auto k = 0U; k < 6U; ++k) {
+        EXPECT_EQ(host_element_freedom_table(0, 0, k), k);
+    }
+    for (auto k = 0U; k < 6U; ++k) {
+        EXPECT_EQ(host_element_freedom_table(0, 1, k), k + 6U);
+    }
+    for (auto k = 0U; k < 6U; ++k) {
+        EXPECT_EQ(host_element_freedom_table(1, 0, k), k + 6U);
+    }
+    for (auto k = 0U; k < 6U; ++k) {
+        EXPECT_EQ(host_element_freedom_table(1, 1, k), k + 12U);
+    }
+}
+
+TEST(TestCreateElementFreedomTable, TwoBeamsTwoNodesShared_Flipped) {
+    auto state = State(3U);
+    constexpr auto host_node_freedom_map_table_data = std::array{0UL, 6UL, 12UL};
+    const auto host_node_freedom_map_table = Kokkos::View<size_t[3], Kokkos::HostSpace>::const_type(
+        host_node_freedom_map_table_data.data()
+    );
+    const auto mirror_node_freedom_map_table = Kokkos::create_mirror(state.node_freedom_map_table);
+    Kokkos::deep_copy(mirror_node_freedom_map_table, host_node_freedom_map_table);
+    Kokkos::deep_copy(state.node_freedom_map_table, mirror_node_freedom_map_table);
+
+    auto beams = Beams(2U, 2U, 1U);
+    constexpr auto host_node_state_indices_data = std::array{1UL, 2UL, 0UL, 1UL};
+    const auto host_node_state_indices =
+        Kokkos::View<size_t[2][2], Kokkos::HostSpace>::const_type(host_node_state_indices_data.data()
+        );
+    const auto mirror_node_state_indices = Kokkos::create_mirror(beams.node_state_indices);
+    Kokkos::deep_copy(mirror_node_state_indices, host_node_state_indices);
+    Kokkos::deep_copy(beams.node_state_indices, mirror_node_state_indices);
+    Kokkos::deep_copy(beams.num_nodes_per_element, 2U);
+
+    create_element_freedom_table(beams, state);
+
+    const auto host_element_freedom_table = Kokkos::create_mirror(beams.element_freedom_table);
+    Kokkos::deep_copy(host_element_freedom_table, beams.element_freedom_table);
+
+    for (auto k = 0U; k < 6U; ++k) {
+        EXPECT_EQ(host_element_freedom_table(1, 0, k), k);
+    }
+    for (auto k = 0U; k < 6U; ++k) {
+        EXPECT_EQ(host_element_freedom_table(1, 1, k), k + 6U);
+    }
+    for (auto k = 0U; k < 6U; ++k) {
+        EXPECT_EQ(host_element_freedom_table(0, 0, k), k + 6U);
+    }
+    for (auto k = 0U; k < 6U; ++k) {
+        EXPECT_EQ(host_element_freedom_table(0, 1, k), k + 12U);
+    }
+}
 }  // namespace openturbine::tests

--- a/tests/unit_tests/dof_management/test_create_element_freedom_table.cpp
+++ b/tests/unit_tests/dof_management/test_create_element_freedom_table.cpp
@@ -17,14 +17,14 @@ TEST(TestCreateElementFreedomTable, OneBeamOneNode) {
     const auto host_element_freedom_table = Kokkos::create_mirror(beams.element_freedom_table);
     Kokkos::deep_copy(host_element_freedom_table, beams.element_freedom_table);
 
-    for (auto k = 0U; k < 7U; ++k) {
+    for (auto k = 0U; k < 6U; ++k) {
         EXPECT_EQ(host_element_freedom_table(0, 0, k), k);
     }
 }
 
 TEST(TestCreateElementFreedomTable, OneBeamTwoNodes) {
     auto state = State(2U);
-    constexpr auto host_node_freedom_map_table_data = std::array{0UL, 7UL};
+    constexpr auto host_node_freedom_map_table_data = std::array{0UL, 6UL};
     const auto host_node_freedom_map_table = Kokkos::View<size_t[2], Kokkos::HostSpace>::const_type(
         host_node_freedom_map_table_data.data()
     );
@@ -47,17 +47,17 @@ TEST(TestCreateElementFreedomTable, OneBeamTwoNodes) {
     const auto host_element_freedom_table = Kokkos::create_mirror(beams.element_freedom_table);
     Kokkos::deep_copy(host_element_freedom_table, beams.element_freedom_table);
 
-    for (auto k = 0U; k < 7U; ++k) {
+    for (auto k = 0U; k < 6U; ++k) {
         EXPECT_EQ(host_element_freedom_table(0, 0, k), k);
     }
-    for (auto k = 0U; k < 7U; ++k) {
-        EXPECT_EQ(host_element_freedom_table(0, 1, k), k + 7U);
+    for (auto k = 0U; k < 6U; ++k) {
+        EXPECT_EQ(host_element_freedom_table(0, 1, k), k + 6U);
     }
 }
 
 TEST(TestCreateElementFreedomTable, TwoBeamsOneNode) {
     auto state = State(2U);
-    constexpr auto host_node_freedom_map_table_data = std::array{0UL, 7UL};
+    constexpr auto host_node_freedom_map_table_data = std::array{0UL, 6UL};
     const auto host_node_freedom_map_table = Kokkos::View<size_t[2], Kokkos::HostSpace>::const_type(
         host_node_freedom_map_table_data.data()
     );
@@ -80,11 +80,11 @@ TEST(TestCreateElementFreedomTable, TwoBeamsOneNode) {
     const auto host_element_freedom_table = Kokkos::create_mirror(beams.element_freedom_table);
     Kokkos::deep_copy(host_element_freedom_table, beams.element_freedom_table);
 
-    for (auto k = 0U; k < 7U; ++k) {
+    for (auto k = 0U; k < 6U; ++k) {
         EXPECT_EQ(host_element_freedom_table(0, 0, k), k);
     }
-    for (auto k = 0U; k < 7U; ++k) {
-        EXPECT_EQ(host_element_freedom_table(1, 0, k), k + 7U);
+    for (auto k = 0U; k < 6U; ++k) {
+        EXPECT_EQ(host_element_freedom_table(1, 0, k), k + 6U);
     }
 }
 

--- a/tests/unit_tests/dof_management/test_create_element_freedom_table.cpp
+++ b/tests/unit_tests/dof_management/test_create_element_freedom_table.cpp
@@ -25,14 +25,18 @@ TEST(TestCreateElementFreedomTable, OneBeamOneNode) {
 TEST(TestCreateElementFreedomTable, OneBeamTwoNodes) {
     auto state = State(2U);
     constexpr auto host_node_freedom_map_table_data = std::array{0UL, 7UL};
-    const auto host_node_freedom_map_table = Kokkos::View<size_t[2], Kokkos::HostSpace>::const_type(host_node_freedom_map_table_data.data());
+    const auto host_node_freedom_map_table = Kokkos::View<size_t[2], Kokkos::HostSpace>::const_type(
+        host_node_freedom_map_table_data.data()
+    );
     const auto mirror_node_freedom_map_table = Kokkos::create_mirror(state.node_freedom_map_table);
     Kokkos::deep_copy(mirror_node_freedom_map_table, host_node_freedom_map_table);
     Kokkos::deep_copy(state.node_freedom_map_table, mirror_node_freedom_map_table);
 
     auto beams = Beams(1U, 2U, 1U);
     constexpr auto host_node_state_indices_data = std::array{0UL, 1UL};
-    const auto host_node_state_indices = Kokkos::View<size_t[1][2], Kokkos::HostSpace>::const_type(host_node_state_indices_data.data());
+    const auto host_node_state_indices =
+        Kokkos::View<size_t[1][2], Kokkos::HostSpace>::const_type(host_node_state_indices_data.data()
+        );
     const auto mirror_node_state_indices = Kokkos::create_mirror(beams.node_state_indices);
     Kokkos::deep_copy(mirror_node_state_indices, host_node_state_indices);
     Kokkos::deep_copy(beams.node_state_indices, mirror_node_state_indices);
@@ -54,14 +58,18 @@ TEST(TestCreateElementFreedomTable, OneBeamTwoNodes) {
 TEST(TestCreateElementFreedomTable, TwoBeamsOneNode) {
     auto state = State(2U);
     constexpr auto host_node_freedom_map_table_data = std::array{0UL, 7UL};
-    const auto host_node_freedom_map_table = Kokkos::View<size_t[2], Kokkos::HostSpace>::const_type(host_node_freedom_map_table_data.data());
+    const auto host_node_freedom_map_table = Kokkos::View<size_t[2], Kokkos::HostSpace>::const_type(
+        host_node_freedom_map_table_data.data()
+    );
     const auto mirror_node_freedom_map_table = Kokkos::create_mirror(state.node_freedom_map_table);
     Kokkos::deep_copy(mirror_node_freedom_map_table, host_node_freedom_map_table);
     Kokkos::deep_copy(state.node_freedom_map_table, mirror_node_freedom_map_table);
 
     auto beams = Beams(2U, 1U, 1U);
     constexpr auto host_node_state_indices_data = std::array{0UL, 1UL};
-    const auto host_node_state_indices = Kokkos::View<size_t[2][1], Kokkos::HostSpace>::const_type(host_node_state_indices_data.data());
+    const auto host_node_state_indices =
+        Kokkos::View<size_t[2][1], Kokkos::HostSpace>::const_type(host_node_state_indices_data.data()
+        );
     const auto mirror_node_state_indices = Kokkos::create_mirror(beams.node_state_indices);
     Kokkos::deep_copy(mirror_node_state_indices, host_node_state_indices);
     Kokkos::deep_copy(beams.node_state_indices, mirror_node_state_indices);

--- a/tests/unit_tests/dof_management/test_create_element_freedom_table.cpp
+++ b/tests/unit_tests/dof_management/test_create_element_freedom_table.cpp
@@ -1,0 +1,83 @@
+#include <gtest/gtest.h>
+
+#include "src/dof_management/create_element_freedom_table.hpp"
+
+namespace openturbine::tests {
+
+TEST(TestCreateElementFreedomTable, OneBeamOneNode) {
+    auto state = State(1U);
+    Kokkos::deep_copy(state.node_freedom_map_table, 0U);
+
+    auto beams = Beams(1U, 1U, 1U);
+    Kokkos::deep_copy(beams.node_state_indices, 0U);
+    Kokkos::deep_copy(beams.num_nodes_per_element, 1U);
+
+    create_element_freedom_table(beams, state);
+
+    const auto host_element_freedom_table = Kokkos::create_mirror(beams.element_freedom_table);
+    Kokkos::deep_copy(host_element_freedom_table, beams.element_freedom_table);
+
+    for (auto k = 0U; k < 7U; ++k) {
+        EXPECT_EQ(host_element_freedom_table(0, 0, k), k);
+    }
+}
+
+TEST(TestCreateElementFreedomTable, OneBeamTwoNodes) {
+    auto state = State(2U);
+    constexpr auto host_node_freedom_map_table_data = std::array{0UL, 7UL};
+    const auto host_node_freedom_map_table = Kokkos::View<size_t[2], Kokkos::HostSpace>::const_type(host_node_freedom_map_table_data.data());
+    const auto mirror_node_freedom_map_table = Kokkos::create_mirror(state.node_freedom_map_table);
+    Kokkos::deep_copy(mirror_node_freedom_map_table, host_node_freedom_map_table);
+    Kokkos::deep_copy(state.node_freedom_map_table, mirror_node_freedom_map_table);
+
+    auto beams = Beams(1U, 2U, 1U);
+    constexpr auto host_node_state_indices_data = std::array{0UL, 1UL};
+    const auto host_node_state_indices = Kokkos::View<size_t[1][2], Kokkos::HostSpace>::const_type(host_node_state_indices_data.data());
+    const auto mirror_node_state_indices = Kokkos::create_mirror(beams.node_state_indices);
+    Kokkos::deep_copy(mirror_node_state_indices, host_node_state_indices);
+    Kokkos::deep_copy(beams.node_state_indices, mirror_node_state_indices);
+    Kokkos::deep_copy(beams.num_nodes_per_element, 2U);
+
+    create_element_freedom_table(beams, state);
+
+    const auto host_element_freedom_table = Kokkos::create_mirror(beams.element_freedom_table);
+    Kokkos::deep_copy(host_element_freedom_table, beams.element_freedom_table);
+
+    for (auto k = 0U; k < 7U; ++k) {
+        EXPECT_EQ(host_element_freedom_table(0, 0, k), k);
+    }
+    for (auto k = 0U; k < 7U; ++k) {
+        EXPECT_EQ(host_element_freedom_table(0, 1, k), k + 7U);
+    }
+}
+
+TEST(TestCreateElementFreedomTable, TwoBeamsOneNode) {
+    auto state = State(2U);
+    constexpr auto host_node_freedom_map_table_data = std::array{0UL, 7UL};
+    const auto host_node_freedom_map_table = Kokkos::View<size_t[2], Kokkos::HostSpace>::const_type(host_node_freedom_map_table_data.data());
+    const auto mirror_node_freedom_map_table = Kokkos::create_mirror(state.node_freedom_map_table);
+    Kokkos::deep_copy(mirror_node_freedom_map_table, host_node_freedom_map_table);
+    Kokkos::deep_copy(state.node_freedom_map_table, mirror_node_freedom_map_table);
+
+    auto beams = Beams(2U, 1U, 1U);
+    constexpr auto host_node_state_indices_data = std::array{0UL, 1UL};
+    const auto host_node_state_indices = Kokkos::View<size_t[2][1], Kokkos::HostSpace>::const_type(host_node_state_indices_data.data());
+    const auto mirror_node_state_indices = Kokkos::create_mirror(beams.node_state_indices);
+    Kokkos::deep_copy(mirror_node_state_indices, host_node_state_indices);
+    Kokkos::deep_copy(beams.node_state_indices, mirror_node_state_indices);
+    Kokkos::deep_copy(beams.num_nodes_per_element, 1U);
+
+    create_element_freedom_table(beams, state);
+
+    const auto host_element_freedom_table = Kokkos::create_mirror(beams.element_freedom_table);
+    Kokkos::deep_copy(host_element_freedom_table, beams.element_freedom_table);
+
+    for (auto k = 0U; k < 7U; ++k) {
+        EXPECT_EQ(host_element_freedom_table(0, 0, k), k);
+    }
+    for (auto k = 0U; k < 7U; ++k) {
+        EXPECT_EQ(host_element_freedom_table(1, 0, k), k + 7U);
+    }
+}
+
+}  // namespace openturbine::tests

--- a/tests/unit_tests/dof_management/test_freedom_signature.cpp
+++ b/tests/unit_tests/dof_management/test_freedom_signature.cpp
@@ -29,11 +29,11 @@ TEST(TestFreedomSignature, CountActiveDofs_Position) {
 
 TEST(TestFreedomSignature, CountActiveDofs_Rotation) {
     auto x = count_active_dofs(FreedomSignature::JustRotation);
-    EXPECT_EQ(x, 4);
+    EXPECT_EQ(x, 3);
 }
 
 TEST(TestFreedomSignature, CountActiveDofs_AllComponents) {
     auto x = count_active_dofs(FreedomSignature::AllComponents);
-    EXPECT_EQ(x, 7);
+    EXPECT_EQ(x, 6);
 }
 }  // namespace openturbine::tests

--- a/tests/unit_tests/dof_management/test_freedom_signature.cpp
+++ b/tests/unit_tests/dof_management/test_freedom_signature.cpp
@@ -1,0 +1,38 @@
+#include <gtest/gtest.h>
+#include <bitset>
+
+#include "src/dof_management/freedom_signature.hpp"
+
+namespace openturbine::tests {
+
+TEST(TestFreedomSignature, CombineSignatures_NoOverlap) {
+    const auto x = FreedomSignature::JustPosition;
+    const auto y = FreedomSignature::JustRotation;
+    const auto z = x | y;
+
+    EXPECT_EQ(z, FreedomSignature::AllComponents);
+}
+
+TEST(TestFreedomSignature, CombineSignatures_Overlap) {
+    const auto x = FreedomSignature::JustPosition;
+    const auto y = FreedomSignature::AllComponents;
+    const auto z = x | y;
+
+    EXPECT_EQ(z, FreedomSignature::AllComponents);
+}
+
+TEST(TestFreedomSignature, CountActiveDofs_Position) {
+    auto x = count_active_dofs(FreedomSignature::JustPosition);
+    EXPECT_EQ(x, 3);
+}
+
+TEST(TestFreedomSignature, CountActiveDofs_Rotation) {
+    auto x = count_active_dofs(FreedomSignature::JustRotation);
+    EXPECT_EQ(x, 4);
+}
+
+TEST(TestFreedomSignature, CountActiveDofs_AllComponents) {
+    auto x = count_active_dofs(FreedomSignature::AllComponents);
+    EXPECT_EQ(x, 7);
+}
+}  // namespace openturbine::tests

--- a/tests/unit_tests/dof_management/test_freedom_signature.cpp
+++ b/tests/unit_tests/dof_management/test_freedom_signature.cpp
@@ -1,5 +1,6 @@
-#include <gtest/gtest.h>
 #include <bitset>
+
+#include <gtest/gtest.h>
 
 #include "src/dof_management/freedom_signature.hpp"
 


### PR DESCRIPTION
This commit adds the element freedom signature, element freedom table, node freedom allocation table, and node freedom map tables necessary for supporting nodes with different numbers of degrees of freedom.  It also adds the free functions necessary for populating them on the State and Beams classes.  The algorithms are currently serial for ease in refactoring as we add features, but can easily make them parallel in the future.  