### PR TITLE
Added CreateSystem and CreateSystemWithSolver methods to model.

### DIFF
--- a/src/model/model.hpp
+++ b/src/model/model.hpp
@@ -29,6 +29,29 @@ namespace openturbine {
 /// Represents an invalid node in constraints that only uses the target node
 static const size_t InvalidNodeID(0U);
 
+/// @brief Compute freedom tables for state, elements, and constraints, then construct and return
+/// solver.
+[[nodiscard]] inline Solver CreateSolver(
+    State& state, Elements& elements, Constraints& constraints
+) {
+    assemble_node_freedom_allocation_table(state, elements, constraints);
+    compute_node_freedom_map_table(state);
+    create_element_freedom_table(elements, state);
+    create_constraint_freedom_table(constraints, state);
+    return {
+        state.ID,
+        state.node_freedom_allocation_table,
+        state.node_freedom_map_table,
+        elements.NumberOfNodesPerElement(),
+        elements.NodeStateIndices(),
+        constraints.num_dofs,
+        constraints.type,
+        constraints.base_node_freedom_table,
+        constraints.target_node_freedom_table,
+        constraints.row_range
+    };
+}
+
 /**
  * @brief Struct to define a turbine model with nodes, elements, and constraints
  *
@@ -120,10 +143,12 @@ public:
     [[nodiscard]] size_t NumBeamElements() const { return this->beam_elements_.size(); }
 
     /// Returns initialized BeamsInput struct
-    [[nodiscard]] BeamsInput CreateBeamsInput() { return {this->beam_elements_, this->gravity_}; }
+    [[nodiscard]] BeamsInput CreateBeamsInput() const {
+        return {this->beam_elements_, this->gravity_};
+    }
 
     /// Returns Beams struct initialized with beams
-    [[nodiscard]] Beams CreateBeams() {
+    [[nodiscard]] Beams CreateBeams() const {
         return openturbine::CreateBeams(this->CreateBeamsInput(), this->nodes_);
     }
 
@@ -155,7 +180,7 @@ public:
     [[nodiscard]] size_t NumMassElements() const { return this->mass_elements_.size(); }
 
     /// Returns Masses struct initialized from mass elements
-    [[nodiscard]] Masses CreateMasses() {
+    [[nodiscard]] Masses CreateMasses() const {
         return openturbine::CreateMasses(
             MassesInput(this->mass_elements_, this->gravity_), this->nodes_
         );
@@ -189,7 +214,7 @@ public:
     [[nodiscard]] size_t NumSpringElements() const { return this->spring_elements_.size(); }
 
     /// Returns Springs struct initialized from spring elements
-    [[nodiscard]] Springs CreateSprings() {
+    [[nodiscard]] Springs CreateSprings() const {
         return openturbine::CreateSprings(SpringsInput(this->spring_elements_), this->nodes_);
     }
 
@@ -198,7 +223,7 @@ public:
     //--------------------------------------------------------------------------
 
     /// Returns Elements struct initialized with elements
-    [[nodiscard]] Elements CreateElements() {
+    [[nodiscard]] Elements CreateElements() const {
         return Elements{
             this->CreateBeams(),
             this->CreateMasses(),
@@ -280,6 +305,18 @@ public:
         return Constraints(this->constraints_, this->nodes_);
     }
 
+    // Returns a State, Elements, and Constraints object initialized from the model
+    [[nodiscard]] std::tuple<State, Elements, Constraints> CreateSystem() const {
+        return {this->CreateState(), this->CreateElements(), this->CreateConstraints()};
+    }
+
+    // Returns a State, Elements, Constraints, and Solver object initialized from the model
+    [[nodiscard]] std::tuple<State, Elements, Constraints, Solver> CreateSystemWithSolver() const {
+        auto [state, elements, constraints] = this->CreateSystem();
+        auto solver = CreateSolver(state, elements, constraints);
+        return {state, elements, constraints, solver};
+    }
+
 private:
     Array_3 gravity_ = {0., 0., 0.};              //< Gravity components
     std::vector<Node> nodes_;                     //< Nodes in the model
@@ -288,28 +325,5 @@ private:
     std::vector<SpringElement> spring_elements_;  //< Spring elements in the model
     std::vector<Constraint> constraints_;         //< Constraints in the model
 };
-
-/// @brief Compute freedom tables for state, elements, and constraints, then construct and return
-/// solver.
-[[nodiscard]] inline Solver CreateSolver(
-    State& state, Elements& elements, Constraints& constraints
-) {
-    assemble_node_freedom_allocation_table(state, elements, constraints);
-    compute_node_freedom_map_table(state);
-    create_element_freedom_table(elements, state);
-    create_constraint_freedom_table(constraints, state);
-    return {
-        state.ID,
-        state.node_freedom_allocation_table,
-        state.node_freedom_map_table,
-        elements.NumberOfNodesPerElement(),
-        elements.NodeStateIndices(),
-        constraints.num_dofs,
-        constraints.type,
-        constraints.base_node_freedom_table,
-        constraints.target_node_freedom_table,
-        constraints.row_range
-    };
-}
 
 }  // namespace openturbine

--- a/tests/regression_tests/external/test_rotor_aero_controller.cpp
+++ b/tests/regression_tests/external/test_rotor_aero_controller.cpp
@@ -389,10 +389,7 @@ TEST(Milestone, IEA15RotorAeroController) {
     auto parameters = StepParameters(is_dynamic_solve, max_iter, step_size, rho_inf);
 
     // Create solver, elements, constraints, and state
-    auto state = model.CreateState();
-    auto elements = model.CreateElements();
-    auto constraints = model.CreateConstraints();
-    auto solver = CreateSolver(state, elements, constraints);
+    auto [state, elements, constraints, solver] = model.CreateSystemWithSolver();
 
     // Transfer initial state to beams for writing output
     UpdateSystemVariables(parameters, elements, state);

--- a/tests/regression_tests/regression/test_cantilever_beam.cpp
+++ b/tests/regression_tests/regression/test_cantilever_beam.cpp
@@ -104,9 +104,7 @@ TEST(DynamicBeamTest, CantileverBeamSineLoad) {
     auto parameters = StepParameters(is_dynamic_solve, max_iter, step_size, rho_inf);
 
     // Create solver, elements, constraints, and state
-    auto state = model.CreateState();
-    auto elements = model.CreateElements();
-    auto constraints = model.CreateConstraints();
+    auto [state, elements, constraints] = model.CreateSystem();
     auto solver = CreateSolver(state, elements, constraints);
 
     // Get ID of last node

--- a/tests/regression_tests/regression/test_precession.cpp
+++ b/tests/regression_tests/regression/test_precession.cpp
@@ -47,10 +47,7 @@ inline auto SetUpPrecessionTest() {
     auto parameters = StepParameters(is_dynamic_solve, max_iter, step_size, rho_inf);
 
     // Create solver, elements, constraints, and state
-    auto state = model.CreateState();
-    auto elements = model.CreateElements();
-    auto constraints = model.CreateConstraints();
-    auto solver = CreateSolver(state, elements, constraints);
+    auto [state, elements, constraints, solver] = model.CreateSystemWithSolver();
 
     // Run simulation for 500 steps
     for (size_t i = 0; i < 500; ++i) {

--- a/tests/regression_tests/regression/test_rotating_beam.cpp
+++ b/tests/regression_tests/regression/test_rotating_beam.cpp
@@ -129,9 +129,7 @@ TEST(RotatingBeamTest, StepConvergence) {
     model.AddPrescribedBC(node_ids[0]);
 
     // Create solver, elements, constraints, and state
-    auto state = model.CreateState();
-    auto elements = model.CreateElements();
-    auto constraints = model.CreateConstraints();
+    auto [state, elements, constraints] = model.CreateSystem();
     auto solver = CreateSolver(state, elements, constraints);
 
     // Create solver parameters
@@ -231,9 +229,7 @@ inline void CreateTwoBeamSolverWithSameBeamsAndStep() {
     auto parameters = StepParameters(is_dynamic_solve, max_iter, step_size, rho_inf);
 
     // Create solver, elements, constraints, and state
-    auto state = model.CreateState();
-    auto elements = model.CreateElements();
-    auto constraints = model.CreateConstraints();
+    auto [state, elements, constraints] = model.CreateSystem();
     auto solver = CreateSolver(state, elements, constraints);
 
     // Calculate hub rotation for this time step
@@ -331,9 +327,7 @@ TEST(RotatingBeamTest, ThreeBladeRotor) {
     auto parameters = StepParameters(is_dynamic_solve, max_iter, step_size, rho_inf);
 
     // Create solver, elements, constraints, and state
-    auto state = model.CreateState();
-    auto elements = model.CreateElements();
-    auto constraints = model.CreateConstraints();
+    auto [state, elements, constraints] = model.CreateSystem();
     auto solver = CreateSolver(state, elements, constraints);
 
     // Perform time steps and check for convergence within max_iter iterations
@@ -399,9 +393,7 @@ TEST(RotatingBeamTest, MasslessConstraints) {
     auto parameters = StepParameters(is_dynamic_solve, max_iter, step_size, rho_inf);
 
     // Create solver, elements, constraints, and state
-    auto state = model.CreateState();
-    auto elements = model.CreateElements();
-    auto constraints = model.CreateConstraints();
+    auto [state, elements, constraints] = model.CreateSystem();
     auto solver = CreateSolver(state, elements, constraints);
 
     // Perform 10 time steps and check for convergence within max_iter iterations
@@ -468,9 +460,7 @@ TEST(RotatingBeamTest, RotationControlConstraint) {
     auto parameters = StepParameters(is_dynamic_solve, max_iter, step_size, rho_inf);
 
     // Create solver, elements, constraints, and state
-    auto state = model.CreateState();
-    auto elements = model.CreateElements();
-    auto constraints = model.CreateConstraints();
+    auto [state, elements, constraints] = model.CreateSystem();
     auto solver = CreateSolver(state, elements, constraints);
 
     // Perform 10 time steps and check for convergence within max_iter iterations
@@ -541,9 +531,7 @@ TEST(RotatingBeamTest, CompoundRotationControlConstraint) {
     auto parameters = StepParameters(is_dynamic_solve, max_iter, step_size, rho_inf);
 
     // Create solver, elements, constraints, and state
-    auto state = model.CreateState();
-    auto elements = model.CreateElements();
-    auto constraints = model.CreateConstraints();
+    auto [state, elements, constraints] = model.CreateSystem();
     auto solver = CreateSolver(state, elements, constraints);
 
     double azimuth = 0.;
@@ -616,9 +604,7 @@ TEST(RotatingBeamTest, RevoluteJointConstraint) {
     auto parameters = StepParameters(is_dynamic_solve, max_iter, step_size, rho_inf);
 
     // Create solver, elements, constraints, and state
-    auto state = model.CreateState();
-    auto elements = model.CreateElements();
-    auto constraints = model.CreateConstraints();
+    auto [state, elements, constraints] = model.CreateSystem();
     auto solver = CreateSolver(state, elements, constraints);
 
 #ifdef OpenTurbine_ENABLE_VTK
@@ -723,9 +709,7 @@ void GeneratorTorqueWithAxisTilt(
     auto parameters = StepParameters(is_dynamic_solve, max_iter, step_size, rho_inf);
 
     // Create solver, elements, constraints, and state
-    auto state = model.CreateState();
-    auto elements = model.CreateElements();
-    auto constraints = model.CreateConstraints();
+    auto [state, elements, constraints] = model.CreateSystem();
     auto solver = CreateSolver(state, elements, constraints);
 
 #ifdef OpenTurbine_ENABLE_VTK

--- a/tests/regression_tests/regression/test_rotor.cpp
+++ b/tests/regression_tests/regression/test_rotor.cpp
@@ -137,10 +137,7 @@ TEST(RotorTest, IEA15Rotor) {
     auto parameters = StepParameters(is_dynamic_solve, max_iter, step_size, rho_inf);
 
     // Create solver, elements, constraints, and state
-    auto state = model.CreateState();
-    auto elements = model.CreateElements();
-    auto constraints = model.CreateConstraints();
-    auto solver = CreateSolver(state, elements, constraints);
+    auto [state, elements, constraints, solver] = model.CreateSystemWithSolver();
 
     // Remove output directory for writing step data
     if (write_output) {
@@ -280,10 +277,7 @@ TEST(RotorTest, IEA15RotorHub) {
     auto parameters = StepParameters(is_dynamic_solve, max_iter, step_size, rho_inf);
 
     // Create solver, elements, constraints, and state
-    auto state = model.CreateState();
-    auto elements = model.CreateElements();
-    auto constraints = model.CreateConstraints();
-    auto solver = CreateSolver(state, elements, constraints);
+    auto [state, elements, constraints, solver] = model.CreateSystemWithSolver();
 
     // Remove output directory for writing step data
     if (write_output) {
@@ -443,10 +437,7 @@ TEST(RotorTest, IEA15RotorController) {
 
     // Create solver, elements, constraints, and state
     auto parameters = StepParameters(is_dynamic_solve, max_iter, step_size, rho_inf);
-    auto state = model.CreateState();
-    auto elements = model.CreateElements();
-    auto constraints = model.CreateConstraints();
-    auto solver = CreateSolver(state, elements, constraints);
+    auto [state, elements, constraints, solver] = model.CreateSystemWithSolver();
 
     // Remove output directory for writing step data
     if (write_output) {

--- a/tests/regression_tests/regression/test_solver.cpp
+++ b/tests/regression_tests/regression/test_solver.cpp
@@ -90,9 +90,7 @@ inline void SetUpSolverAndAssemble() {
     auto parameters = StepParameters(is_dynamic_solve, max_iter, step_size, rho_inf);
 
     // Create solver, elements, constraints, and state
-    auto state = model.CreateState();
-    auto elements = model.CreateElements();
-    auto constraints = model.CreateConstraints();
+    auto [state, elements, constraints] = model.CreateSystem();
     auto solver = CreateSolver(state, elements, constraints);
 
     auto q = RotationVectorToQuaternion({0., 0., omega * step_size});
@@ -315,9 +313,7 @@ inline void SetupAndTakeNoSteps() {
     auto parameters = StepParameters(is_dynamic_solve, max_iter, step_size, rho_inf);
 
     // Create solver, elements, constraints, and state
-    auto state = model.CreateState();
-    auto elements = model.CreateElements();
-    auto constraints = model.CreateConstraints();
+    auto [state, elements, constraints] = model.CreateSystem();
     auto solver = CreateSolver(state, elements, constraints);
 
     auto q = RotationVectorToQuaternion({0., 0., omega * step_size});
@@ -511,9 +507,7 @@ inline auto SetupAndTakeTwoSteps() {
     auto parameters = StepParameters(is_dynamic_solve, max_iter, step_size, rho_inf);
 
     // Create solver, elements, constraints, and state
-    auto state = model.CreateState();
-    auto elements = model.CreateElements();
-    auto constraints = model.CreateConstraints();
+    auto [state, elements, constraints] = model.CreateSystem();
     auto solver = CreateSolver(state, elements, constraints);
 
     auto q = RotationVectorToQuaternion({0., 0., omega * step_size});

--- a/tests/regression_tests/regression/test_spring_mass_system.cpp
+++ b/tests/regression_tests/regression/test_spring_mass_system.cpp
@@ -61,11 +61,9 @@ inline auto SetUpSpringMassSystem() {
     auto parameters = StepParameters(is_dynamic_solve, max_iter, step_size, rho_inf);
 
     // Create solver, elements, constraints, and state
-    auto state = model.CreateState();
-    auto elements = model.CreateElements();
-    auto constraints = model.CreateConstraints();
-    auto solver = CreateSolver(state, elements, constraints);
+    auto [state, elements, constraints, solver] = model.CreateSystemWithSolver();
 
+    // Create host mirror for checking solution
     auto q = Kokkos::create_mirror(state.q);
 
     // Run simulation for T seconds
@@ -146,10 +144,8 @@ inline auto SetUpSpringMassChainSystem() {
     model.AddFixedBC(0);
     model.AddFixedBC(number_of_masses + 1);
 
-    // Set up solver components
-    auto state = model.CreateState();
-    auto elements = model.CreateElements();
-    auto constraints = model.CreateConstraints();
+    // Create system and solver
+    auto [state, elements, constraints] = model.CreateSystem();
     auto solver = CreateSolver(state, elements, constraints);
 
     const double T = 2. * M_PI * sqrt(m / k);

--- a/tests/unit_tests/model/test_model.cpp
+++ b/tests/unit_tests/model/test_model.cpp
@@ -184,4 +184,49 @@ TEST(Model, ModelCreateState) {
     }
 }
 
+TEST(Model, ModelCreateSystem) {
+    Model model;
+
+    // Rotation of 1 radian around x
+    auto R1 = RotationVectorToQuaternion({1., 0., 0.});
+    auto R2 = RotationVectorToQuaternion({0., 1., 0.});
+
+    // Create node with initial position and displacement from initial position
+    static_cast<void>(model.AddNode()
+                          .SetPosition(1., 2., 3., R1[0], R1[1], R1[2], R1[3])
+                          .SetDisplacement(3., 2., 1., R2[0], R2[1], R2[2], R2[3])
+                          .Build());
+
+    // Create state object from model
+    auto [state, elements, constraints] = model.CreateSystem();
+
+    // Verify initial position
+    const auto x0 = Kokkos::create_mirror(state.x0);
+    Kokkos::deep_copy(x0, state.x0);
+    const auto exact_x0 = std::array{1., 2., 3., R1[0], R1[1], R1[2], R1[3]};
+    for (auto i = 0U; i < 7U; ++i) {
+        EXPECT_NEAR(x0(0, i), exact_x0[i], 1.e-15);
+    }
+
+    // Verify initial displacement
+    const auto q = Kokkos::create_mirror(state.q);
+    Kokkos::deep_copy(q, state.q);
+    const auto exact_q = std::array{3., 2., 1., R2[0], R2[1], R2[2], R2[3]};
+    for (auto i = 0U; i < 7U; ++i) {
+        EXPECT_NEAR(q(0, i), exact_q[i], 1.e-15);
+    }
+
+    // Verify current position (initial position plus displacement)
+    auto Rt = QuaternionCompose(R2, R1);
+    const auto x = Kokkos::create_mirror(state.x);
+    Kokkos::deep_copy(x, state.x);
+    const auto exact_x = std::array{4., 4., 4., Rt[0], Rt[1], Rt[2], Rt[3]};
+    for (auto i = 0U; i < 7U; ++i) {
+        EXPECT_NEAR(x(0, i), exact_x[i], 1.e-15);
+    }
+
+    EXPECT_EQ(elements.NumElementsInSystem(), 0);
+    EXPECT_EQ(constraints.num, 0);
+}
+
 }  // namespace openturbine::tests


### PR DESCRIPTION
These methods give users a shorter way to create the structures needed to use OpenTurbine.  CreateSystem just creates the State, Elements, and Constraints, while CreateSystemWithSolver also creates the Solver.

To support this, a copy constructor was added to Solver.  This is needed because the default copy constructor was not properly initializing the new Kernel Handles needed for sparse matrix addition and multiplication.