### PR TITLE
Add trapezoidal quadrature

### DIFF
--- a/src/elements/beams/beam_element.hpp
+++ b/src/elements/beams/beam_element.hpp
@@ -3,6 +3,7 @@
 #include <array>
 #include <vector>
 
+#include "beam_quadrature.hpp"
 #include "beam_section.hpp"
 #include "types.hpp"
 

--- a/src/elements/beams/beam_quadrature.hpp
+++ b/src/elements/beams/beam_quadrature.hpp
@@ -1,0 +1,28 @@
+#pragma once
+
+#include <algorithm>
+#include <vector>
+
+#include "types.hpp"
+
+namespace openturbine {
+
+using BeamQuadrature = std::vector<Array_2>;
+
+inline BeamQuadrature CreateTrapezoidalQuadrature(const std::vector<double>& grid) {
+    const auto n{grid.size()};
+    const auto [grid_min, grid_max] = std::minmax_element(begin(grid), end(grid));
+    const auto grid_range{*grid_max - *grid_min};
+    BeamQuadrature quadrature{
+        {-1., (grid[1] - grid[0]) / grid_range},
+    };
+    for (auto i = 1U; i < n - 1; ++i) {
+        quadrature.push_back(
+            {2. * (grid[i] - *grid_min) / grid_range - 1., (grid[i + 1] - grid[i - 1]) / grid_range}
+        );
+    }
+    quadrature.push_back({1., (grid[n - 1] - grid[n - 2]) / grid_range});
+    return quadrature;
+}
+
+}  // namespace openturbine

--- a/src/types.hpp
+++ b/src/types.hpp
@@ -37,7 +37,7 @@ using Array_3 = std::array<double, 3>;
 using Array_4 = std::array<double, 4>;
 using Array_6 = std::array<double, 6>;
 using Array_7 = std::array<double, 7>;
-using BeamQuadrature = std::vector<Array_2>;
+
 // 2D arrays
 using Array_3x3 = std::array<Array_3, 3>;
 using Array_6x6 = std::array<Array_6, 6>;

--- a/tests/regression_tests/regression/iea15_rotor_data.hpp
+++ b/tests/regression_tests/regression/iea15_rotor_data.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "elements/beams/beam_quadrature.hpp"
 #include "elements/beams/beam_section.hpp"
 #include "types.hpp"
 

--- a/tests/unit_tests/elements/beams/CMakeLists.txt
+++ b/tests/unit_tests/elements/beams/CMakeLists.txt
@@ -3,6 +3,7 @@ target_sources(
     openturbine_unit_tests
     PRIVATE
     test_beams_input.cpp
+    test_beam_quadrature.cpp
     test_interpolate_QP_state.cpp
     test_interpolate_QP_vector.cpp
     test_interpolation.cpp

--- a/tests/unit_tests/elements/beams/test_beam_quadrature.cpp
+++ b/tests/unit_tests/elements/beams/test_beam_quadrature.cpp
@@ -1,0 +1,48 @@
+#include <gtest/gtest.h>
+
+#include "elements/beams/beam_quadrature.hpp"
+
+namespace openturbine::tests {
+
+TEST(BeamQuadratureTest, CheckCreateTrapezoidalQuadrature) {
+    struct TestData {
+        std::vector<double> grid;
+        BeamQuadrature q_exp;
+    };
+
+    for (const auto& td : std::vector<TestData>{
+             {
+                 {0., 0.2, 0.4, 0.6, 0.8, 1.0},  // Grid
+                 {
+                     {-1., 0.2},
+                     {-0.6, 0.4},
+                     {-0.2, 0.4},
+                     {0.2, 0.4},
+                     {0.6, 0.4},
+                     {1., 0.2},
+                 },  // Quadrature
+             },
+             {
+                 {-5., -3., -1., 0., 3., 4., 5.},  // Grid
+                 {
+                     {-1., 0.2},
+                     {-0.6, 0.4},
+                     {-0.2, 0.3},
+                     {0., 0.4},
+                     {0.6, 0.4},
+                     {0.8, 0.2},
+                     {1., 0.1},
+                 },  // Quadrature
+             },
+         }) {
+        const auto q_act = CreateTrapezoidalQuadrature(td.grid);
+
+        for (auto i = 0U; i < td.q_exp.size(); ++i) {
+            for (auto j = 0U; j < 2U; ++j) {
+                EXPECT_NEAR(q_act[i][j], td.q_exp[i][j], 1e-14);
+            }
+        }
+    }
+}
+
+}  // namespace openturbine::tests

--- a/tests/unit_tests/elements/beams/test_beam_quadrature.cpp
+++ b/tests/unit_tests/elements/beams/test_beam_quadrature.cpp
@@ -10,33 +10,34 @@ TEST(BeamQuadratureTest, CheckCreateTrapezoidalQuadrature) {
         BeamQuadrature q_exp;
     };
 
-    for (const auto& td : std::vector<TestData>{
-             {
-                 {0., 0.2, 0.4, 0.6, 0.8, 1.0},  // Grid
-                 {
-                     {-1., 0.2},
-                     {-0.6, 0.4},
-                     {-0.2, 0.4},
-                     {0.2, 0.4},
-                     {0.6, 0.4},
-                     {1., 0.2},
-                 },  // Quadrature
-             },
-             {
-                 {-5., -3., -1., 0., 3., 4., 5.},  // Grid
-                 {
-                     {-1., 0.2},
-                     {-0.6, 0.4},
-                     {-0.2, 0.3},
-                     {0., 0.4},
-                     {0.6, 0.4},
-                     {0.8, 0.2},
-                     {1., 0.1},
-                 },  // Quadrature
-             },
-         }) {
-        const auto q_act = CreateTrapezoidalQuadrature(td.grid);
+    std::vector<TestData> test_data{
+        {
+            {0., 0.2, 0.4, 0.6, 0.8, 1.0},  // Grid
+            {
+                {-1., 0.2},
+                {-0.6, 0.4},
+                {-0.2, 0.4},
+                {0.2, 0.4},
+                {0.6, 0.4},
+                {1., 0.2},
+            },  // Quadrature
+        },
+        {
+            {-5., -3., -1., 0., 3., 4., 5.},  // Grid
+            {
+                {-1., 0.2},
+                {-0.6, 0.4},
+                {-0.2, 0.3},
+                {0., 0.4},
+                {0.6, 0.4},
+                {0.8, 0.2},
+                {1., 0.1},
+            },  // Quadrature
+        },
+    };
 
+    for (const TestData& td : test_data) {
+        const auto q_act = CreateTrapezoidalQuadrature(td.grid);
         for (auto i = 0U; i < td.q_exp.size(); ++i) {
             for (auto j = 0U; j < 2U; ++j) {
                 EXPECT_NEAR(q_act[i][j], td.q_exp[i][j], 1e-14);

--- a/tests/unit_tests/elements/beams/test_beam_quadrature.cpp
+++ b/tests/unit_tests/elements/beams/test_beam_quadrature.cpp
@@ -10,7 +10,7 @@ TEST(BeamQuadratureTest, CheckCreateTrapezoidalQuadrature) {
         BeamQuadrature q_exp;
     };
 
-    std::vector<TestData> test_data{
+    const std::vector<TestData> test_data{
         {
             {0., 0.2, 0.4, 0.6, 0.8, 1.0},  // Grid
             {

--- a/tests/unit_tests/elements/beams/test_beam_quadrature.cpp
+++ b/tests/unit_tests/elements/beams/test_beam_quadrature.cpp
@@ -4,44 +4,26 @@
 
 namespace openturbine::tests {
 
-TEST(BeamQuadratureTest, CheckCreateTrapezoidalQuadrature) {
-    struct TestData {
-        std::vector<double> grid;
-        BeamQuadrature q_exp;
+TEST(BeamQuadratureTest, CheckCreateTrapezoidalQuadrature_1) {
+    const auto q_act = CreateTrapezoidalQuadrature({0., 0.2, 0.4, 0.6, 0.8, 1.0});
+    const BeamQuadrature q_exp{
+        {-1., 0.2}, {-0.6, 0.4}, {-0.2, 0.4}, {0.2, 0.4}, {0.6, 0.4}, {1., 0.2},
     };
+    for (auto i = 0U; i < q_exp.size(); ++i) {
+        for (auto j = 0U; j < 2U; ++j) {
+            EXPECT_NEAR(q_act[i][j], q_exp[i][j], 1e-14);
+        }
+    }
+}
 
-    const std::vector<TestData> test_data{
-        {
-            {0., 0.2, 0.4, 0.6, 0.8, 1.0},  // Grid
-            {
-                {-1., 0.2},
-                {-0.6, 0.4},
-                {-0.2, 0.4},
-                {0.2, 0.4},
-                {0.6, 0.4},
-                {1., 0.2},
-            },  // Quadrature
-        },
-        {
-            {-5., -3., -1., 0., 3., 4., 5.},  // Grid
-            {
-                {-1., 0.2},
-                {-0.6, 0.4},
-                {-0.2, 0.3},
-                {0., 0.4},
-                {0.6, 0.4},
-                {0.8, 0.2},
-                {1., 0.1},
-            },  // Quadrature
-        },
+TEST(BeamQuadratureTest, CheckCreateTrapezoidalQuadrature_2) {
+    const auto q_act = CreateTrapezoidalQuadrature({-5., -3., -1., 0., 3., 4., 5.});
+    const BeamQuadrature q_exp{
+        {-1., 0.2}, {-0.6, 0.4}, {-0.2, 0.3}, {0., 0.4}, {0.6, 0.4}, {0.8, 0.2}, {1., 0.1},
     };
-
-    for (const TestData& td : test_data) {
-        const auto q_act = CreateTrapezoidalQuadrature(td.grid);
-        for (auto i = 0U; i < td.q_exp.size(); ++i) {
-            for (auto j = 0U; j < 2U; ++j) {
-                EXPECT_NEAR(q_act[i][j], td.q_exp[i][j], 1e-14);
-            }
+    for (auto i = 0U; i < q_exp.size(); ++i) {
+        for (auto j = 0U; j < 2U; ++j) {
+            EXPECT_NEAR(q_act[i][j], q_exp[i][j], 1e-14);
         }
     }
 }


### PR DESCRIPTION
Added a function and associated tests to create a trapezoidal quadrature from a series of grid locations. This will be used to generate quadrature corresponding to beam section property locations for the blade interface.