### PR TITLE
Build solver using new data structures allowing the use of different numbers of components per node

### DIFF
--- a/src/constraints/constraints.hpp
+++ b/src/constraints/constraints.hpp
@@ -1,11 +1,14 @@
 #pragma once
 
 #include <array>
+#include <numeric>
 #include <vector>
 
 #include <Kokkos_Core.hpp>
 
 #include "constraint.hpp"
+
+#include "src/dof_management/freedom_signature.hpp"
 
 namespace openturbine {
 
@@ -24,6 +27,8 @@ struct Constraints {
     Kokkos::View<Kokkos::pair<size_t, size_t>*> target_node_col_range;
     Kokkos::View<size_t*> base_node_index;
     Kokkos::View<size_t*> target_node_index;
+    Kokkos::View<FreedomSignature*> base_node_freedom_signature;
+    Kokkos::View<FreedomSignature*> target_node_freedom_signature;
     Kokkos::View<double* [3]> X0;
     Kokkos::View<double* [3][3]> axes;
 
@@ -52,6 +57,8 @@ struct Constraints {
           target_node_col_range("target_row_col_range", num),
           base_node_index("base_node_index", num),
           target_node_index("target_node_index", num),
+          base_node_freedom_signature("base_node_freedom_signature", num),
+          target_node_freedom_signature("target_node_freedom_signature", num),
           X0("X0", num),
           axes("axes", num),
           input("inputs", num),
@@ -63,6 +70,9 @@ struct Constraints {
           system_residual_terms("system_residual_terms", num),
           base_gradient_terms("base_gradient_terms", num),
           target_gradient_terms("target_gradient_terms", num) {
+        Kokkos::deep_copy(base_node_freedom_signature, FreedomSignature::AllComponents);
+        Kokkos::deep_copy(target_node_freedom_signature, FreedomSignature::AllComponents);
+
         // Create host mirror for constraint data
         auto host_type = Kokkos::create_mirror(type);
         auto host_row_range = Kokkos::create_mirror(row_range);

--- a/src/dof_management/assemble_node_freedom_allocation_table.hpp
+++ b/src/dof_management/assemble_node_freedom_allocation_table.hpp
@@ -13,6 +13,15 @@ namespace openturbine {
 inline void assemble_node_freedom_allocation_table(
     State& state, const Beams& beams, const Constraints& constraints
 ) {
+    const auto state_node_freedom_allocation_table = state.node_freedom_allocation_table;
+
+    const auto beams_num_elems = beams.num_elems;
+    const auto beams_num_nodes_per_element = beams.num_nodes_per_element;
+    const auto beams_node_state_indices = beams.node_state_indices;
+    const auto beams_element_freedom_signature = beams.element_freedom_signature;
+
+    const auto constraints_num = constraints.num;
+    const auto constraints_type = constraints.type;
     const auto constraints_target_node_index = constraints.target_node_index;
     const auto constraints_target_node_freedom_signature = constraints.target_node_freedom_signature;
     const auto constraints_base_node_index = constraints.base_node_index;
@@ -20,31 +29,31 @@ inline void assemble_node_freedom_allocation_table(
     Kokkos::parallel_for(
         "Assemble Node Freedom Map Table", 1,
         KOKKOS_LAMBDA(size_t) {
-            for (auto i = 0U; i < beams.num_elems; ++i) {
-                const auto num_nodes = beams.num_nodes_per_element(i);
+            for (auto i = 0U; i < beams_num_elems; ++i) {
+                const auto num_nodes = beams_num_nodes_per_element(i);
                 for (auto j = 0U; j < num_nodes; ++j) {
-                    const auto node_index = beams.node_state_indices(i, j);
-                    const auto current_signature = state.node_freedom_allocation_table(node_index);
-                    const auto contributed_signature = beams.element_freedom_signature(i, j);
-                    state.node_freedom_allocation_table(node_index) =
+                    const auto node_index = beams_node_state_indices(i, j);
+                    const auto current_signature = state_node_freedom_allocation_table(node_index);
+                    const auto contributed_signature = beams_element_freedom_signature(i, j);
+                    state_node_freedom_allocation_table(node_index) =
                         current_signature | contributed_signature;
                 }
             }
 
-            for (auto i = 0U; i < constraints.num; ++i) {
+            for (auto i = 0U; i < constraints_num; ++i) {
                 {
                     const auto node_index = constraints_target_node_index(i);
-                    const auto current_signature = state.node_freedom_allocation_table(node_index);
+                    const auto current_signature = state_node_freedom_allocation_table(node_index);
                     const auto contributed_signature = constraints_target_node_freedom_signature(i);
                     state.node_freedom_allocation_table(node_index) =
                         current_signature | contributed_signature;
                 }
 
-                if (GetNumberOfNodes(constraints.type(i)) == 2U) {
+                if (GetNumberOfNodes(constraints_type(i)) == 2U) {
                     const auto node_index = constraints_base_node_index(i);
-                    const auto current_signature = state.node_freedom_allocation_table(node_index);
+                    const auto current_signature = state_node_freedom_allocation_table(node_index);
                     const auto contributed_signature = constraints_base_node_freedom_signature(i);
-                    state.node_freedom_allocation_table(node_index) =
+                    state_node_freedom_allocation_table(node_index) =
                         current_signature | contributed_signature;
                 }
             }

--- a/src/solver/contribute_elements_to_sparse_matrix.hpp
+++ b/src/solver/contribute_elements_to_sparse_matrix.hpp
@@ -31,7 +31,6 @@ struct ContributeElementsToSparseMatrix {
         });
         member.team_barrier();
         Kokkos::single(Kokkos::PerTeam(member), [&]() {
-            // sparse.sumIntoValues(i, col_idx.data(), row.length, row_data.data(), true, true);
             sparse.replaceValues(i, col_idx.data(), row.length, row_data.data());
         });
     }

--- a/src/solver/solver.hpp
+++ b/src/solver/solver.hpp
@@ -80,6 +80,8 @@ struct Solver {
 
     Solver(
         const Kokkos::View<size_t*>::const_type& node_IDs,
+        const Kokkos::View<FreedomSignature*>::const_type& node_freedom_allocation_table,
+        const Kokkos::View<size_t*>::const_type& node_freedom_map_table,
         const Kokkos::View<size_t*>::const_type& num_nodes_per_element,
         const Kokkos::View<size_t**>::const_type& node_state_indices, size_t num_constraint_dofs,
         const Kokkos::View<ConstraintType*>::const_type& constraint_type,
@@ -87,55 +89,188 @@ struct Solver {
         const Kokkos::View<size_t*>::const_type& constraint_target_node_index,
         const Kokkos::View<Kokkos::pair<size_t, size_t>*>::const_type& constraint_row_range
     )
-        : num_system_nodes(node_IDs.extent(0)),
-          num_system_dofs(num_system_nodes * kLieAlgebraComponents),
-          num_dofs(num_system_dofs + num_constraint_dofs),
-          R("R", num_dofs),
-          x("x", num_dofs) {
-        auto K_num_rows = this->num_system_dofs;
-        auto K_num_columns = K_num_rows;
-        auto K_num_non_zero = size_t{0U};
-        Kokkos::parallel_reduce(
-            "ComputeNumberOfNonZeros", num_nodes_per_element.extent(0),
-            ComputeNumberOfNonZeros{num_nodes_per_element}, K_num_non_zero
-        );
-        auto K_row_ptrs = RowPtrType("K_row_ptrs", K_num_rows + 1);
-        auto K_col_inds = IndicesType("indices", K_num_non_zero);
-        Kokkos::parallel_for(
-            "PopulateSparseRowPtrs", 1,
-            PopulateSparseRowPtrs<RowPtrType>{num_nodes_per_element, K_row_ptrs}
-        );
-        Kokkos::parallel_for(
-            "PopulateSparseIndices", 1,
-            PopulateSparseIndices{num_nodes_per_element, node_state_indices, K_col_inds}
-        );
+        : num_system_nodes(node_IDs.extent(0)) {
+        const auto nfat_host = Kokkos::create_mirror(node_freedom_allocation_table);
+        Kokkos::deep_copy(nfat_host, node_freedom_allocation_table);
 
-        Kokkos::fence();
+        const auto nfmt_host = Kokkos::create_mirror(node_freedom_map_table);
+        Kokkos::deep_copy(nfmt_host, node_freedom_map_table);
+
+        num_system_dofs = 0UL;
+        for (auto i = 0U; i < num_system_nodes; ++i) {
+            num_system_dofs += count_active_dofs(nfat_host(i));
+        }
+        num_dofs = num_system_dofs + num_constraint_dofs;
+
+        R = Kokkos::View<double*>("R", num_dofs);
+        x = Kokkos::View<double*>("x", num_dofs);
+
+        const auto K_num_rows = num_system_dofs;
+        const auto K_num_columns = K_num_rows;
+        auto K_num_non_zero = 0UL;
+        const auto nnpe_host = Kokkos::create_mirror(num_nodes_per_element);
+        Kokkos::deep_copy(nnpe_host, num_nodes_per_element);
+        const auto nsi_host = Kokkos::create_mirror(node_state_indices);
+        Kokkos::deep_copy(nsi_host, node_state_indices);
+        // compute off-diagonal non-zero terms
+        for (auto i = 0U; i < nnpe_host.extent(0); ++i) {
+            auto num_element_dof = 0UL;
+            for (auto j = 0U; j < nnpe_host(i); ++j) {
+                const auto num_node_dof = count_active_dofs(nfat_host(nsi_host(i, j)));
+                num_element_dof += num_node_dof;
+            }
+            const auto num_element_non_zero = num_element_dof * num_element_dof;
+            auto num_diagonal_non_zero = 0UL;
+            for (auto j = 0U; j < nnpe_host(i); ++j) {
+                const auto num_node_dof = count_active_dofs(nfat_host(nsi_host(i, j)));
+                num_diagonal_non_zero += num_node_dof * num_node_dof;
+            }
+            K_num_non_zero += num_element_non_zero - num_diagonal_non_zero;
+        }
+        // compute diagonal non-zero terms
+        for (auto i = 0U; i < num_system_nodes; ++i) {
+            const auto num_node_dof = count_active_dofs(nfat_host(i));
+            const auto num_diagonal_non_zero = num_node_dof * num_node_dof;
+            K_num_non_zero += num_diagonal_non_zero;
+        }
+        auto K_row_ptrs = RowPtrType("row_ptrs", K_num_rows + 1);
+        auto K_col_inds = IndicesType("col_inds", K_num_non_zero);
+
+        const auto K_row_ptrs_host = Kokkos::create_mirror(K_row_ptrs);
+        const auto K_col_inds_host = Kokkos::create_mirror(K_col_inds);
+
+        const auto K_row_entries = RowPtrType("row_entries", K_num_rows);
+        const auto K_row_entries_host = Kokkos::create_mirror(K_row_entries);
+
+        for (auto i = 0U; i < num_system_nodes; ++i) {
+            const auto this_node_num_dof = count_active_dofs(nfat_host(i));
+            const auto this_node_dof_index = nfmt_host(i);
+
+            auto num_entries_in_row = this_node_num_dof;
+            bool node_found_in_system = false;
+
+            // contributions to non-diagonal block from coupled nodes
+            for (auto e = 0U; e < nnpe_host.extent(0); ++e) {
+                bool contains_node = false;
+                auto num_entries_in_element = 0UL;
+                for (auto j = 0U; j < nnpe_host(e); ++j) {
+                    contains_node = contains_node || (nsi_host(e, j) == i);
+                    num_entries_in_element += count_active_dofs(nfat_host(nsi_host(e, j)));
+                }
+                if (contains_node) {
+                    node_found_in_system = true;
+                    num_entries_in_row += num_entries_in_element - this_node_num_dof;
+                }
+            }
+            if (node_found_in_system) {
+                for (auto j = 0U; j < this_node_num_dof; ++j) {
+                    K_row_entries_host(this_node_dof_index + j) = num_entries_in_row;
+                }
+            }
+        }
+
+        for (auto i = 0U; i < num_system_dofs; ++i) {
+            K_row_ptrs_host(i + 1) = K_row_ptrs_host(i) + K_row_entries_host(i);
+        }
+
+        Kokkos::deep_copy(K_row_ptrs, K_row_ptrs_host);
+
+        for (auto i = 0U; i < num_system_nodes; ++i) {
+            const auto this_node_num_dof = count_active_dofs(nfat_host(i));
+            const auto this_node_dof_index = nfmt_host(i);
+
+            for (auto j = 0U; j < this_node_num_dof; ++j) {
+                auto current_dof_index = K_row_ptrs_host(this_node_dof_index + j);
+
+                // entries from current node
+                for (auto k = 0U; k < this_node_num_dof; ++k, ++current_dof_index) {
+                    K_col_inds_host(current_dof_index) = static_cast<int>(this_node_dof_index + k);
+                }
+
+                for (auto e = 0U; e < nnpe_host.extent(0); ++e) {
+                    bool contains_node = false;
+                    for (auto n = 0U; n < nnpe_host(e); ++n) {
+                        contains_node = contains_node || (nsi_host(e, n) == i);
+                    }
+                    if (contains_node) {
+                        for (auto n = 0U; n < nnpe_host(e); ++n) {
+                            if (nsi_host(e, n) != i) {
+                                const auto target_node_num_dof =
+                                    count_active_dofs(nfat_host(nsi_host(e, n)));
+                                const auto target_node_dof_index = nfmt_host(nsi_host(e, n));
+                                for (auto k = 0U; k < target_node_num_dof;
+                                     ++k, ++current_dof_index) {
+                                    K_col_inds_host(current_dof_index) =
+                                        static_cast<int>(target_node_dof_index + k);
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        Kokkos::deep_copy(K_col_inds, K_col_inds_host);
+
         auto K_values = ValuesType("K values", K_num_non_zero);
+        KokkosSparse::sort_crs_matrix(K_row_ptrs, K_col_inds, K_values);
         K = CrsMatrixType(
             "K", static_cast<int>(K_num_rows), static_cast<int>(K_num_columns), K_num_non_zero,
             K_values, K_row_ptrs, K_col_inds
         );
 
         // Tangent operator sparse matrix
-        auto T_num_non_zero = this->num_system_nodes * 6 * 6;
+        auto T_num_non_zero = 0UL;
+        for (auto i = 0U; i < num_system_nodes; ++i) {
+            const auto num_node_dof = count_active_dofs(nfat_host(i));
+            const auto num_diagonal_non_zero = num_node_dof * num_node_dof;
+            T_num_non_zero += num_diagonal_non_zero;
+        }
         auto T_row_ptrs = RowPtrType("T_row_ptrs", K_num_rows + 1);
-        auto T_indices = IndicesType("T_indices", T_num_non_zero);
-        Kokkos::parallel_for(
-            "PopulateTangentRowPtrs", 1,
-            PopulateTangentRowPtrs<CrsMatrixType::size_type>{this->num_system_nodes, T_row_ptrs}
-        );
+        auto T_col_inds = IndicesType("T_indices", T_num_non_zero);
 
-        Kokkos::parallel_for(
-            "PopulateTangentIndices", 1,
-            PopulateTangentIndices{this->num_system_nodes, node_IDs, T_indices}
-        );
+        auto T_row_ptrs_host = Kokkos::create_mirror(T_row_ptrs);
+        auto T_col_inds_host = Kokkos::create_mirror(T_col_inds);
+
+        const auto T_row_entries = RowPtrType("row_entries", K_num_rows);
+        const auto T_row_entries_host = Kokkos::create_mirror(T_row_entries);
+
+        for (auto i = 0U; i < num_system_nodes; ++i) {
+            const auto this_node_num_dof = count_active_dofs(nfat_host(i));
+            const auto this_node_dof_index = nfmt_host(i);
+
+            auto num_entries_in_row = this_node_num_dof;
+
+            for (auto j = 0U; j < this_node_num_dof; ++j) {
+                T_row_entries_host(this_node_dof_index + j) = num_entries_in_row;
+            }
+        }
+
+        for (auto i = 0U; i < num_system_dofs; ++i) {
+            T_row_ptrs_host(i + 1) = T_row_ptrs_host(i) + T_row_entries_host(i);
+        }
+
+        Kokkos::deep_copy(T_row_ptrs, T_row_ptrs_host);
+
+        for (auto i = 0U; i < num_system_nodes; ++i) {
+            const auto this_node_num_dof = count_active_dofs(nfat_host(i));
+            const auto this_node_dof_index = nfmt_host(i);
+
+            for (auto j = 0U; j < this_node_num_dof; ++j) {
+                auto current_dof_index = T_row_ptrs_host(this_node_dof_index + j);
+
+                for (auto k = 0U; k < this_node_num_dof; ++k, ++current_dof_index) {
+                    T_col_inds_host(current_dof_index) = static_cast<int>(this_node_dof_index + k);
+                }
+            }
+        }
+        Kokkos::deep_copy(T_col_inds, T_col_inds_host);
+
         auto T_values = ValuesType("T values", T_num_non_zero);
+        KokkosSparse::sort_crs_matrix(T_row_ptrs, T_col_inds, T_values);
         T = CrsMatrixType(
             "T", static_cast<int>(K_num_rows), static_cast<int>(K_num_columns), T_num_non_zero,
-            T_values, T_row_ptrs, T_indices
+            T_values, T_row_ptrs, T_col_inds
         );
-
         // Initialize contraint for indexing for sparse matrices
         auto B_num_non_zero = size_t{0U};
         Kokkos::parallel_reduce(
@@ -176,6 +311,7 @@ struct Solver {
                 B_t_row_ptrs, B_t_col_inds
             }
         );
+        KokkosSparse::sort_crs_matrix(B_t_row_ptrs, B_t_col_inds, B_t_values);
         B_t = CrsMatrixType(
             "B_t", static_cast<int>(B_t_num_rows), static_cast<int>(B_t_num_columns),
             B_t_num_non_zero, B_t_values, B_t_row_ptrs, B_t_col_inds

--- a/src/solver/solver.hpp
+++ b/src/solver/solver.hpp
@@ -309,7 +309,7 @@ private:
     [[nodiscard]] static IndicesType ComputeTColInds(
         size_t T_num_non_zero,
         const Kokkos::View<FreedomSignature*>::const_type& node_freedom_allocation_table,
-        const Kokkos::View<size_t*>::const_type node_freedom_map_table, const RowPtrType& T_row_ptrs
+        const Kokkos::View<size_t*>::const_type& node_freedom_map_table, const RowPtrType& T_row_ptrs
     ) {
         const auto nfat_host = Kokkos::create_mirror(node_freedom_allocation_table);
         Kokkos::deep_copy(nfat_host, node_freedom_allocation_table);
@@ -378,10 +378,15 @@ private:
         const auto K_values = ValuesType("K values", K_num_non_zero);
 
         KokkosSparse::sort_crs_matrix(K_row_ptrs, K_col_inds, K_values);
-        return CrsMatrixType(
-            "K", static_cast<int>(K_num_rows), static_cast<int>(K_num_columns), K_num_non_zero,
-            K_values, K_row_ptrs, K_col_inds
-        );
+        return {
+            "K",
+            static_cast<int>(K_num_rows),
+            static_cast<int>(K_num_columns),
+            K_num_non_zero,
+            K_values,
+            K_row_ptrs,
+            K_col_inds
+        };
     }
 
     [[nodiscard]] static CrsMatrixType CreateTMatrix(
@@ -401,10 +406,15 @@ private:
         const auto T_values = ValuesType("T values", T_num_non_zero);
 
         KokkosSparse::sort_crs_matrix(T_row_ptrs, T_col_inds, T_values);
-        return CrsMatrixType(
-            "T", static_cast<int>(T_num_rows), static_cast<int>(T_num_columns), T_num_non_zero,
-            T_values, T_row_ptrs, T_col_inds
-        );
+        return {
+            "T",
+            static_cast<int>(T_num_rows),
+            static_cast<int>(T_num_columns),
+            T_num_non_zero,
+            T_values,
+            T_row_ptrs,
+            T_col_inds
+        };
     }
 
     [[nodiscard]] static CrsMatrixType CreateBMatrix(
@@ -429,10 +439,15 @@ private:
         );
         const auto B_values = ValuesType("B values", B_num_non_zero);
         KokkosSparse::sort_crs_matrix(B_row_ptrs, B_col_ind, B_values);
-        return CrsMatrixType(
-            "B", static_cast<int>(B_num_rows), static_cast<int>(B_num_columns), B_num_non_zero,
-            B_values, B_row_ptrs, B_col_ind
-        );
+        return {
+            "B",
+            static_cast<int>(B_num_rows),
+            static_cast<int>(B_num_columns),
+            B_num_non_zero,
+            B_values,
+            B_row_ptrs,
+            B_col_ind
+        };
     }
 
     [[nodiscard]] static CrsMatrixType CreateBtMatrix(
@@ -475,10 +490,15 @@ private:
             }
         );
         KokkosSparse::sort_crs_matrix(B_t_row_ptrs, B_t_col_inds, B_t_values);
-        return CrsMatrixType(
-            "B_t", static_cast<int>(B_t_num_rows), static_cast<int>(B_t_num_columns),
-            B_t_num_non_zero, B_t_values, B_t_row_ptrs, B_t_col_inds
-        );
+        return {
+            "B_t",
+            static_cast<int>(B_t_num_rows),
+            static_cast<int>(B_t_num_columns),
+            B_t_num_non_zero,
+            B_t_values,
+            B_t_row_ptrs,
+            B_t_col_inds
+        };
     }
 
 public:

--- a/src/solver/solver.hpp
+++ b/src/solver/solver.hpp
@@ -150,7 +150,7 @@ private:
         const auto K_row_ptrs_host = Kokkos::create_mirror(K_row_ptrs);
 
         const auto K_row_entries = RowPtrType("row_ptrs", K_num_rows);
-        const auto K_row_entries_host = Kokkos::create_mirror(K_row_ptrs);
+        const auto K_row_entries_host = Kokkos::create_mirror(K_row_entries);
 
         for (auto i = 0U; i < nfat_host.extent(0); ++i) {
             const auto this_node_num_dof = count_active_dofs(nfat_host(i));

--- a/src/step/assemble_system_matrix.hpp
+++ b/src/step/assemble_system_matrix.hpp
@@ -26,7 +26,6 @@ inline void AssembleSystemMatrix(Solver& solver, Beams& beams) {
     auto sparse_matrix_policy = Kokkos::TeamPolicy<>(static_cast<int>(num_rows), Kokkos::AUTO());
 
     sparse_matrix_policy.set_scratch_size(1, Kokkos::PerTeam(row_data_size + col_idx_size));
-
     Kokkos::parallel_for(
         "ContributeElementsToSparseMatrix", sparse_matrix_policy,
         ContributeElementsToSparseMatrix<Solver::CrsMatrixType>{

--- a/tests/regression_tests/external/test_rotor_aero_controller.cpp
+++ b/tests/regression_tests/external/test_rotor_aero_controller.cpp
@@ -14,6 +14,9 @@
 #include "src/beams/beams.hpp"
 #include "src/beams/beams_input.hpp"
 #include "src/beams/create_beams.hpp"
+#include "src/dof_management/assemble_node_freedom_allocation_table.hpp"
+#include "src/dof_management/compute_node_freedom_map_table.hpp"
+#include "src/dof_management/create_element_freedom_table.hpp"
 #include "src/model/model.hpp"
 #include "src/solver/solver.hpp"
 #include "src/state/state.hpp"
@@ -411,8 +414,12 @@ TEST(Milestone, IEA15RotorAeroController) {
     auto parameters = StepParameters(is_dynamic_solve, max_iter, step_size, rho_inf);
 
     // Create solver
+    assemble_node_freedom_allocation_table(state, beams, constraints);
+    compute_node_freedom_map_table(state);
+    create_element_freedom_table(beams, state);
     auto solver = Solver(
-        state.ID, beams.num_nodes_per_element, beams.node_state_indices, constraints.num_dofs,
+        state.ID, state.node_freedom_allocation_table, state.node_freedom_map_table,
+        beams.num_nodes_per_element, beams.node_state_indices, constraints.num_dofs,
         constraints.type, constraints.base_node_index, constraints.target_node_index,
         constraints.row_range
     );

--- a/tests/regression_tests/regression/test_cantilever_beam.cpp
+++ b/tests/regression_tests/regression/test_cantilever_beam.cpp
@@ -12,6 +12,9 @@
 #include "src/beams/beams.hpp"
 #include "src/beams/beams_input.hpp"
 #include "src/beams/create_beams.hpp"
+#include "src/dof_management/assemble_node_freedom_allocation_table.hpp"
+#include "src/dof_management/compute_node_freedom_map_table.hpp"
+#include "src/dof_management/create_element_freedom_table.hpp"
 #include "src/model/model.hpp"
 #include "src/solver/solver.hpp"
 #include "src/state/state.hpp"
@@ -104,9 +107,12 @@ TEST(DynamicBeamTest, CantileverBeamSineLoad) {
     auto parameters = StepParameters(is_dynamic_solve, max_iter, step_size, rho_inf);
     auto constraints = Constraints(model.GetConstraints());
     auto state = model.CreateState();
-
+    assemble_node_freedom_allocation_table(state, beams, constraints);
+    compute_node_freedom_map_table(state);
+    create_element_freedom_table(beams, state);
     auto solver = Solver(
-        state.ID, beams.num_nodes_per_element, beams.node_state_indices, constraints.num_dofs,
+        state.ID, state.node_freedom_allocation_table, state.node_freedom_map_table,
+        beams.num_nodes_per_element, beams.node_state_indices, constraints.num_dofs,
         constraints.type, constraints.base_node_index, constraints.target_node_index,
         constraints.row_range
     );

--- a/tests/regression_tests/regression/test_rotating_beam.cpp
+++ b/tests/regression_tests/regression/test_rotating_beam.cpp
@@ -17,6 +17,9 @@
 #include "src/beams/beams.hpp"
 #include "src/beams/beams_input.hpp"
 #include "src/beams/create_beams.hpp"
+#include "src/dof_management/assemble_node_freedom_allocation_table.hpp"
+#include "src/dof_management/compute_node_freedom_map_table.hpp"
+#include "src/dof_management/create_element_freedom_table.hpp"
 #include "src/model/model.hpp"
 #include "src/solver/solver.hpp"
 #include "src/state/state.hpp"
@@ -152,8 +155,12 @@ TEST(RotatingBeamTest, StepConvergence) {
     auto parameters = StepParameters(is_dynamic_solve, max_iter, step_size, rho_inf);
     auto constraints = Constraints(model.GetConstraints());
     auto state = model.CreateState();
+    assemble_node_freedom_allocation_table(state, beams, constraints);
+    compute_node_freedom_map_table(state);
+    create_element_freedom_table(beams, state);
     auto solver = Solver(
-        state.ID, beams.num_nodes_per_element, beams.node_state_indices, constraints.num_dofs,
+        state.ID, state.node_freedom_allocation_table, state.node_freedom_map_table,
+        beams.num_nodes_per_element, beams.node_state_indices, constraints.num_dofs,
         constraints.type, constraints.base_node_index, constraints.target_node_index,
         constraints.row_range
     );
@@ -256,8 +263,12 @@ inline void CreateTwoBeamSolverWithSameBeamsAndStep() {
     auto parameters = StepParameters(is_dynamic_solve, max_iter, step_size, rho_inf);
     auto constraints = Constraints(model.GetConstraints());
     auto state = model.CreateState();
+    assemble_node_freedom_allocation_table(state, beams, constraints);
+    compute_node_freedom_map_table(state);
+    create_element_freedom_table(beams, state);
     auto solver = Solver(
-        state.ID, beams.num_nodes_per_element, beams.node_state_indices, constraints.num_dofs,
+        state.ID, state.node_freedom_allocation_table, state.node_freedom_map_table,
+        beams.num_nodes_per_element, beams.node_state_indices, constraints.num_dofs,
         constraints.type, constraints.base_node_index, constraints.target_node_index,
         constraints.row_range
     );
@@ -375,8 +386,12 @@ TEST(RotatingBeamTest, ThreeBladeRotor) {
     auto parameters = StepParameters(is_dynamic_solve, max_iter, step_size, rho_inf);
     auto constraints = Constraints(model.GetConstraints());
     auto state = model.CreateState();
+    assemble_node_freedom_allocation_table(state, beams, constraints);
+    compute_node_freedom_map_table(state);
+    create_element_freedom_table(beams, state);
     auto solver = Solver(
-        state.ID, beams.num_nodes_per_element, beams.node_state_indices, constraints.num_dofs,
+        state.ID, state.node_freedom_allocation_table, state.node_freedom_map_table,
+        beams.num_nodes_per_element, beams.node_state_indices, constraints.num_dofs,
         constraints.type, constraints.base_node_index, constraints.target_node_index,
         constraints.row_range
     );
@@ -461,8 +476,12 @@ TEST(RotatingBeamTest, MasslessConstraints) {
     auto parameters = StepParameters(is_dynamic_solve, max_iter, step_size, rho_inf);
     auto constraints = Constraints(model.GetConstraints());
     auto state = model.CreateState();
+    assemble_node_freedom_allocation_table(state, beams, constraints);
+    compute_node_freedom_map_table(state);
+    create_element_freedom_table(beams, state);
     auto solver = Solver(
-        state.ID, beams.num_nodes_per_element, beams.node_state_indices, constraints.num_dofs,
+        state.ID, state.node_freedom_allocation_table, state.node_freedom_map_table,
+        beams.num_nodes_per_element, beams.node_state_indices, constraints.num_dofs,
         constraints.type, constraints.base_node_index, constraints.target_node_index,
         constraints.row_range
     );
@@ -533,8 +552,12 @@ TEST(RotatingBeamTest, RotationControlConstraint) {
     auto parameters = StepParameters(is_dynamic_solve, max_iter, step_size, rho_inf);
     auto constraints = Constraints(model.GetConstraints());
     auto state = model.CreateState();
+    assemble_node_freedom_allocation_table(state, beams, constraints);
+    compute_node_freedom_map_table(state);
+    create_element_freedom_table(beams, state);
     auto solver = Solver(
-        state.ID, beams.num_nodes_per_element, beams.node_state_indices, constraints.num_dofs,
+        state.ID, state.node_freedom_allocation_table, state.node_freedom_map_table,
+        beams.num_nodes_per_element, beams.node_state_indices, constraints.num_dofs,
         constraints.type, constraints.base_node_index, constraints.target_node_index,
         constraints.row_range
     );
@@ -609,8 +632,12 @@ TEST(RotatingBeamTest, CompoundRotationControlConstraint) {
     auto parameters = StepParameters(is_dynamic_solve, max_iter, step_size, rho_inf);
     auto constraints = Constraints(model.GetConstraints());
     auto state = model.CreateState();
+    assemble_node_freedom_allocation_table(state, beams, constraints);
+    compute_node_freedom_map_table(state);
+    create_element_freedom_table(beams, state);
     auto solver = Solver(
-        state.ID, beams.num_nodes_per_element, beams.node_state_indices, constraints.num_dofs,
+        state.ID, state.node_freedom_allocation_table, state.node_freedom_map_table,
+        beams.num_nodes_per_element, beams.node_state_indices, constraints.num_dofs,
         constraints.type, constraints.base_node_index, constraints.target_node_index,
         constraints.row_range
     );
@@ -701,8 +728,12 @@ TEST(RotatingBeamTest, RevoluteJointConstraint) {
     auto parameters = StepParameters(is_dynamic_solve, max_iter, step_size, rho_inf);
     auto constraints = Constraints(model.GetConstraints());
     auto state = model.CreateState();
+    assemble_node_freedom_allocation_table(state, beams, constraints);
+    compute_node_freedom_map_table(state);
+    create_element_freedom_table(beams, state);
     auto solver = Solver(
-        state.ID, beams.num_nodes_per_element, beams.node_state_indices, constraints.num_dofs,
+        state.ID, state.node_freedom_allocation_table, state.node_freedom_map_table,
+        beams.num_nodes_per_element, beams.node_state_indices, constraints.num_dofs,
         constraints.type, constraints.base_node_index, constraints.target_node_index,
         constraints.row_range
     );
@@ -819,8 +850,12 @@ void GeneratorTorqueWithAxisTilt(
     auto parameters = StepParameters(is_dynamic_solve, max_iter, step_size, rho_inf);
     auto constraints = Constraints(model.GetConstraints());
     auto state = model.CreateState();
+    assemble_node_freedom_allocation_table(state, beams, constraints);
+    compute_node_freedom_map_table(state);
+    create_element_freedom_table(beams, state);
     auto solver = Solver(
-        state.ID, beams.num_nodes_per_element, beams.node_state_indices, constraints.num_dofs,
+        state.ID, state.node_freedom_allocation_table, state.node_freedom_map_table,
+        beams.num_nodes_per_element, beams.node_state_indices, constraints.num_dofs,
         constraints.type, constraints.base_node_index, constraints.target_node_index,
         constraints.row_range
     );

--- a/tests/regression_tests/regression/test_rotor.cpp
+++ b/tests/regression_tests/regression/test_rotor.cpp
@@ -499,9 +499,6 @@ TEST(RotorTest, IEA15RotorController) {
     assemble_node_freedom_allocation_table(state, beams, constraints);
     compute_node_freedom_map_table(state);
     create_element_freedom_table(beams, state);
-    //    auto solver = Solver(state.ID, beams.num_nodes_per_element, beams.node_state_indices,
-    //                         constraints.num_dofs, constraints.type, constraints.base_node_index,
-    //                         constraints.target_node_index, constraints.row_range);
     auto solver = Solver(
         state.ID, state.node_freedom_allocation_table, state.node_freedom_map_table,
         beams.num_nodes_per_element, beams.node_state_indices, constraints.num_dofs,

--- a/tests/regression_tests/regression/test_rotor.cpp
+++ b/tests/regression_tests/regression/test_rotor.cpp
@@ -14,6 +14,9 @@
 #include "src/beams/beams.hpp"
 #include "src/beams/beams_input.hpp"
 #include "src/beams/create_beams.hpp"
+#include "src/dof_management/assemble_node_freedom_allocation_table.hpp"
+#include "src/dof_management/compute_node_freedom_map_table.hpp"
+#include "src/dof_management/create_element_freedom_table.hpp"
 #include "src/model/model.hpp"
 #include "src/solver/solver.hpp"
 #include "src/state/state.hpp"
@@ -147,8 +150,12 @@ TEST(RotorTest, IEA15Rotor) {
     auto parameters = StepParameters(is_dynamic_solve, max_iter, step_size, rho_inf);
     auto constraints = Constraints(model.GetConstraints());
     auto state = model.CreateState();
+    assemble_node_freedom_allocation_table(state, beams, constraints);
+    compute_node_freedom_map_table(state);
+    create_element_freedom_table(beams, state);
     auto solver = Solver(
-        state.ID, beams.num_nodes_per_element, beams.node_state_indices, constraints.num_dofs,
+        state.ID, state.node_freedom_allocation_table, state.node_freedom_map_table,
+        beams.num_nodes_per_element, beams.node_state_indices, constraints.num_dofs,
         constraints.type, constraints.base_node_index, constraints.target_node_index,
         constraints.row_range
     );
@@ -302,8 +309,12 @@ TEST(RotorTest, IEA15RotorHub) {
     auto parameters = StepParameters(is_dynamic_solve, max_iter, step_size, rho_inf);
     auto constraints = Constraints(model.GetConstraints());
     auto state = model.CreateState();
+    assemble_node_freedom_allocation_table(state, beams, constraints);
+    compute_node_freedom_map_table(state);
+    create_element_freedom_table(beams, state);
     auto solver = Solver(
-        state.ID, beams.num_nodes_per_element, beams.node_state_indices, constraints.num_dofs,
+        state.ID, state.node_freedom_allocation_table, state.node_freedom_map_table,
+        beams.num_nodes_per_element, beams.node_state_indices, constraints.num_dofs,
         constraints.type, constraints.base_node_index, constraints.target_node_index,
         constraints.row_range
     );
@@ -485,8 +496,15 @@ TEST(RotorTest, IEA15RotorController) {
     auto parameters = StepParameters(is_dynamic_solve, max_iter, step_size, rho_inf);
     auto constraints = Constraints(model.GetConstraints());
     auto state = model.CreateState();
+    assemble_node_freedom_allocation_table(state, beams, constraints);
+    compute_node_freedom_map_table(state);
+    create_element_freedom_table(beams, state);
+    //    auto solver = Solver(state.ID, beams.num_nodes_per_element, beams.node_state_indices,
+    //                         constraints.num_dofs, constraints.type, constraints.base_node_index,
+    //                         constraints.target_node_index, constraints.row_range);
     auto solver = Solver(
-        state.ID, beams.num_nodes_per_element, beams.node_state_indices, constraints.num_dofs,
+        state.ID, state.node_freedom_allocation_table, state.node_freedom_map_table,
+        beams.num_nodes_per_element, beams.node_state_indices, constraints.num_dofs,
         constraints.type, constraints.base_node_index, constraints.target_node_index,
         constraints.row_range
     );

--- a/tests/regression_tests/regression/test_solver.cpp
+++ b/tests/regression_tests/regression/test_solver.cpp
@@ -10,6 +10,9 @@
 #include "src/beams/beams.hpp"
 #include "src/beams/beams_input.hpp"
 #include "src/beams/create_beams.hpp"
+#include "src/dof_management/assemble_node_freedom_allocation_table.hpp"
+#include "src/dof_management/compute_node_freedom_map_table.hpp"
+#include "src/dof_management/create_element_freedom_table.hpp"
 #include "src/model/model.hpp"
 #include "src/solver/solver.hpp"
 #include "src/state/state.hpp"
@@ -111,8 +114,12 @@ inline void SetUpSolverAndAssemble() {
     auto parameters = StepParameters(is_dynamic_solve, max_iter, step_size, rho_inf);
     auto constraints = Constraints(model.GetConstraints());
     auto state = model.CreateState();
+    assemble_node_freedom_allocation_table(state, beams, constraints);
+    compute_node_freedom_map_table(state);
+    create_element_freedom_table(beams, state);
     auto solver = Solver(
-        state.ID, beams.num_nodes_per_element, beams.node_state_indices, constraints.num_dofs,
+        state.ID, state.node_freedom_allocation_table, state.node_freedom_map_table,
+        beams.num_nodes_per_element, beams.node_state_indices, constraints.num_dofs,
         constraints.type, constraints.base_node_index, constraints.target_node_index,
         constraints.row_range
     );
@@ -348,8 +355,12 @@ inline void SetupAndTakeNoSteps() {
     auto parameters = StepParameters(is_dynamic_solve, max_iter, step_size, rho_inf);
     auto constraints = Constraints(model.GetConstraints());
     auto state = model.CreateState();
+    assemble_node_freedom_allocation_table(state, beams, constraints);
+    compute_node_freedom_map_table(state);
+    create_element_freedom_table(beams, state);
     auto solver = Solver(
-        state.ID, beams.num_nodes_per_element, beams.node_state_indices, constraints.num_dofs,
+        state.ID, state.node_freedom_allocation_table, state.node_freedom_map_table,
+        beams.num_nodes_per_element, beams.node_state_indices, constraints.num_dofs,
         constraints.type, constraints.base_node_index, constraints.target_node_index,
         constraints.row_range
     );
@@ -556,8 +567,12 @@ inline auto SetupAndTakeTwoSteps() {
     auto parameters = StepParameters(is_dynamic_solve, max_iter, step_size, rho_inf);
     auto constraints = Constraints(model.GetConstraints());
     auto state = model.CreateState();
+    assemble_node_freedom_allocation_table(state, beams, constraints);
+    compute_node_freedom_map_table(state);
+    create_element_freedom_table(beams, state);
     auto solver = Solver(
-        state.ID, beams.num_nodes_per_element, beams.node_state_indices, constraints.num_dofs,
+        state.ID, state.node_freedom_allocation_table, state.node_freedom_map_table,
+        beams.num_nodes_per_element, beams.node_state_indices, constraints.num_dofs,
         constraints.type, constraints.base_node_index, constraints.target_node_index,
         constraints.row_range
     );

--- a/tests/unit_tests/dof_management/test_assemble_node_freedom_allocation_table.cpp
+++ b/tests/unit_tests/dof_management/test_assemble_node_freedom_allocation_table.cpp
@@ -11,7 +11,9 @@ TEST(TestAssembleNodeFreedomAllocationTable, OneBeamOneNode) {
     Kokkos::deep_copy(beams.node_state_indices, 0U);
     Kokkos::deep_copy(beams.num_nodes_per_element, 1U);
 
-    assemble_node_freedom_allocation_table(state, beams);
+    auto constraints = Constraints({});
+
+    assemble_node_freedom_allocation_table(state, beams, constraints);
 
     const auto host_node_freedom_allocation_table =
         Kokkos::create_mirror(state.node_freedom_allocation_table);
@@ -33,7 +35,9 @@ TEST(TestAssembleNodeFreedomAllocationTable, OneBeamTwoNodes) {
     Kokkos::deep_copy(beams.node_state_indices, mirror_node_state_indices);
     Kokkos::deep_copy(beams.num_nodes_per_element, 2U);
 
-    assemble_node_freedom_allocation_table(state, beams);
+    auto constraints = Constraints({});
+
+    assemble_node_freedom_allocation_table(state, beams, constraints);
 
     const auto host_node_freedom_allocation_table =
         Kokkos::create_mirror(state.node_freedom_allocation_table);
@@ -56,7 +60,9 @@ TEST(TestAssembleNodeFreedomAllocationTable, TwoBeamsOneNode) {
     Kokkos::deep_copy(beams.node_state_indices, mirror_node_state_indices);
     Kokkos::deep_copy(beams.num_nodes_per_element, 1U);
 
-    assemble_node_freedom_allocation_table(state, beams);
+    auto constraints = Constraints({});
+
+    assemble_node_freedom_allocation_table(state, beams, constraints);
 
     const auto host_node_freedom_allocation_table =
         Kokkos::create_mirror(state.node_freedom_allocation_table);

--- a/tests/unit_tests/dof_management/test_assemble_node_freedom_allocation_table.cpp
+++ b/tests/unit_tests/dof_management/test_assemble_node_freedom_allocation_table.cpp
@@ -11,7 +11,7 @@ TEST(TestAssembleNodeFreedomAllocationTable, OneBeamOneNode) {
     Kokkos::deep_copy(beams.node_state_indices, 0U);
     Kokkos::deep_copy(beams.num_nodes_per_element, 1U);
 
-    auto constraints = Constraints({});
+    auto constraints = Constraints(std::vector<std::shared_ptr<Constraint>>{});
 
     assemble_node_freedom_allocation_table(state, beams, constraints);
 
@@ -35,7 +35,7 @@ TEST(TestAssembleNodeFreedomAllocationTable, OneBeamTwoNodes) {
     Kokkos::deep_copy(beams.node_state_indices, mirror_node_state_indices);
     Kokkos::deep_copy(beams.num_nodes_per_element, 2U);
 
-    auto constraints = Constraints({});
+    auto constraints = Constraints(std::vector<std::shared_ptr<Constraint>>{});
 
     assemble_node_freedom_allocation_table(state, beams, constraints);
 
@@ -60,7 +60,7 @@ TEST(TestAssembleNodeFreedomAllocationTable, TwoBeamsOneNode) {
     Kokkos::deep_copy(beams.node_state_indices, mirror_node_state_indices);
     Kokkos::deep_copy(beams.num_nodes_per_element, 1U);
 
-    auto constraints = Constraints({});
+    auto constraints = Constraints(std::vector<std::shared_ptr<Constraint>>{});
 
     assemble_node_freedom_allocation_table(state, beams, constraints);
 


### PR DESCRIPTION
This change should also give us the ability to create sparse matrix layouts for blades made of multiple beams.

The solver setup is currently done on host.  I will move it to device and properly parallelize it in a follow on story once we're feature complete.  

The next step is to propagate these data structures to the system assembly routines.  