### PR TITLE
Floating Platform CFD Interface Milestone

### DIFF
--- a/src/interfaces/cfd/floating_platform.hpp
+++ b/src/interfaces/cfd/floating_platform.hpp
@@ -22,7 +22,7 @@ struct FloatingPlatform {
     size_t mass_element_id;
 
     /// @brief Mooring line data array
-    std::vector<MooringLine> mooring_lines;
+    std::vector<MooringLine> mooring_lines{};
 };
 
 }  // namespace openturbine::cfd

--- a/src/interfaces/cfd/floating_platform.hpp
+++ b/src/interfaces/cfd/floating_platform.hpp
@@ -16,10 +16,10 @@ struct FloatingPlatform {
     bool active = false;
 
     /// @brief Platform node data (ID, motion, loads)
-    NodeData node{0};
+    NodeData node;
 
     /// @brief Platform mass element identifier
-    size_t mass_element_id = 0;
+    size_t mass_element_id;
 
     /// @brief Mooring line data array
     std::vector<MooringLine> mooring_lines;

--- a/src/interfaces/cfd/floating_platform.hpp
+++ b/src/interfaces/cfd/floating_platform.hpp
@@ -22,7 +22,7 @@ struct FloatingPlatform {
     size_t mass_element_id;
 
     /// @brief Mooring line data array
-    std::vector<MooringLine> mooring_lines{};
+    std::vector<MooringLine> mooring_lines;
 };
 
 }  // namespace openturbine::cfd

--- a/src/interfaces/cfd/floating_platform_input.hpp
+++ b/src/interfaces/cfd/floating_platform_input.hpp
@@ -9,16 +9,16 @@ namespace openturbine::cfd {
 
 struct FloatingPlatformInput {
     /// Flag to enable use of floating platform in model
-    bool enable = false;
+    bool enable{false};
 
     /// Platform point coordinates and orientation (XYZ,quaternion)
-    std::array<double, 7> position = {0., 0., 0., 1., 0., 0., 0.};
+    std::array<double, 7> position{0., 0., 0., 1., 0., 0., 0.};
 
     /// Platform point translational and rotational velocity
-    std::array<double, 6> velocity = {0., 0., 0., 0., 0., 0.};
+    std::array<double, 6> velocity{0., 0., 0., 0., 0., 0.};
 
     /// Platform point translational and rotational acceleration
-    std::array<double, 6> acceleration = {0., 0., 0., 0., 0., 0.};
+    std::array<double, 6> acceleration{0., 0., 0., 0., 0., 0.};
 
     /// Platform point mass matrix
     std::array<std::array<double, 6>, 6> mass_matrix;

--- a/src/interfaces/cfd/interface.cpp
+++ b/src/interfaces/cfd/interface.cpp
@@ -176,6 +176,17 @@ Interface::Interface(const InterfaceInput& input)
       host_state_q("host_state_q", state.num_system_nodes),
       host_state_v("host_state_v", state.num_system_nodes),
       host_state_vd("host_state_vd", state.num_system_nodes) {
+    // Copy state motion members from device to host
+    Kokkos::deep_copy(this->host_state_x, this->state.x);
+    Kokkos::deep_copy(this->host_state_q, this->state.q);
+    Kokkos::deep_copy(this->host_state_v, this->state.v);
+    Kokkos::deep_copy(this->host_state_vd, this->state.vd);
+
+    // Update the turbine motion to match restored state
+    GetTurbineMotion(
+        this->turbine, this->host_state_x, this->host_state_q, this->host_state_v,
+        this->host_state_vd
+    );
 }
 
 void Interface::Step() {

--- a/src/interfaces/cfd/interface.cpp
+++ b/src/interfaces/cfd/interface.cpp
@@ -46,6 +46,7 @@ FloatingPlatform CreateFloatingPlatform(const FloatingPlatformInput& input, Mode
             false,         // active
             NodeData(0U),  // platform node
             0U,            // mass element ID
+            {},
         };
     }
 
@@ -64,6 +65,7 @@ FloatingPlatform CreateFloatingPlatform(const FloatingPlatformInput& input, Mode
         true,  // enable platform
         NodeData(platform_node_id),
         mass_element_id,
+        {},
     };
 
     // Construct mooring lines

--- a/src/interfaces/cfd/interface.cpp
+++ b/src/interfaces/cfd/interface.cpp
@@ -40,26 +40,33 @@ void GetNodeMotion(
 //------------------------------------------------------------------------------
 
 FloatingPlatform CreateFloatingPlatform(const FloatingPlatformInput& input, Model& model) {
-    // Instantiate floating platform
-    FloatingPlatform platform{};
-
     // If floating platform is not enabled, return
     if (!input.enable) {
-        return platform;
+        return {
+            false,         // active
+            NodeData(0U),  // platform node
+            0U,            // mass element ID
+            {},            // mooring lines
+        };
     }
 
-    // Set platform active to true
-    platform.active = true;
+    FloatingPlatform platform{
+        // Set platform active to true
+        true,
 
-    // Construct platform node and save ID
-    platform.node.id = model.AddNode()
-                           .SetPosition(input.position)
-                           .SetVelocity(input.velocity)
-                           .SetAcceleration(input.acceleration)
-                           .Build();
+        // Construct platform node and save ID
+        NodeData(model.AddNode()
+                     .SetPosition(input.position)
+                     .SetVelocity(input.velocity)
+                     .SetAcceleration(input.acceleration)
+                     .Build()),
 
-    // Add element for platform mass
-    platform.mass_element_id = model.AddMassElement(platform.node.id, input.mass_matrix);
+        // Add element for platform mass
+        model.AddMassElement(platform.node.id, input.mass_matrix),
+
+        // Mooring lines
+        {},
+    };
 
     // Construct mooring lines
     std::transform(

--- a/src/interfaces/cfd/interface.cpp
+++ b/src/interfaces/cfd/interface.cpp
@@ -46,26 +46,24 @@ FloatingPlatform CreateFloatingPlatform(const FloatingPlatformInput& input, Mode
             false,         // active
             NodeData(0U),  // platform node
             0U,            // mass element ID
-            {},            // mooring lines
         };
     }
 
+    // Construct platform node and save ID
+    const auto platform_node_id = model.AddNode()
+                                      .SetPosition(input.position)
+                                      .SetVelocity(input.velocity)
+                                      .SetAcceleration(input.acceleration)
+                                      .Build();
+
+    // Add element for platform mass
+    const auto mass_element_id = model.AddMassElement(platform_node_id, input.mass_matrix);
+
+    // Instantiate platform
     FloatingPlatform platform{
-        // Set platform active to true
-        true,
-
-        // Construct platform node and save ID
-        NodeData(model.AddNode()
-                     .SetPosition(input.position)
-                     .SetVelocity(input.velocity)
-                     .SetAcceleration(input.acceleration)
-                     .Build()),
-
-        // Add element for platform mass
-        model.AddMassElement(platform.node.id, input.mass_matrix),
-
-        // Mooring lines
-        {},
+        true,  // enable platform
+        NodeData(platform_node_id),
+        mass_element_id,
     };
 
     // Construct mooring lines

--- a/src/interfaces/cfd/interface.hpp
+++ b/src/interfaces/cfd/interface.hpp
@@ -11,7 +11,7 @@ public:
     explicit Interface(const InterfaceInput& input);
 
     /// @brief Step forward in time
-    void Step();
+    [[nodiscard]] bool Step();
 
     /// @brief Save state for correction step
     void SaveState();

--- a/src/interfaces/cfd/interface_input.hpp
+++ b/src/interfaces/cfd/interface_input.hpp
@@ -8,16 +8,16 @@ namespace openturbine::cfd {
 
 struct InterfaceInput {
     /// @brief Array of gravity components (XYZ)
-    std::array<double, 3> gravity{};
+    std::array<double, 3> gravity{0., 0., 0.};
 
     /// @brief Solver time step
-    double time_step = 0.01;
+    double time_step{0.01};
 
     /// @brief Solver numerical damping factor (0 = maximum damping)
-    double rho_inf = 0.0;
+    double rho_inf{0.0};
 
     /// @brief Maximum number of convergence iterations
-    size_t max_iter = 5;
+    size_t max_iter{5U};
 
     /// @brief Turbine input data
     TurbineInput turbine;

--- a/src/interfaces/cfd/mooring_line.hpp
+++ b/src/interfaces/cfd/mooring_line.hpp
@@ -12,13 +12,13 @@ struct MooringLine {
     NodeData anchor_node;
 
     /// @brief Fixed constraint identifier for the anchor node
-    size_t fixed_constraint_id = 0;
+    size_t fixed_constraint_id;
 
     /// @brief Rigid constraint identifier between fairlead and platform nodes
-    size_t rigid_constraint_id = 0;
+    size_t rigid_constraint_id;
 
     /// @brief Spring element identifier between fairlead and anchor nodes
-    size_t spring_element_id = 0;
+    size_t spring_element_id;
 };
 
 }  // namespace openturbine::cfd

--- a/src/interfaces/cfd/mooring_line.hpp
+++ b/src/interfaces/cfd/mooring_line.hpp
@@ -11,20 +11,14 @@ struct MooringLine {
     /// @brief Anchor node
     NodeData anchor_node;
 
-    /// @brief Spring element identifier
-    size_t spring_element_id = 0;
+    /// @brief Fixed constraint identifier for the anchor node
+    size_t fixed_constraint_id = 0;
 
-    /// @brief Rigid constraint identifier
+    /// @brief Rigid constraint identifier between fairlead and platform nodes
     size_t rigid_constraint_id = 0;
 
-    MooringLine(
-        size_t fairlead_node_id, size_t anchor_node_id, size_t spring_element_id_,
-        size_t rigid_constraint_id_
-    )
-        : fairlead_node(fairlead_node_id),
-          anchor_node(anchor_node_id),
-          spring_element_id(spring_element_id_),
-          rigid_constraint_id(rigid_constraint_id_) {}
+    /// @brief Spring element identifier between fairlead and anchor nodes
+    size_t spring_element_id = 0;
 };
 
 }  // namespace openturbine::cfd

--- a/src/interfaces/cfd/mooring_line.hpp
+++ b/src/interfaces/cfd/mooring_line.hpp
@@ -12,13 +12,13 @@ struct MooringLine {
     NodeData anchor_node;
 
     /// @brief Fixed constraint identifier for the anchor node
-    size_t fixed_constraint_id;
+    size_t fixed_constraint_id{0U};
 
     /// @brief Rigid constraint identifier between fairlead and platform nodes
-    size_t rigid_constraint_id;
+    size_t rigid_constraint_id{0U};
 
     /// @brief Spring element identifier between fairlead and anchor nodes
-    size_t spring_element_id;
+    size_t spring_element_id{0U};
 };
 
 }  // namespace openturbine::cfd

--- a/src/interfaces/cfd/mooring_line_input.hpp
+++ b/src/interfaces/cfd/mooring_line_input.hpp
@@ -12,22 +12,22 @@ struct MooringLineInput {
     double undeformed_length = 0.;
 
     /// Fairlead point coordinates (XYZ)
-    std::array<double, 3> fairlead_position = {0., 0., 0.};
+    std::array<double, 3> fairlead_position{0., 0., 0.};
 
     /// Fairlead point velocity (XYZ)
-    std::array<double, 3> fairlead_velocity = {0., 0., 0.};
+    std::array<double, 3> fairlead_velocity{0., 0., 0.};
 
     /// Fairlead point acceleration (XYZ)
-    std::array<double, 3> fairlead_acceleration = {0., 0., 0.};
+    std::array<double, 3> fairlead_acceleration{0., 0., 0.};
 
     /// Anchor point coordinates (XYZ)
-    std::array<double, 3> anchor_position = {0., 0., 0.};
+    std::array<double, 3> anchor_position{0., 0., 0.};
 
     /// Anchor point velocity (XYZ)
-    std::array<double, 3> anchor_velocity = {0., 0., 0.};
+    std::array<double, 3> anchor_velocity{0., 0., 0.};
 
     /// Anchor point acceleration (XYZ)
-    std::array<double, 3> anchor_acceleration = {0., 0., 0.};
+    std::array<double, 3> anchor_acceleration{0., 0., 0.};
 };
 
 }  // namespace openturbine::cfd

--- a/src/interfaces/cfd/mooring_line_input.hpp
+++ b/src/interfaces/cfd/mooring_line_input.hpp
@@ -12,22 +12,22 @@ struct MooringLineInput {
     double undeformed_length = 0.;
 
     /// Fairlead point coordinates (XYZ)
-    std::array<double, 3> fairlead_position = {0.};
+    std::array<double, 3> fairlead_position = {0., 0., 0.};
 
     /// Fairlead point velocity (XYZ)
-    std::array<double, 3> fairlead_velocity = {0.};
+    std::array<double, 3> fairlead_velocity = {0., 0., 0.};
 
     /// Fairlead point acceleration (XYZ)
-    std::array<double, 3> fairlead_acceleration = {0.};
+    std::array<double, 3> fairlead_acceleration = {0., 0., 0.};
 
     /// Anchor point coordinates (XYZ)
-    std::array<double, 3> anchor_position = {0.};
+    std::array<double, 3> anchor_position = {0., 0., 0.};
 
     /// Anchor point velocity (XYZ)
-    std::array<double, 3> anchor_velocity = {0.};
+    std::array<double, 3> anchor_velocity = {0., 0., 0.};
 
     /// Anchor point acceleration (XYZ)
-    std::array<double, 3> anchor_acceleration = {0.};
+    std::array<double, 3> anchor_acceleration = {0., 0., 0.};
 };
 
 }  // namespace openturbine::cfd

--- a/src/interfaces/cfd/node_data.hpp
+++ b/src/interfaces/cfd/node_data.hpp
@@ -6,11 +6,11 @@ namespace openturbine::cfd {
 
 struct NodeData {
     size_t id;
-    std::array<double, 7> position = {0., 0., 0., 1., 0., 0., 0.};
-    std::array<double, 7> displacement = {0., 0., 0., 1., 0., 0., 0.};
-    std::array<double, 6> velocity = {0., 0., 0., 0., 0., 0.};
-    std::array<double, 6> acceleration = {0., 0., 0., 0., 0., 0.};
-    std::array<double, 6> loads = {0., 0., 0., 0., 0., 0.};
+    std::array<double, 7> position{0., 0., 0., 1., 0., 0., 0.};
+    std::array<double, 7> displacement{0., 0., 0., 1., 0., 0., 0.};
+    std::array<double, 6> velocity{0., 0., 0., 0., 0., 0.};
+    std::array<double, 6> acceleration{0., 0., 0., 0., 0., 0.};
+    std::array<double, 6> loads{0., 0., 0., 0., 0., 0.};
 
     explicit NodeData(size_t id_) : id(id_) {}
 };

--- a/src/viz/vtk_lines.hpp
+++ b/src/viz/vtk_lines.hpp
@@ -1,0 +1,63 @@
+#pragma once
+
+#include <array>
+#include <vector>
+
+#ifdef OpenTurbine_ENABLE_VTK
+
+#include <vtkCellType.h>
+#include <vtkDoubleArray.h>
+#include <vtkFloatArray.h>
+#include <vtkLine.h>
+#include <vtkNew.h>
+#include <vtkPointData.h>
+#include <vtkPoints.h>
+#include <vtkPolyData.h>
+#include <vtkUnstructuredGrid.h>
+#include <vtkXMLPolyDataWriter.h>
+#include <vtkXMLUnstructuredGridWriter.h>
+
+#endif
+
+namespace openturbine {
+
+#ifdef OpenTurbine_ENABLE_VTK
+
+inline void WriteLinesVTK(
+    const std::vector<std::array<size_t, 2>>& lines,
+    const std::vector<std::array<double, 7>>& points, const std::string& filename
+) {
+    // Create a grid object and add the points to it.
+    const auto gd = vtkNew<vtkUnstructuredGrid>();
+    gd->Allocate(static_cast<vtkIdType>(lines.size()));
+    for (const auto& line : lines) {
+        std::vector<vtkIdType> pts;
+        pts.push_back(static_cast<vtkIdType>(line[0]));
+        pts.push_back(static_cast<vtkIdType>(line[1]));
+        gd->InsertNextCell(VTK_LINE, static_cast<vtkIdType>(2), pts.data());
+    }
+
+    // Set point positions
+    const auto pt_pos = vtkNew<vtkPoints>();
+    for (const auto& point : points) {
+        pt_pos->InsertNextPoint(point[0], point[1], point[2]);
+    }
+    gd->SetPoints(pt_pos);
+
+    // Write the file
+    const auto writer = vtkNew<vtkXMLUnstructuredGridWriter>();
+    writer->SetFileName(filename.c_str());
+    writer->SetInputData(gd);
+    writer->SetDataModeToAscii();
+    writer->Write();
+}
+
+#else
+
+inline void
+WriteLinesVTK(const std::vector<std::array<size_t, 2>>&, const std::vector<std::array<double, 7>>&, const std::string&) {
+}
+
+#endif
+
+}  // namespace openturbine

--- a/tests/regression_tests/interfaces/test_cfd_interface.cpp
+++ b/tests/regression_tests/interfaces/test_cfd_interface.cpp
@@ -268,6 +268,18 @@ TEST(CFDInterfaceTest, FloatingPlatform) {
         // Step
         converged = interface.Step();
         EXPECT_EQ(converged, true);
+
+        // Check for expected displacements/rotations of platform node
+        if (i == 100) {
+            const auto& platform_u = interface.turbine.floating_platform.node.displacement;
+            EXPECT_NEAR(platform_u[0], 3.4379940641493395e-06, 1e-12);
+            EXPECT_NEAR(platform_u[1], 0.0036709089002912518, 1e-12);
+            EXPECT_NEAR(platform_u[2], 0.0034998271929752248, 1e-12);
+            EXPECT_NEAR(platform_u[3], 0.99999999992274302, 1e-12);
+            EXPECT_NEAR(platform_u[4], 1.3448158662549561e-06, 1e-12);
+            EXPECT_NEAR(platform_u[5], 1.2713890988278111e-06, 1e-12);
+            EXPECT_NEAR(platform_u[6], 1.2291853012439073e-05, 1e-12);
+        }
     }
 }
 

--- a/tests/regression_tests/interfaces/test_cfd_interface.cpp
+++ b/tests/regression_tests/interfaces/test_cfd_interface.cpp
@@ -147,7 +147,7 @@ void OutputLines(const FloatingPlatform&, size_t, const std::string&) {
 TEST(CFDInterfaceTest, FloatingPlatform) {
     // Solution parameters
     constexpr auto time_step = 0.01;
-    constexpr auto t_end = 120.;
+    constexpr auto t_end = 1.;
     constexpr auto rho_inf = 0.0;
     constexpr auto max_iter = 5;
     const auto n_steps{static_cast<size_t>(ceil(t_end / time_step)) + 1};

--- a/tests/regression_tests/interfaces/test_cfd_interface.cpp
+++ b/tests/regression_tests/interfaces/test_cfd_interface.cpp
@@ -1,14 +1,6 @@
 #include <gtest/gtest.h>
 
-#include "src/elements/elements.hpp"
-#include "src/elements/masses/create_masses.hpp"
 #include "src/interfaces/cfd/interface.hpp"
-#include "src/model/model.hpp"
-#include "src/state/set_node_external_loads.hpp"
-#include "src/state/state.hpp"
-#include "src/step/step.hpp"
-#include "src/step/update_system_variables.hpp"
-#include "src/types.hpp"
 #include "src/viz/vtk_lines.hpp"
 #include "tests/regression_tests/regression/test_utilities.hpp"
 


### PR DESCRIPTION
This PR implements the floating platform as part of the CFD interface for the FY25Q1 milestone. The `CFDInterfaceTest.FloatingPlatform` test is implemented in `tests/regression_tests/interfaces/test_cfd_interface.cpp`. This test initializes the floating platform and then runs a simulation with time varying loads applied to the platform node. The motion of the platform can be visualized with VTK. The platform parameters for this test are taken from Table 2 and Table 4 of https://www.nrel.gov/docs/fy22osti/80803.pdf. 