### PR TITLE
Upgrade system assembly to dof maps

### DIFF
--- a/src/constraints/constraints.hpp
+++ b/src/constraints/constraints.hpp
@@ -29,6 +29,8 @@ struct Constraints {
     Kokkos::View<size_t*> target_node_index;
     Kokkos::View<FreedomSignature*> base_node_freedom_signature;
     Kokkos::View<FreedomSignature*> target_node_freedom_signature;
+    Kokkos::View<size_t* [6]> target_node_freedom_table;
+    Kokkos::View<size_t* [6]> base_node_freedom_table;
     Kokkos::View<double* [3]> X0;
     Kokkos::View<double* [3][3]> axes;
 
@@ -59,6 +61,8 @@ struct Constraints {
           target_node_index("target_node_index", num),
           base_node_freedom_signature("base_node_freedom_signature", num),
           target_node_freedom_signature("target_node_freedom_signature", num),
+          base_node_freedom_table("base_node_freedom_table", num),
+          target_node_freedom_table("target_node_freedom_table", num),
           X0("X0", num),
           axes("axes", num),
           input("inputs", num),

--- a/src/constraints/constraints.hpp
+++ b/src/constraints/constraints.hpp
@@ -29,8 +29,8 @@ struct Constraints {
     Kokkos::View<size_t*> target_node_index;
     Kokkos::View<FreedomSignature*> base_node_freedom_signature;
     Kokkos::View<FreedomSignature*> target_node_freedom_signature;
-    Kokkos::View<size_t* [6]> target_node_freedom_table;
     Kokkos::View<size_t* [6]> base_node_freedom_table;
+    Kokkos::View<size_t* [6]> target_node_freedom_table;
     Kokkos::View<double* [3]> X0;
     Kokkos::View<double* [3][3]> axes;
 

--- a/src/dof_management/create_constraint_freedom_table.hpp
+++ b/src/dof_management/create_constraint_freedom_table.hpp
@@ -1,0 +1,45 @@
+#pragma once
+
+#include <Kokkos_Core.hpp>
+
+#include "freedom_signature.hpp"
+
+#include "src/constraints/constraints.hpp"
+#include "src/state/state.hpp"
+
+namespace openturbine {
+
+inline void create_constraint_freedom_table(Constraints& constraints, const State& state) {
+    const auto constraints_num = constraints.num;
+    const auto constraints_type = constraints.type;
+    const auto constraints_target_node_index = constraints.target_node_index;
+    const auto constraints_base_node_index = constraints.base_node_index;
+    const auto constraints_target_node_freedom_table = constraints.target_node_freedom_table;
+    const auto constraints_base_node_freedom_table = constraints.base_node_freedom_table;
+
+    const auto state_node_freedom_map_table = state.node_freedom_map_table;
+
+    Kokkos::parallel_for(
+        "Create Constraint Node Freedom Table", 1,
+        KOKKOS_LAMBDA(size_t) {
+            for (auto i = 0U; i < constraints_num; ++i) {
+                {
+                    const auto node_index = constraints_target_node_index(i);
+                    for (auto k = 0U; k < 6U; ++k) {
+                        constraints_target_node_freedom_table(i, k) =
+                            state_node_freedom_map_table(node_index) + k;
+                    }
+                }
+                if (GetNumberOfNodes(constraints_type(i)) == 2U) {
+                    const auto node_index = constraints_base_node_index(i);
+                    for (auto k = 0U; k < 6U; ++k) {
+                        constraints_base_node_freedom_table(i, k) =
+                            state_node_freedom_map_table(node_index) + k;
+                    }
+                }
+            }
+        }
+    );
+}
+
+}  // namespace openturbine

--- a/src/solver/contribute_elements_to_sparse_matrix.hpp
+++ b/src/solver/contribute_elements_to_sparse_matrix.hpp
@@ -3,35 +3,43 @@
 #include <KokkosSparse.hpp>
 #include <Kokkos_Core.hpp>
 
+#include "src/dof_management/freedom_signature.hpp"
+
 namespace openturbine {
 template <typename CrsMatrixType>
 struct ContributeElementsToSparseMatrix {
     using RowDataType = typename CrsMatrixType::values_type::non_const_type;
     using ColIdxType = typename CrsMatrixType::staticcrsgraph_type::entries_type::non_const_type;
-    CrsMatrixType sparse;
+    Kokkos::View<size_t*> num_nodes_per_element;
+    Kokkos::View<FreedomSignature**> element_freedom_signature;
+    Kokkos::View<size_t** [6]> element_freedom_table;
     Kokkos::View<double*** [6][6]>::const_type dense;
+    CrsMatrixType sparse;
 
     KOKKOS_FUNCTION
     void operator()(Kokkos::TeamPolicy<>::member_type member) const {
         const auto i = member.league_rank();
-        const auto row = sparse.row(i);
-        const auto row_map = sparse.graph.row_map;
-        const auto cols = sparse.graph.entries;
-        const auto row_data = RowDataType(member.team_scratch(1), static_cast<size_t>(row.length));
-        const auto col_idx = ColIdxType(member.team_scratch(1), static_cast<size_t>(row.length));
-        Kokkos::parallel_for(Kokkos::TeamThreadRange(member, row.length), [&](size_t entry) {
-            const auto element = i / row.length;
-            const auto row_block = i % row.length;
-            const auto node_1 = row_block / 6;
-            const auto component_1 = row_block % 6;
-            const auto node_2 = entry / 6;
-            const auto component_2 = entry % 6;
-            col_idx(entry) = cols(row_map(i) + entry);
-            row_data(entry) = dense(element, node_1, node_2, component_1, component_2);
-        });
-        member.team_barrier();
-        Kokkos::single(Kokkos::PerTeam(member), [&]() {
-            sparse.replaceValues(i, col_idx.data(), row.length, row_data.data());
+        const auto num_nodes = num_nodes_per_element(i);
+        Kokkos::parallel_for(Kokkos::TeamThreadRange(member, num_nodes), [&](size_t node_1) {
+            const auto num_dofs = count_active_dofs(element_freedom_signature(i, node_1));
+            auto row_map = sparse.graph.row_map;
+            auto cols = sparse.graph.entries;
+            auto row_data = RowDataType(member.thread_scratch(1), num_dofs);
+            auto col_idx = ColIdxType(member.thread_scratch(1), num_dofs);
+
+            for (auto node_2 = 0U; node_2 < num_nodes; ++node_2) {
+                for (auto component_1 = 0U; component_1 < num_dofs; ++component_1) {
+                    const auto row_num = element_freedom_table(i, node_1, component_1);
+                    for (auto component_2 = 0U; component_2 < num_dofs; ++component_2) {
+                        col_idx(component_2) =
+                            static_cast<int>(element_freedom_table(i, node_2, component_2));
+                        row_data(component_2) = dense(i, node_1, node_2, component_1, component_2);
+                    }
+                    sparse.replaceValues(
+                        static_cast<int>(row_num), col_idx.data(), static_cast<int>(num_dofs), row_data.data()
+                    );
+                }
+            }
         });
     }
 };

--- a/src/solver/contribute_elements_to_vector.hpp
+++ b/src/solver/contribute_elements_to_vector.hpp
@@ -16,7 +16,7 @@ struct ContributeElementsToVector {
 
         Kokkos::parallel_for(Kokkos::TeamThreadRange(member, num_nodes), [&](size_t i_node) {
             for (auto j = 0U; j < element_freedom_table.extent(2); ++j) {
-                vector(element_freedom_table(i_elem, i_node, j)) = elements(i_elem, i_node, j);
+                vector(element_freedom_table(i_elem, i_node, j)) += elements(i_elem, i_node, j);
             }
         });
     }

--- a/src/solver/contribute_elements_to_vector.hpp
+++ b/src/solver/contribute_elements_to_vector.hpp
@@ -5,7 +5,7 @@
 namespace openturbine {
 struct ContributeElementsToVector {
     Kokkos::View<size_t*>::const_type num_nodes_per_element;
-    Kokkos::View<size_t**>::const_type node_state_indices;
+    Kokkos::View<size_t** [6]>::const_type element_freedom_table;
     Kokkos::View<double** [6]>::const_type elements;
     Kokkos::View<double*> vector;
 
@@ -15,9 +15,8 @@ struct ContributeElementsToVector {
         const auto num_nodes = num_nodes_per_element(i_elem);
 
         Kokkos::parallel_for(Kokkos::TeamThreadRange(member, num_nodes), [&](size_t i_node) {
-            const auto node_start = node_state_indices(i_elem, i_node) * 6U;
-            for (auto j = 0U; j < 6U; ++j) {
-                vector(node_start + j) = elements(i_elem, i_node, j);
+            for (auto j = 0U; j < element_freedom_table.extent(2); ++j) {
+                vector(element_freedom_table(i_elem, i_node, j)) = elements(i_elem, i_node, j);
             }
         });
     }

--- a/src/solver/copy_tangent_to_sparse_matrix.hpp
+++ b/src/solver/copy_tangent_to_sparse_matrix.hpp
@@ -3,29 +3,41 @@
 #include <KokkosSparse.hpp>
 #include <Kokkos_Core.hpp>
 
+#include "src/dof_management/freedom_signature.hpp"
+
 namespace openturbine {
 template <typename CrsMatrixType>
 struct CopyTangentToSparseMatrix {
     using RowDataType = typename CrsMatrixType::values_type::non_const_type;
     using ColIdxType = typename CrsMatrixType::staticcrsgraph_type::entries_type::non_const_type;
+    Kokkos::View<size_t*>::const_type ID;
+    Kokkos::View<FreedomSignature*>::const_type node_freedom_allocation_table;
+    Kokkos::View<size_t*>::const_type node_freedom_map_table;
+    Kokkos::View<double* [6][6]>::const_type dense;
     CrsMatrixType sparse;
-    Kokkos::View<const double* [6][6]> dense;
 
     KOKKOS_FUNCTION
     void operator()(Kokkos::TeamPolicy<>::member_type member) const {
-        auto i = member.league_rank();
-        auto row = sparse.row(i);
-        auto row_map = sparse.graph.row_map;
-        auto cols = sparse.graph.entries;
-        auto row_data = RowDataType(member.team_scratch(1), static_cast<size_t>(row.length));
-        auto col_idx = ColIdxType(member.team_scratch(1), static_cast<size_t>(row.length));
-        Kokkos::parallel_for(Kokkos::TeamThreadRange(member, row.length), [&](size_t entry) {
-            col_idx(entry) = cols(row_map(i) + entry);
-            row_data(entry) = dense(i / 6, i % 6, entry);
-        });
-        member.team_barrier();
-        Kokkos::single(Kokkos::PerTeam(member), [&]() {
-            sparse.replaceValues(i, col_idx.data(), row.length, row_data.data());
+        const auto i = member.league_rank();
+        const auto node_id = ID(i);
+        const auto num_dofs = count_active_dofs(node_freedom_allocation_table(node_id));
+        const auto first_entry = node_freedom_map_table(node_id);
+
+        Kokkos::parallel_for(Kokkos::TeamThreadRange(member, num_dofs), [&](size_t dof) {
+            const auto row_num = first_entry + dof;
+            auto row_map = sparse.graph.row_map;
+            auto cols = sparse.graph.entries;
+            auto row_data = RowDataType(member.thread_scratch(1), num_dofs);
+            auto col_idx = ColIdxType(member.thread_scratch(1), num_dofs);
+
+            for (auto entry = 0U; entry < num_dofs; ++entry) {
+                col_idx(entry) = cols(row_map(row_num) + entry);
+                row_data(entry) = dense(node_id, dof, entry);
+            }
+            sparse.replaceValues(
+                static_cast<int>(row_num), col_idx.data(), static_cast<int>(num_dofs),
+                row_data.data()
+            );
         });
     }
 };

--- a/src/solver/populate_sparse_row_ptrs_col_inds_constraints.hpp
+++ b/src/solver/populate_sparse_row_ptrs_col_inds_constraints.hpp
@@ -9,8 +9,8 @@ namespace openturbine {
 template <typename RowPtrType, typename IndicesType>
 struct PopulateSparseRowPtrsColInds_Constraints {
     Kokkos::View<ConstraintType*>::const_type type;
-    Kokkos::View<size_t*>::const_type base_node_index;
-    Kokkos::View<size_t*>::const_type target_node_index;
+    Kokkos::View<size_t* [6]>::const_type base_node_freedom_table;
+    Kokkos::View<size_t* [6]>::const_type target_node_freedom_table;
     Kokkos::View<Kokkos::pair<size_t, size_t>*>::const_type row_range;
     RowPtrType B_row_ptrs;
     IndicesType B_col_inds;
@@ -28,7 +28,7 @@ struct PopulateSparseRowPtrsColInds_Constraints {
                 // Add column indices for target node
                 for (auto j = 0U; j < 6U; ++j) {
                     B_col_inds(ind_col) = static_cast<typename IndicesType::value_type>(
-                        target_node_index(i_constraint) * 6U + j
+                        target_node_freedom_table(i_constraint, j)
                     );
                     ind_col++;
                 }
@@ -38,7 +38,7 @@ struct PopulateSparseRowPtrsColInds_Constraints {
                     // Add column indices for base node
                     for (auto j = 0U; j < 6U; ++j) {
                         B_col_inds(ind_col) = static_cast<typename IndicesType::value_type>(
-                            base_node_index(i_constraint) * 6U + j
+                            base_node_freedom_table(i_constraint, j)
                         );
                         ind_col++;
                     }

--- a/src/solver/solver.hpp
+++ b/src/solver/solver.hpp
@@ -420,8 +420,8 @@ private:
     [[nodiscard]] static CrsMatrixType CreateBMatrix(
         size_t system_dofs, size_t constraint_dofs,
         const Kokkos::View<ConstraintType*>::const_type& constraint_type,
-        const Kokkos::View<size_t*>::const_type& constraint_base_node_index,
-        const Kokkos::View<size_t*>::const_type& constraint_target_node_index,
+        const Kokkos::View<size_t* [6]>::const_type& constraint_base_node_freedom_table,
+        const Kokkos::View<size_t* [6]>::const_type& constraint_target_node_freedom_table,
         const Kokkos::View<Kokkos::pair<size_t, size_t>*>::const_type& constraint_row_range
     ) {
         const auto B_num_rows = constraint_dofs;
@@ -433,8 +433,8 @@ private:
         Kokkos::parallel_for(
             "PopulateSparseRowPtrsColInds_Constraints", 1,
             PopulateSparseRowPtrsColInds_Constraints<RowPtrType, IndicesType>{
-                constraint_type, constraint_base_node_index, constraint_target_node_index,
-                constraint_row_range, B_row_ptrs, B_col_ind
+                constraint_type, constraint_base_node_freedom_table,
+                constraint_target_node_freedom_table, constraint_row_range, B_row_ptrs, B_col_ind
             }
         );
         const auto B_values = ValuesType("B values", B_num_non_zero);
@@ -453,8 +453,8 @@ private:
     [[nodiscard]] static CrsMatrixType CreateBtMatrix(
         size_t system_dofs, size_t constraint_dofs,
         const Kokkos::View<ConstraintType*>::const_type& constraint_type,
-        const Kokkos::View<size_t*>::const_type& constraint_base_node_index,
-        const Kokkos::View<size_t*>::const_type& constraint_target_node_index,
+        const Kokkos::View<size_t* [6]>::const_type& constraint_base_node_freedom_table,
+        const Kokkos::View<size_t* [6]>::const_type& constraint_target_node_freedom_table,
         const Kokkos::View<Kokkos::pair<size_t, size_t>*>::const_type& constraint_row_range
     ) {
         const auto B_num_rows = constraint_dofs;
@@ -466,8 +466,8 @@ private:
         Kokkos::parallel_for(
             "PopulateSparseRowPtrsColInds_Constraints", 1,
             PopulateSparseRowPtrsColInds_Constraints<RowPtrType, IndicesType>{
-                constraint_type, constraint_base_node_index, constraint_target_node_index,
-                constraint_row_range, B_row_ptrs, B_col_ind
+                constraint_type, constraint_base_node_freedom_table,
+                constraint_target_node_freedom_table, constraint_row_range, B_row_ptrs, B_col_ind
             }
         );
         const auto B_values = ValuesType("B values", B_num_non_zero);
@@ -509,8 +509,8 @@ public:
         const Kokkos::View<size_t*>::const_type& num_nodes_per_element,
         const Kokkos::View<size_t**>::const_type& node_state_indices, size_t num_constraint_dofs,
         const Kokkos::View<ConstraintType*>::const_type& constraint_type,
-        const Kokkos::View<size_t*>::const_type& constraint_base_node_index,
-        const Kokkos::View<size_t*>::const_type& constraint_target_node_index,
+        const Kokkos::View<size_t* [6]>::const_type& constraint_base_node_freedom_table,
+        const Kokkos::View<size_t* [6]>::const_type& constraint_target_node_freedom_table,
         const Kokkos::View<Kokkos::pair<size_t, size_t>*>::const_type& constraint_row_range
     )
         : num_system_nodes(node_IDs.extent(0)),
@@ -522,12 +522,14 @@ public:
           )),
           T(CreateTMatrix(num_system_dofs, node_freedom_allocation_table, node_freedom_map_table)),
           B(CreateBMatrix(
-              num_system_dofs, num_constraint_dofs, constraint_type, constraint_base_node_index,
-              constraint_target_node_index, constraint_row_range
+              num_system_dofs, num_constraint_dofs, constraint_type,
+              constraint_base_node_freedom_table, constraint_target_node_freedom_table,
+              constraint_row_range
           )),
           B_t(CreateBtMatrix(
-              num_system_dofs, num_constraint_dofs, constraint_type, constraint_base_node_index,
-              constraint_target_node_index, constraint_row_range
+              num_system_dofs, num_constraint_dofs, constraint_type,
+              constraint_base_node_freedom_table, constraint_target_node_freedom_table,
+              constraint_row_range
           )),
           R("R", num_dofs),
           x("x", num_dofs) {

--- a/src/step/assemble_system_matrix.hpp
+++ b/src/step/assemble_system_matrix.hpp
@@ -16,18 +16,19 @@ namespace openturbine {
 inline void AssembleSystemMatrix(Solver& solver, Beams& beams) {
     auto region = Kokkos::Profiling::ScopedRegion("Assemble System Matrix");
 
-    const auto max_row_entries = 6U;
-    const auto row_data_size = Kokkos::View<double*>::shmem_size(max_row_entries);
-    const auto col_idx_size = Kokkos::View<int*>::shmem_size(max_row_entries);
+    const auto num_beam_dofs = 6U;
+    const auto row_data_size = Kokkos::View<double*>::shmem_size(num_beam_dofs);
+    const auto col_idx_size = Kokkos::View<int*>::shmem_size(num_beam_dofs);
     auto sparse_matrix_policy =
         Kokkos::TeamPolicy<>(static_cast<int>(beams.num_elems), Kokkos::AUTO());
 
     sparse_matrix_policy.set_scratch_size(1, Kokkos::PerThread(row_data_size + col_idx_size));
+    Kokkos::deep_copy(solver.K.values, 0.);
     Kokkos::parallel_for(
         "ContributeElementsToSparseMatrix", sparse_matrix_policy,
         ContributeElementsToSparseMatrix<Solver::CrsMatrixType>{
-            beams.num_nodes_per_element, beams.element_freedom_signature, beams.element_freedom_table, beams.stiffness_matrix_terms,
-            solver.K
+            beams.num_nodes_per_element, beams.element_freedom_signature,
+            beams.element_freedom_table, beams.stiffness_matrix_terms, solver.K
         }
     );
 
@@ -40,11 +41,12 @@ inline void AssembleSystemMatrix(Solver& solver, Beams& beams) {
         );
     }
 
+    Kokkos::deep_copy(solver.K.values, 0.);
     Kokkos::parallel_for(
         "ContributeElementsToSparseMatrix", sparse_matrix_policy,
         ContributeElementsToSparseMatrix<Solver::CrsMatrixType>{
-            beams.num_nodes_per_element, beams.element_freedom_signature, beams.element_freedom_table, beams.inertia_matrix_terms,
-            solver.K
+            beams.num_nodes_per_element, beams.element_freedom_signature,
+            beams.element_freedom_table, beams.inertia_matrix_terms, solver.K
         }
     );
 

--- a/src/step/assemble_system_residual.hpp
+++ b/src/step/assemble_system_residual.hpp
@@ -19,7 +19,7 @@ inline void AssembleSystemResidual(Solver& solver, Beams& beams) {
     Kokkos::parallel_for(
         "ContributeElementsToVector", vector_policy,
         ContributeElementsToVector{
-            beams.num_nodes_per_element, beams.node_state_indices, beams.residual_vector_terms,
+            beams.num_nodes_per_element, beams.element_freedom_table, beams.residual_vector_terms,
             solver.R
         }
     );

--- a/tests/regression_tests/external/test_rotor_aero_controller.cpp
+++ b/tests/regression_tests/external/test_rotor_aero_controller.cpp
@@ -16,6 +16,7 @@
 #include "src/beams/create_beams.hpp"
 #include "src/dof_management/assemble_node_freedom_allocation_table.hpp"
 #include "src/dof_management/compute_node_freedom_map_table.hpp"
+#include "src/dof_management/create_constraint_freedom_table.hpp"
 #include "src/dof_management/create_element_freedom_table.hpp"
 #include "src/model/model.hpp"
 #include "src/solver/solver.hpp"
@@ -417,10 +418,11 @@ TEST(Milestone, IEA15RotorAeroController) {
     assemble_node_freedom_allocation_table(state, beams, constraints);
     compute_node_freedom_map_table(state);
     create_element_freedom_table(beams, state);
+    create_constraint_freedom_table(constraints, state);
     auto solver = Solver(
         state.ID, state.node_freedom_allocation_table, state.node_freedom_map_table,
         beams.num_nodes_per_element, beams.node_state_indices, constraints.num_dofs,
-        constraints.type, constraints.base_node_index, constraints.target_node_index,
+        constraints.type, constraints.base_node_freedom_table, constraints.target_node_freedom_table,
         constraints.row_range
     );
 

--- a/tests/regression_tests/regression/test_cantilever_beam.cpp
+++ b/tests/regression_tests/regression/test_cantilever_beam.cpp
@@ -14,6 +14,7 @@
 #include "src/beams/create_beams.hpp"
 #include "src/dof_management/assemble_node_freedom_allocation_table.hpp"
 #include "src/dof_management/compute_node_freedom_map_table.hpp"
+#include "src/dof_management/create_constraint_freedom_table.hpp"
 #include "src/dof_management/create_element_freedom_table.hpp"
 #include "src/model/model.hpp"
 #include "src/solver/solver.hpp"
@@ -110,10 +111,11 @@ TEST(DynamicBeamTest, CantileverBeamSineLoad) {
     assemble_node_freedom_allocation_table(state, beams, constraints);
     compute_node_freedom_map_table(state);
     create_element_freedom_table(beams, state);
+    create_constraint_freedom_table(constraints, state);
     auto solver = Solver(
         state.ID, state.node_freedom_allocation_table, state.node_freedom_map_table,
         beams.num_nodes_per_element, beams.node_state_indices, constraints.num_dofs,
-        constraints.type, constraints.base_node_index, constraints.target_node_index,
+        constraints.type, constraints.base_node_freedom_table, constraints.target_node_freedom_table,
         constraints.row_range
     );
 

--- a/tests/regression_tests/regression/test_rotating_beam.cpp
+++ b/tests/regression_tests/regression/test_rotating_beam.cpp
@@ -19,6 +19,7 @@
 #include "src/beams/create_beams.hpp"
 #include "src/dof_management/assemble_node_freedom_allocation_table.hpp"
 #include "src/dof_management/compute_node_freedom_map_table.hpp"
+#include "src/dof_management/create_constraint_freedom_table.hpp"
 #include "src/dof_management/create_element_freedom_table.hpp"
 #include "src/model/model.hpp"
 #include "src/solver/solver.hpp"
@@ -158,10 +159,11 @@ TEST(RotatingBeamTest, StepConvergence) {
     assemble_node_freedom_allocation_table(state, beams, constraints);
     compute_node_freedom_map_table(state);
     create_element_freedom_table(beams, state);
+    create_constraint_freedom_table(constraints, state);
     auto solver = Solver(
         state.ID, state.node_freedom_allocation_table, state.node_freedom_map_table,
         beams.num_nodes_per_element, beams.node_state_indices, constraints.num_dofs,
-        constraints.type, constraints.base_node_index, constraints.target_node_index,
+        constraints.type, constraints.base_node_freedom_table, constraints.target_node_freedom_table,
         constraints.row_range
     );
 
@@ -266,10 +268,11 @@ inline void CreateTwoBeamSolverWithSameBeamsAndStep() {
     assemble_node_freedom_allocation_table(state, beams, constraints);
     compute_node_freedom_map_table(state);
     create_element_freedom_table(beams, state);
+    create_constraint_freedom_table(constraints, state);
     auto solver = Solver(
         state.ID, state.node_freedom_allocation_table, state.node_freedom_map_table,
         beams.num_nodes_per_element, beams.node_state_indices, constraints.num_dofs,
-        constraints.type, constraints.base_node_index, constraints.target_node_index,
+        constraints.type, constraints.base_node_freedom_table, constraints.target_node_freedom_table,
         constraints.row_range
     );
 
@@ -389,10 +392,11 @@ TEST(RotatingBeamTest, ThreeBladeRotor) {
     assemble_node_freedom_allocation_table(state, beams, constraints);
     compute_node_freedom_map_table(state);
     create_element_freedom_table(beams, state);
+    create_constraint_freedom_table(constraints, state);
     auto solver = Solver(
         state.ID, state.node_freedom_allocation_table, state.node_freedom_map_table,
         beams.num_nodes_per_element, beams.node_state_indices, constraints.num_dofs,
-        constraints.type, constraints.base_node_index, constraints.target_node_index,
+        constraints.type, constraints.base_node_freedom_table, constraints.target_node_freedom_table,
         constraints.row_range
     );
 
@@ -479,10 +483,11 @@ TEST(RotatingBeamTest, MasslessConstraints) {
     assemble_node_freedom_allocation_table(state, beams, constraints);
     compute_node_freedom_map_table(state);
     create_element_freedom_table(beams, state);
+    create_constraint_freedom_table(constraints, state);
     auto solver = Solver(
         state.ID, state.node_freedom_allocation_table, state.node_freedom_map_table,
         beams.num_nodes_per_element, beams.node_state_indices, constraints.num_dofs,
-        constraints.type, constraints.base_node_index, constraints.target_node_index,
+        constraints.type, constraints.base_node_freedom_table, constraints.target_node_freedom_table,
         constraints.row_range
     );
 
@@ -555,10 +560,11 @@ TEST(RotatingBeamTest, RotationControlConstraint) {
     assemble_node_freedom_allocation_table(state, beams, constraints);
     compute_node_freedom_map_table(state);
     create_element_freedom_table(beams, state);
+    create_constraint_freedom_table(constraints, state);
     auto solver = Solver(
         state.ID, state.node_freedom_allocation_table, state.node_freedom_map_table,
         beams.num_nodes_per_element, beams.node_state_indices, constraints.num_dofs,
-        constraints.type, constraints.base_node_index, constraints.target_node_index,
+        constraints.type, constraints.base_node_freedom_table, constraints.target_node_freedom_table,
         constraints.row_range
     );
 
@@ -635,10 +641,11 @@ TEST(RotatingBeamTest, CompoundRotationControlConstraint) {
     assemble_node_freedom_allocation_table(state, beams, constraints);
     compute_node_freedom_map_table(state);
     create_element_freedom_table(beams, state);
+    create_constraint_freedom_table(constraints, state);
     auto solver = Solver(
         state.ID, state.node_freedom_allocation_table, state.node_freedom_map_table,
         beams.num_nodes_per_element, beams.node_state_indices, constraints.num_dofs,
-        constraints.type, constraints.base_node_index, constraints.target_node_index,
+        constraints.type, constraints.base_node_freedom_table, constraints.target_node_freedom_table,
         constraints.row_range
     );
 
@@ -731,10 +738,11 @@ TEST(RotatingBeamTest, RevoluteJointConstraint) {
     assemble_node_freedom_allocation_table(state, beams, constraints);
     compute_node_freedom_map_table(state);
     create_element_freedom_table(beams, state);
+    create_constraint_freedom_table(constraints, state);
     auto solver = Solver(
         state.ID, state.node_freedom_allocation_table, state.node_freedom_map_table,
         beams.num_nodes_per_element, beams.node_state_indices, constraints.num_dofs,
-        constraints.type, constraints.base_node_index, constraints.target_node_index,
+        constraints.type, constraints.base_node_freedom_table, constraints.target_node_freedom_table,
         constraints.row_range
     );
 
@@ -853,10 +861,11 @@ void GeneratorTorqueWithAxisTilt(
     assemble_node_freedom_allocation_table(state, beams, constraints);
     compute_node_freedom_map_table(state);
     create_element_freedom_table(beams, state);
+    create_constraint_freedom_table(constraints, state);
     auto solver = Solver(
         state.ID, state.node_freedom_allocation_table, state.node_freedom_map_table,
         beams.num_nodes_per_element, beams.node_state_indices, constraints.num_dofs,
-        constraints.type, constraints.base_node_index, constraints.target_node_index,
+        constraints.type, constraints.base_node_freedom_table, constraints.target_node_freedom_table,
         constraints.row_range
     );
 

--- a/tests/regression_tests/regression/test_rotor.cpp
+++ b/tests/regression_tests/regression/test_rotor.cpp
@@ -16,6 +16,7 @@
 #include "src/beams/create_beams.hpp"
 #include "src/dof_management/assemble_node_freedom_allocation_table.hpp"
 #include "src/dof_management/compute_node_freedom_map_table.hpp"
+#include "src/dof_management/create_constraint_freedom_table.hpp"
 #include "src/dof_management/create_element_freedom_table.hpp"
 #include "src/model/model.hpp"
 #include "src/solver/solver.hpp"
@@ -153,10 +154,11 @@ TEST(RotorTest, IEA15Rotor) {
     assemble_node_freedom_allocation_table(state, beams, constraints);
     compute_node_freedom_map_table(state);
     create_element_freedom_table(beams, state);
+    create_constraint_freedom_table(constraints, state);
     auto solver = Solver(
         state.ID, state.node_freedom_allocation_table, state.node_freedom_map_table,
         beams.num_nodes_per_element, beams.node_state_indices, constraints.num_dofs,
-        constraints.type, constraints.base_node_index, constraints.target_node_index,
+        constraints.type, constraints.base_node_freedom_table, constraints.target_node_freedom_table,
         constraints.row_range
     );
 
@@ -312,10 +314,11 @@ TEST(RotorTest, IEA15RotorHub) {
     assemble_node_freedom_allocation_table(state, beams, constraints);
     compute_node_freedom_map_table(state);
     create_element_freedom_table(beams, state);
+    create_constraint_freedom_table(constraints, state);
     auto solver = Solver(
         state.ID, state.node_freedom_allocation_table, state.node_freedom_map_table,
         beams.num_nodes_per_element, beams.node_state_indices, constraints.num_dofs,
-        constraints.type, constraints.base_node_index, constraints.target_node_index,
+        constraints.type, constraints.base_node_freedom_table, constraints.target_node_freedom_table,
         constraints.row_range
     );
 
@@ -499,10 +502,11 @@ TEST(RotorTest, IEA15RotorController) {
     assemble_node_freedom_allocation_table(state, beams, constraints);
     compute_node_freedom_map_table(state);
     create_element_freedom_table(beams, state);
+    create_constraint_freedom_table(constraints, state);
     auto solver = Solver(
         state.ID, state.node_freedom_allocation_table, state.node_freedom_map_table,
         beams.num_nodes_per_element, beams.node_state_indices, constraints.num_dofs,
-        constraints.type, constraints.base_node_index, constraints.target_node_index,
+        constraints.type, constraints.base_node_freedom_table, constraints.target_node_freedom_table,
         constraints.row_range
     );
 

--- a/tests/regression_tests/regression/test_solver.cpp
+++ b/tests/regression_tests/regression/test_solver.cpp
@@ -12,6 +12,7 @@
 #include "src/beams/create_beams.hpp"
 #include "src/dof_management/assemble_node_freedom_allocation_table.hpp"
 #include "src/dof_management/compute_node_freedom_map_table.hpp"
+#include "src/dof_management/create_constraint_freedom_table.hpp"
 #include "src/dof_management/create_element_freedom_table.hpp"
 #include "src/model/model.hpp"
 #include "src/solver/solver.hpp"
@@ -117,10 +118,11 @@ inline void SetUpSolverAndAssemble() {
     assemble_node_freedom_allocation_table(state, beams, constraints);
     compute_node_freedom_map_table(state);
     create_element_freedom_table(beams, state);
+    create_constraint_freedom_table(constraints, state);
     auto solver = Solver(
         state.ID, state.node_freedom_allocation_table, state.node_freedom_map_table,
         beams.num_nodes_per_element, beams.node_state_indices, constraints.num_dofs,
-        constraints.type, constraints.base_node_index, constraints.target_node_index,
+        constraints.type, constraints.base_node_freedom_table, constraints.target_node_freedom_table,
         constraints.row_range
     );
 
@@ -358,10 +360,11 @@ inline void SetupAndTakeNoSteps() {
     assemble_node_freedom_allocation_table(state, beams, constraints);
     compute_node_freedom_map_table(state);
     create_element_freedom_table(beams, state);
+    create_constraint_freedom_table(constraints, state);
     auto solver = Solver(
         state.ID, state.node_freedom_allocation_table, state.node_freedom_map_table,
         beams.num_nodes_per_element, beams.node_state_indices, constraints.num_dofs,
-        constraints.type, constraints.base_node_index, constraints.target_node_index,
+        constraints.type, constraints.base_node_freedom_table, constraints.target_node_freedom_table,
         constraints.row_range
     );
 
@@ -570,10 +573,11 @@ inline auto SetupAndTakeTwoSteps() {
     assemble_node_freedom_allocation_table(state, beams, constraints);
     compute_node_freedom_map_table(state);
     create_element_freedom_table(beams, state);
+    create_constraint_freedom_table(constraints, state);
     auto solver = Solver(
         state.ID, state.node_freedom_allocation_table, state.node_freedom_map_table,
         beams.num_nodes_per_element, beams.node_state_indices, constraints.num_dofs,
-        constraints.type, constraints.base_node_index, constraints.target_node_index,
+        constraints.type, constraints.base_node_freedom_table, constraints.target_node_freedom_table,
         constraints.row_range
     );
 

--- a/tests/unit_tests/solver/test_populate_sparse_row_ptrs_col_inds_constraints.cpp
+++ b/tests/unit_tests/solver/test_populate_sparse_row_ptrs_col_inds_constraints.cpp
@@ -18,11 +18,14 @@ TEST(PopulateSparseRowPtrsColInds_Constraints, OneOfEach) {
         Kokkos::pair<size_t, size_t>{12U, 18U}, Kokkos::pair<size_t, size_t>{18U, 23U},
         Kokkos::pair<size_t, size_t>{23U, 29U}
     };
-    constexpr auto base_node_index_host_data =
-        std::array<size_t, num_constraints>{1U, 3U, 5U, 7U, 9U};
-    constexpr auto target_node_index_host_data =
-        std::array<size_t, num_constraints>{2U, 4U, 6U, 8U, 10U};
-
+    constexpr auto base_node_freedom_table_host_data =
+        std::array<size_t, num_constraints * 6>{6U,  7U,  8U,  9U,  10U, 11U, 18U, 19U, 20U, 21U,
+                                                22U, 23U, 30U, 31U, 32U, 33U, 34U, 35U, 42U, 43U,
+                                                44U, 45U, 46U, 47U, 54U, 55U, 56U, 57U, 58U, 59U};
+    constexpr auto target_node_freedom_table_host_data = 
+        std::array<size_t, num_constraints * 6>{12U, 13U, 14U, 15U, 16U, 17U, 24U, 25U, 26U, 27U,
+                                                28U, 29U, 36U, 37U, 38U, 39U, 40U, 41U, 48U, 49U,
+                                                50U, 51U, 52U, 53U, 60U, 61U, 62U, 63U, 64U, 65U};
     const auto type_host =
         Kokkos::View<const ConstraintType[num_constraints], Kokkos::HostSpace>(type_host_data.data()
         );
@@ -36,18 +39,25 @@ TEST(PopulateSparseRowPtrsColInds_Constraints, OneOfEach) {
     const auto row_range = Kokkos::View<Kokkos::pair<size_t, size_t>[num_constraints]>("row_range");
     Kokkos::deep_copy(row_range, row_range_host);
 
-    const auto base_node_index_host = Kokkos::View<const size_t[num_constraints], Kokkos::HostSpace>(
-        base_node_index_host_data.data()
-    );
-    const auto base_node_index = Kokkos::View<size_t[num_constraints]>("base_node_index");
-    Kokkos::deep_copy(base_node_index, base_node_index_host);
-
-    const auto target_node_index_host =
-        Kokkos::View<const size_t[num_constraints], Kokkos::HostSpace>(
-            target_node_index_host_data.data()
+    const auto base_node_freedom_table_host =
+        Kokkos::View<const size_t[num_constraints][6], Kokkos::HostSpace>(
+            base_node_freedom_table_host_data.data()
         );
-    const auto target_node_index = Kokkos::View<size_t[num_constraints]>("target_node_index");
-    Kokkos::deep_copy(target_node_index, target_node_index_host);
+    const auto base_node_freedom_table =
+        Kokkos::View<size_t[num_constraints][6]>("base_node_freedom_table");
+    const auto base_node_freedom_table_mirror = Kokkos::create_mirror(base_node_freedom_table);
+    Kokkos::deep_copy(base_node_freedom_table_mirror, base_node_freedom_table_host);
+    Kokkos::deep_copy(base_node_freedom_table, base_node_freedom_table_mirror);
+
+    const auto target_node_freedom_table_host =
+        Kokkos::View<const size_t[num_constraints][6], Kokkos::HostSpace>(
+            target_node_freedom_table_host_data.data()
+        );
+    const auto target_node_freedom_table =
+        Kokkos::View<size_t[num_constraints][6]>("target_node_freedom_table");
+    const auto target_node_freedom_table_mirror = Kokkos::create_mirror(target_node_freedom_table);
+    Kokkos::deep_copy(target_node_freedom_table_mirror, target_node_freedom_table_host);
+    Kokkos::deep_copy(target_node_freedom_table, target_node_freedom_table_mirror);
 
     const auto B_row_ptrs = Kokkos::View<size_t[num_constraint_dofs + 1U]>("B_row_ptrs");
     const auto B_col_inds = Kokkos::View<size_t[num_non_zero]>("B_col_inds");
@@ -55,7 +65,8 @@ TEST(PopulateSparseRowPtrsColInds_Constraints, OneOfEach) {
     Kokkos::parallel_for(
         "PopulateSparseRowPtrsColInds_Constraints", 1,
         PopulateSparseRowPtrsColInds_Constraints<Kokkos::View<size_t*>, Kokkos::View<size_t*>>{
-            type, base_node_index, target_node_index, row_range, B_row_ptrs, B_col_inds
+            type, base_node_freedom_table, target_node_freedom_table, row_range, B_row_ptrs,
+            B_col_inds
         }
     );
 

--- a/tests/unit_tests/solver/test_populate_sparse_row_ptrs_col_inds_constraints.cpp
+++ b/tests/unit_tests/solver/test_populate_sparse_row_ptrs_col_inds_constraints.cpp
@@ -8,6 +8,7 @@ namespace openturbine::tests {
 TEST(PopulateSparseRowPtrsColInds_Constraints, OneOfEach) {
     constexpr auto num_constraints = 5U;
     constexpr auto num_constraint_dofs = 29U;
+    constexpr auto num_node_dofs = 30U;
     constexpr auto num_non_zero = 288U;
     constexpr auto type_host_data = std::array{
         ConstraintType::kFixedBC, ConstraintType::kPrescribedBC, ConstraintType::kRigidJoint,
@@ -19,13 +20,13 @@ TEST(PopulateSparseRowPtrsColInds_Constraints, OneOfEach) {
         Kokkos::pair<size_t, size_t>{23U, 29U}
     };
     constexpr auto base_node_freedom_table_host_data =
-        std::array<size_t, num_constraints * 6>{6U,  7U,  8U,  9U,  10U, 11U, 18U, 19U, 20U, 21U,
-                                                22U, 23U, 30U, 31U, 32U, 33U, 34U, 35U, 42U, 43U,
-                                                44U, 45U, 46U, 47U, 54U, 55U, 56U, 57U, 58U, 59U};
-    constexpr auto target_node_freedom_table_host_data = 
-        std::array<size_t, num_constraints * 6>{12U, 13U, 14U, 15U, 16U, 17U, 24U, 25U, 26U, 27U,
-                                                28U, 29U, 36U, 37U, 38U, 39U, 40U, 41U, 48U, 49U,
-                                                50U, 51U, 52U, 53U, 60U, 61U, 62U, 63U, 64U, 65U};
+        std::array<size_t, num_node_dofs>{6U,  7U,  8U,  9U,  10U, 11U, 18U, 19U, 20U, 21U,
+                                          22U, 23U, 30U, 31U, 32U, 33U, 34U, 35U, 42U, 43U,
+                                          44U, 45U, 46U, 47U, 54U, 55U, 56U, 57U, 58U, 59U};
+    constexpr auto target_node_freedom_table_host_data =
+        std::array<size_t, num_node_dofs>{12U, 13U, 14U, 15U, 16U, 17U, 24U, 25U, 26U, 27U,
+                                          28U, 29U, 36U, 37U, 38U, 39U, 40U, 41U, 48U, 49U,
+                                          50U, 51U, 52U, 53U, 60U, 61U, 62U, 63U, 64U, 65U};
     const auto type_host =
         Kokkos::View<const ConstraintType[num_constraints], Kokkos::HostSpace>(type_host_data.data()
         );


### PR DESCRIPTION
This PR changes the tangent operator, system residual vector, and system matrix assembly functions to use the new DoF mappings defined on State and Beams.  It also modifies the system assembly to allow nodes to be shared by multiple beams (thus allowing, for example, multiple beam elements per turbine blade).

It also changes the construction of the constraints sparse matrix to use the new DoF mappings, adding an equivalent of the element freedom table to constraints.  