### PR TITLE
Suppresses CppCheck warning about missing member copy.  

### DIFF
--- a/src/solver/solver.hpp
+++ b/src/solver/solver.hpp
@@ -148,6 +148,7 @@ struct Solver {
               CreateSparseDenseSolver<GlobalCrsMatrixType, GlobalMultiVectorType>(A, x_mv, b)
           ) {}
 
+    // cppcheck-suppress missingMemberCopy
     Solver(const Solver& other)
         : num_system_nodes(other.num_system_nodes),
           num_system_dofs(other.num_system_dofs),
@@ -175,6 +176,7 @@ struct Solver {
           x_mv(Tpetra::createMultiVector<GlobalCrsMatrixType::scalar_type>(A->getDomainMap(), 1)),
           R("R", num_dofs),
           x("x", num_dofs),
+          convergence_err(other.convergence_err),
           amesos_solver(
               CreateSparseDenseSolver<GlobalCrsMatrixType, GlobalMultiVectorType>(A, x_mv, b)
           ) {}


### PR DESCRIPTION
Kernel handles cannot be copied and must be regenerated as done here.  CppCheck does not understand this.

I don't know why CI didn't catch this when the original PR was approved.  