### PR TITLE
Updated the documentation to encourage users to install OpenTurbine through Spack.

### DIFF
--- a/docs/compiling.md
+++ b/docs/compiling.md
@@ -6,6 +6,64 @@ Every effort is made to test on a variety of platforms, including both Linux and
 This page documents the build proceedure as known to work on Linux (RHEL8).  
 Please reach out to the developers if additional guidance is needed for your particular situation.
 
+## Spack Installation
+
+The easiest way to use OpenTurbine is through the [Spack](https://spack.io/) package manager.
+Once you have downloaded and set up Spack for your environment, simply run
+```bash
+spack install openturbine
+```
+To see the latest list of supported configuration options, check out the package file or run
+```bash
+spack info openturbine
+```
+Once it is installed, you can load the OpenTurbine library and its dependencies into your environment using
+```bash
+spack load openturbine
+```
+
+## Development using Spack Developer Workflow
+
+One easy way to set up a development environment for OpenTurbine is to use Spack's Developer Workflow.
+To setup an environment for working on OpenTurbine, setup Spack and then run the following commands:
+```bash
+mkdir openturbine
+cd openturbine
+spack env create -d .
+spack env activate .
+spack add openturbine+tests
+spack install
+spack develop openturbine@main
+spack concretize -f
+spack install
+```
+OpenTurbine's source code will now be located in the openturbine folder, but can be accessed from anywhere by
+```bash
+spack cd -c openturbine
+```
+After editing the code here, it can be rebuilt by running
+```bash
+spack install
+```
+To run the tests, first access the build folder through the spack command
+```bash
+spack cd -b openturbine
+```
+Next, the tests can be run either through ctest or directly from the unit test or regression test executables
+```bash
+ctest
+./tests/unit_tests/openturbine_unit_tests
+./tests/regression_tests/openturbine_regression_tests
+```
+You can also build OpenTurbine from this folder using standard make commands.
+
+For more information, please see Spack's documentation: https://spack-tutorial.readthedocs.io/en/latest/tutorial_developer_workflows.html
+
+## Building and Developing in OpenTurbine Directly
+
+The following sections outline how to build and develop OpenTurbine without Spack's Developer Workflows.
+The main complication here is that developers will have to manage their environment and dependicies manually, which may be an unnecessary complication or a freeing feature, depending on your perspective.
+
 ## Dependencies
 
 Before building OpenTurbine, you'll need the following:
@@ -117,7 +175,6 @@ ctest --output-on-failure
 
 Once built, the unit test executable can also be run directly from the build directory
 ```bash
-cp src/*.dll ./
 ./tests/unit_tests/openturbine_unit_tests
 ```
 


### PR DESCRIPTION
It also provides documentation for developers on how to use Spack's Developer Workflows for developing OpenTurbine rather than doing so directly with CMake as we have been up unill now.