### PR TITLE
Performance Tweaks to ContributeElementsToSparseMatrix

### DIFF
--- a/src/solver/contribute_elements_to_sparse_matrix.hpp
+++ b/src/solver/contribute_elements_to_sparse_matrix.hpp
@@ -20,21 +20,24 @@ struct ContributeElementsToSparseMatrix {
     void operator()(Kokkos::TeamPolicy<>::member_type member) const {
         const auto i = member.league_rank();
         const auto num_nodes = num_nodes_per_element(i);
-        constexpr auto is_sorted = false;
-        constexpr auto force_atomic = true;
+        constexpr auto is_sorted = true;
+        constexpr auto force_atomic =
+            !std::is_same_v<Kokkos::TeamPolicy<>::member_type::execution_space, Kokkos::Serial>;
         Kokkos::parallel_for(Kokkos::TeamThreadRange(member, num_nodes), [&](size_t node_1) {
             const auto num_dofs = count_active_dofs(element_freedom_signature(i, node_1));
-            auto row_map = sparse.graph.row_map;
-            auto cols = sparse.graph.entries;
-            auto row_data = RowDataType(member.thread_scratch(1), num_dofs);
-            auto col_idx = ColIdxType(member.thread_scratch(1), num_dofs);
+            auto row_data_data = Kokkos::Array<typename RowDataType::value_type, 6>{};
+            auto col_idx_data = Kokkos::Array<typename ColIdxType::value_type, 6>{};
+            auto row_data = RowDataType(row_data_data.data(), num_dofs);
+            auto col_idx = ColIdxType(col_idx_data.data(), num_dofs);
 
             for (auto node_2 = 0U; node_2 < num_nodes; ++node_2) {
+                for (auto component_2 = 0U; component_2 < num_dofs; ++component_2) {
+                    col_idx(component_2) =
+                        static_cast<int>(element_freedom_table(i, node_2, component_2));
+                }
                 for (auto component_1 = 0U; component_1 < num_dofs; ++component_1) {
                     const auto row_num = element_freedom_table(i, node_1, component_1);
                     for (auto component_2 = 0U; component_2 < num_dofs; ++component_2) {
-                        col_idx(component_2) =
-                            static_cast<int>(element_freedom_table(i, node_2, component_2));
                         row_data(component_2) = dense(i, node_1, node_2, component_1, component_2);
                     }
                     sparse.sumIntoValues(

--- a/src/step/assemble_system_matrix.hpp
+++ b/src/step/assemble_system_matrix.hpp
@@ -16,13 +16,9 @@ namespace openturbine {
 inline void AssembleSystemMatrix(Solver& solver, Beams& beams) {
     auto region = Kokkos::Profiling::ScopedRegion("Assemble System Matrix");
 
-    const auto num_beam_dofs = 6U;
-    const auto row_data_size = Kokkos::View<double*>::shmem_size(num_beam_dofs);
-    const auto col_idx_size = Kokkos::View<int*>::shmem_size(num_beam_dofs);
     auto sparse_matrix_policy =
         Kokkos::TeamPolicy<>(static_cast<int>(beams.num_elems), Kokkos::AUTO());
 
-    sparse_matrix_policy.set_scratch_size(1, Kokkos::PerThread(row_data_size + col_idx_size));
     Kokkos::deep_copy(solver.K.values, 0.);
     Kokkos::parallel_for(
         "ContributeElementsToSparseMatrix", sparse_matrix_policy,

--- a/tests/unit_tests/state/test_update_dynamic_prediction.cpp
+++ b/tests/unit_tests/state/test_update_dynamic_prediction.cpp
@@ -22,7 +22,7 @@ TEST(UpdateDynamicPrediction, OneNode) {
     constexpr auto gamma_prime = 3.;
 
     constexpr auto node_freedom_allocation_table_host_data =
-        std::array{FreedomSignature::AllComponents};
+        std::array<FreedomSignature, 1>{FreedomSignature::AllComponents};
     const auto node_freedom_allocation_table_host =
         Kokkos::View<FreedomSignature[1], Kokkos::HostSpace>::const_type(
             node_freedom_allocation_table_host_data.data()
@@ -33,7 +33,7 @@ TEST(UpdateDynamicPrediction, OneNode) {
     Kokkos::deep_copy(node_freedom_allocation_table_mirror, node_freedom_allocation_table_host);
     Kokkos::deep_copy(node_freedom_allocation_table, node_freedom_allocation_table_mirror);
 
-    constexpr auto node_freedom_map_table_host_data = std::array{0UL};
+    constexpr auto node_freedom_map_table_host_data = std::array<size_t, 1>{0UL};
     const auto node_freedom_map_table_host = Kokkos::View<size_t[1], Kokkos::HostSpace>::const_type(
         node_freedom_map_table_host_data.data()
     );


### PR DESCRIPTION
Several tweaks, but the end result is that this algorithm is now just as fast as before instead of a 133% slowdown on CPU.  

Added a check to not use atomics when in a serial build.  Improves speed by 3s out of 45s on benchmark

Assume components are in sorted order.  Improves speed by an additional 1s

Move col_idx population to its own loop.  Another 1s or so improvement.

Uses local scratch memory instead of heap memory pool.  No performance change, but removes need to set up memory pool

Fixed some compiler warnings when building for CUDA