### PR TITLE
Add utilities for copying the State data structure

### DIFF
--- a/src/state/clone_state.hpp
+++ b/src/state/clone_state.hpp
@@ -1,0 +1,24 @@
+#pragma once
+
+#include "state.hpp"
+
+namespace openturbine {
+
+inline State CloneState(const State& old) {
+    auto clone = State(old.num_system_nodes);
+    Kokkos::deep_copy(clone.ID, old.ID);
+    Kokkos::deep_copy(clone.node_freedom_allocation_table, old.node_freedom_allocation_table);
+    Kokkos::deep_copy(clone.node_freedom_map_table, old.node_freedom_map_table);
+    Kokkos::deep_copy(clone.x0, old.x0);
+    Kokkos::deep_copy(clone.x, old.x);
+    Kokkos::deep_copy(clone.q_delta, old.q_delta);
+    Kokkos::deep_copy(clone.q_prev, old.q_prev);
+    Kokkos::deep_copy(clone.q, old.q);
+    Kokkos::deep_copy(clone.v, old.v);
+    Kokkos::deep_copy(clone.vd, old.vd);
+    Kokkos::deep_copy(clone.a, old.a);
+    Kokkos::deep_copy(clone.tangent, old.tangent);
+    return clone;
+}
+
+}  // namespace openturbine

--- a/src/state/copy_state_data.hpp
+++ b/src/state/copy_state_data.hpp
@@ -1,0 +1,18 @@
+#pragma once
+
+#include "state.hpp"
+
+namespace openturbine {
+
+inline void CopyStateData(State& copy, const State& old) {
+    Kokkos::deep_copy(copy.x, old.x);
+    Kokkos::deep_copy(copy.q_delta, old.q_delta);
+    Kokkos::deep_copy(copy.q_prev, old.q_prev);
+    Kokkos::deep_copy(copy.q, old.q);
+    Kokkos::deep_copy(copy.v, old.v);
+    Kokkos::deep_copy(copy.vd, old.vd);
+    Kokkos::deep_copy(copy.a, old.a);
+    Kokkos::deep_copy(copy.tangent, old.tangent);
+}
+
+}  // namespace openturbine

--- a/tests/unit_tests/state/CMakeLists.txt
+++ b/tests/unit_tests/state/CMakeLists.txt
@@ -5,6 +5,7 @@ target_sources(
     test_calculate_next_state.cpp
     test_calculate_displacement.cpp
     test_clone_state.cpp
+    test_copy_state_data.cpp
     test_update_algorithmic_acceleration.cpp
     test_update_dynamic_prediction.cpp
     test_update_global_position.cpp

--- a/tests/unit_tests/state/CMakeLists.txt
+++ b/tests/unit_tests/state/CMakeLists.txt
@@ -4,6 +4,7 @@ target_sources(
     PRIVATE
     test_calculate_next_state.cpp
     test_calculate_displacement.cpp
+    test_clone_state.cpp
     test_update_algorithmic_acceleration.cpp
     test_update_dynamic_prediction.cpp
     test_update_global_position.cpp

--- a/tests/unit_tests/state/test_clone_state.cpp
+++ b/tests/unit_tests/state/test_clone_state.cpp
@@ -4,8 +4,10 @@
 #include "src/state/clone_state.hpp"
 #include "src/state/state.hpp"
 
+namespace {
+
 template <typename T>
-static void Compare(const T& field_1, const T& field_2) {
+void Compare(const T& field_1, const T& field_2) {
     const auto mirror_1 = Kokkos::create_mirror(field_1);
     Kokkos::deep_copy(mirror_1, field_1);
     const auto mirror_2 = Kokkos::create_mirror(field_2);
@@ -32,7 +34,7 @@ static void Compare(const T& field_1, const T& field_2) {
     }
 }
 
-static void CompareStates(const openturbine::State& state_1, const openturbine::State& state_2) {
+void CompareStates(const openturbine::State& state_1, const openturbine::State& state_2) {
     EXPECT_EQ(state_1.num_system_nodes, state_2.num_system_nodes);
     Compare(state_1.ID, state_2.ID);
     Compare(state_1.node_freedom_allocation_table, state_2.node_freedom_allocation_table);
@@ -48,7 +50,7 @@ static void CompareStates(const openturbine::State& state_1, const openturbine::
     Compare(state_1.tangent, state_2.tangent);
 }
 
-static openturbine::State CreateTestState() {
+openturbine::State CreateTestState() {
     constexpr auto num_system_nodes = 2UL;
     auto state = openturbine::State(num_system_nodes);
     Kokkos::deep_copy(state.ID, 1UL);
@@ -67,6 +69,8 @@ static openturbine::State CreateTestState() {
     Kokkos::deep_copy(state.tangent, 12.);
     return state;
 }
+
+}  // namespace
 
 namespace openturbine::tests {
 

--- a/tests/unit_tests/state/test_clone_state.cpp
+++ b/tests/unit_tests/state/test_clone_state.cpp
@@ -1,0 +1,80 @@
+#include <Kokkos_Core.hpp>
+#include <gtest/gtest.h>
+
+#include "src/state/clone_state.hpp"
+#include "src/state/state.hpp"
+
+template <typename T>
+static void Compare(const T& field_1, const T& field_2) {
+    const auto mirror_1 = Kokkos::create_mirror(field_1);
+    Kokkos::deep_copy(mirror_1, field_1);
+    const auto mirror_2 = Kokkos::create_mirror(field_2);
+    Kokkos::deep_copy(mirror_2, field_2);
+
+    if constexpr (T::rank() == 1) {
+        for (auto i = 0U; i < field_1.extent(0); ++i) {
+            EXPECT_EQ(mirror_1(i), mirror_2(i));
+        }
+    } else if constexpr (T::rank() == 2) {
+        for (auto i = 0U; i < field_1.extent(0); ++i) {
+            for (auto j = 0U; j < field_1.extent(1); ++j) {
+                EXPECT_EQ(mirror_1(i, j), mirror_2(i, j));
+            }
+        }
+    } else if constexpr (T::rank() == 3) {
+        for (auto i = 0U; i < field_1.extent(0); ++i) {
+            for (auto j = 0U; j < field_1.extent(1); ++j) {
+                for (auto k = 0U; k < field_1.extent(2); ++k) {
+                    EXPECT_EQ(mirror_1(i, j, k), mirror_2(i, j, k));
+                }
+            }
+        }
+    }
+}
+
+static void CompareStates(const openturbine::State& state_1, const openturbine::State& state_2) {
+    EXPECT_EQ(state_1.num_system_nodes, state_2.num_system_nodes);
+    Compare(state_1.ID, state_2.ID);
+    Compare(state_1.node_freedom_allocation_table, state_2.node_freedom_allocation_table);
+    Compare(state_1.node_freedom_map_table, state_2.node_freedom_map_table);
+    Compare(state_1.x0, state_2.x0);
+    Compare(state_1.x, state_2.x);
+    Compare(state_1.q_delta, state_2.q_delta);
+    Compare(state_1.q_prev, state_2.q_prev);
+    Compare(state_1.q, state_2.q);
+    Compare(state_1.v, state_2.v);
+    Compare(state_1.vd, state_2.vd);
+    Compare(state_1.a, state_2.a);
+    Compare(state_1.tangent, state_2.tangent);
+}
+
+static openturbine::State CreateTestState() {
+    constexpr auto num_system_nodes = 2UL;
+    auto state = openturbine::State(num_system_nodes);
+    Kokkos::deep_copy(state.ID, 1UL);
+    Kokkos::deep_copy(
+        state.node_freedom_allocation_table, openturbine::FreedomSignature::AllComponents
+    );
+    Kokkos::deep_copy(state.node_freedom_map_table, 3UL);
+    Kokkos::deep_copy(state.x0, 4.);
+    Kokkos::deep_copy(state.x, 5.);
+    Kokkos::deep_copy(state.q_delta, 6.);
+    Kokkos::deep_copy(state.q_prev, 7.);
+    Kokkos::deep_copy(state.q, 8.);
+    Kokkos::deep_copy(state.v, 9.);
+    Kokkos::deep_copy(state.vd, 10.);
+    Kokkos::deep_copy(state.a, 11.);
+    Kokkos::deep_copy(state.tangent, 12.);
+    return state;
+}
+
+namespace openturbine::tests {
+
+TEST(CloneState, CloneState) {
+    auto state_1 = CreateTestState();
+    auto state_2 = CloneState(state_1);
+
+    CompareStates(state_1, state_2);
+}
+
+}  // namespace openturbine::tests

--- a/tests/unit_tests/state/test_copy_state_data.cpp
+++ b/tests/unit_tests/state/test_copy_state_data.cpp
@@ -5,8 +5,10 @@
 #include "src/state/copy_state_data.hpp"
 #include "src/state/state.hpp"
 
+namespace {
+
 template <typename T>
-static void Compare(const T& field_1, const T& field_2) {
+void Compare(const T& field_1, const T& field_2) {
     const auto mirror_1 = Kokkos::create_mirror(field_1);
     Kokkos::deep_copy(mirror_1, field_1);
     const auto mirror_2 = Kokkos::create_mirror(field_2);
@@ -33,7 +35,7 @@ static void Compare(const T& field_1, const T& field_2) {
     }
 }
 
-static void CompareStates(const openturbine::State& state_1, const openturbine::State& state_2) {
+void CompareStates(const openturbine::State& state_1, const openturbine::State& state_2) {
     EXPECT_EQ(state_1.num_system_nodes, state_2.num_system_nodes);
     Compare(state_1.ID, state_2.ID);
     Compare(state_1.node_freedom_allocation_table, state_2.node_freedom_allocation_table);
@@ -49,7 +51,7 @@ static void CompareStates(const openturbine::State& state_1, const openturbine::
     Compare(state_1.tangent, state_2.tangent);
 }
 
-static openturbine::State CreateTestState() {
+openturbine::State CreateTestState() {
     constexpr auto num_system_nodes = 2UL;
     auto state = openturbine::State(num_system_nodes);
     Kokkos::deep_copy(state.ID, 1UL);
@@ -69,7 +71,7 @@ static openturbine::State CreateTestState() {
     return state;
 }
 
-static void ModifyTestState(openturbine::State& state) {
+void ModifyTestState(openturbine::State& state) {
     Kokkos::deep_copy(state.x, 20.);
     Kokkos::deep_copy(state.q_delta, 21.);
     Kokkos::deep_copy(state.q_prev, 22.);
@@ -79,6 +81,8 @@ static void ModifyTestState(openturbine::State& state) {
     Kokkos::deep_copy(state.a, 26.);
     Kokkos::deep_copy(state.tangent, 27.);
 }
+
+}  // namespace
 
 namespace openturbine::tests {
 

--- a/tests/unit_tests/state/test_copy_state_data.cpp
+++ b/tests/unit_tests/state/test_copy_state_data.cpp
@@ -1,0 +1,98 @@
+#include <Kokkos_Core.hpp>
+#include <gtest/gtest.h>
+
+#include "src/state/clone_state.hpp"
+#include "src/state/copy_state_data.hpp"
+#include "src/state/state.hpp"
+
+template <typename T>
+static void Compare(const T& field_1, const T& field_2) {
+    const auto mirror_1 = Kokkos::create_mirror(field_1);
+    Kokkos::deep_copy(mirror_1, field_1);
+    const auto mirror_2 = Kokkos::create_mirror(field_2);
+    Kokkos::deep_copy(mirror_2, field_2);
+
+    if constexpr (T::rank() == 1) {
+        for (auto i = 0U; i < field_1.extent(0); ++i) {
+            EXPECT_EQ(mirror_1(i), mirror_2(i));
+        }
+    } else if constexpr (T::rank() == 2) {
+        for (auto i = 0U; i < field_1.extent(0); ++i) {
+            for (auto j = 0U; j < field_1.extent(1); ++j) {
+                EXPECT_EQ(mirror_1(i, j), mirror_2(i, j));
+            }
+        }
+    } else if constexpr (T::rank() == 3) {
+        for (auto i = 0U; i < field_1.extent(0); ++i) {
+            for (auto j = 0U; j < field_1.extent(1); ++j) {
+                for (auto k = 0U; k < field_1.extent(2); ++k) {
+                    EXPECT_EQ(mirror_1(i, j, k), mirror_2(i, j, k));
+                }
+            }
+        }
+    }
+}
+
+static void CompareStates(const openturbine::State& state_1, const openturbine::State& state_2) {
+    EXPECT_EQ(state_1.num_system_nodes, state_2.num_system_nodes);
+    Compare(state_1.ID, state_2.ID);
+    Compare(state_1.node_freedom_allocation_table, state_2.node_freedom_allocation_table);
+    Compare(state_1.node_freedom_map_table, state_2.node_freedom_map_table);
+    Compare(state_1.x0, state_2.x0);
+    Compare(state_1.x, state_2.x);
+    Compare(state_1.q_delta, state_2.q_delta);
+    Compare(state_1.q_prev, state_2.q_prev);
+    Compare(state_1.q, state_2.q);
+    Compare(state_1.v, state_2.v);
+    Compare(state_1.vd, state_2.vd);
+    Compare(state_1.a, state_2.a);
+    Compare(state_1.tangent, state_2.tangent);
+}
+
+static openturbine::State CreateTestState() {
+    constexpr auto num_system_nodes = 2UL;
+    auto state = openturbine::State(num_system_nodes);
+    Kokkos::deep_copy(state.ID, 1UL);
+    Kokkos::deep_copy(
+        state.node_freedom_allocation_table, openturbine::FreedomSignature::AllComponents
+    );
+    Kokkos::deep_copy(state.node_freedom_map_table, 3UL);
+    Kokkos::deep_copy(state.x0, 4.);
+    Kokkos::deep_copy(state.x, 5.);
+    Kokkos::deep_copy(state.q_delta, 6.);
+    Kokkos::deep_copy(state.q_prev, 7.);
+    Kokkos::deep_copy(state.q, 8.);
+    Kokkos::deep_copy(state.v, 9.);
+    Kokkos::deep_copy(state.vd, 10.);
+    Kokkos::deep_copy(state.a, 11.);
+    Kokkos::deep_copy(state.tangent, 12.);
+    return state;
+}
+
+static void ModifyTestState(openturbine::State& state) {
+    Kokkos::deep_copy(state.x, 20.);
+    Kokkos::deep_copy(state.q_delta, 21.);
+    Kokkos::deep_copy(state.q_prev, 22.);
+    Kokkos::deep_copy(state.q, 23.);
+    Kokkos::deep_copy(state.v, 24.);
+    Kokkos::deep_copy(state.vd, 25.);
+    Kokkos::deep_copy(state.a, 26.);
+    Kokkos::deep_copy(state.tangent, 27.);
+}
+
+namespace openturbine::tests {
+
+TEST(CopyStateData, CopyStateData) {
+    auto state_1 = CreateTestState();
+    auto state_2 = CloneState(state_1);
+
+    CompareStates(state_1, state_2);
+
+    ModifyTestState(state_1);
+
+    CopyStateData(state_2, state_1);
+
+    CompareStates(state_1, state_2);
+}
+
+}  // namespace openturbine::tests


### PR DESCRIPTION
This PR adds two new utility functions: CloneState and CopyStateData.

CloneState allocates memory for a new state and copies all data from an existing one.  This should be used in problem initialization and results in a fully usable clone of the existing state (i.e. `auto archive_state = CloneState(current_state)`.  

CopyStateData does not allocate memory and only copies that data which will change over the course of a time step.  Data which will not change during a time step is not copied as a performance optimization.  This should be used during time stepping when a state wants to be saved (i.e. `CopyStateData(archive_state, current_state)`) or restored (i.e. `CopyStateData(current_state, archive_state)`).