### PR TITLE
Rather than using the default GEMM algorithm, use KK_DENSE algorithm.

### DIFF
--- a/src/solver/create_matrix_spgemm.hpp
+++ b/src/solver/create_matrix_spgemm.hpp
@@ -10,7 +10,7 @@ template <typename CrsMatrixType, typename KernelHandle>
     const CrsMatrixType& A, const CrsMatrixType& B, KernelHandle& handle
 ) {
     auto C = CrsMatrixType{};
-    handle.create_spgemm_handle();
+    handle.create_spgemm_handle(KokkosSparse::SPGEMMAlgorithm::SPGEMM_KK_DENSE);
     KokkosSparse::spgemm_symbolic(handle, A, false, B, false, C);
     KokkosSparse::spgemm_numeric(handle, A, false, B, false, C);
     return C;


### PR DESCRIPTION
The result is substantial performance improvements (10-30% of the total runtime) for the Floating Platform, IEA15 Rotor, and IEA15 Rotor with 3000 elements on CPU.  Similar performance improvements are seen on GPU, with the exception of the IEA15 with 3000 elements. However, the performance of that test is dominated by the system solve, so the result is no net change in performance.