### PR TITLE
Remove linear node spacing option on blade interface

### DIFF
--- a/src/interfaces/components/blade.hpp
+++ b/src/interfaces/components/blade.hpp
@@ -34,18 +34,7 @@ struct Blade {
         const auto n_nodes = input.element_order + 1;
 
         // Generate node locations within element [-1,1]
-        if (input.node_spacing == BladeInput::NodeSpacing::GaussLobattoLegendre) {
-            this->node_xi = GenerateGLLPoints(input.element_order);
-        } else if (input.node_spacing == BladeInput::NodeSpacing::Linear) {
-            this->node_xi.clear();
-            for (auto i = 0U; i <= input.element_order; ++i) {
-                this->node_xi.emplace_back(
-                    2. * static_cast<double>(i) / static_cast<double>(input.element_order) - 1.
-                );
-            }
-        } else {
-            throw("invalid node spacing option");
-        }
+        this->node_xi = GenerateGLLPoints(input.element_order);
 
         // Fit node coordinates to key points
         const std::vector<double> kp_xi(MapGeometricLocations(input.ref_axis.coordinate_grid));

--- a/src/interfaces/components/blade_builder.hpp
+++ b/src/interfaces/components/blade_builder.hpp
@@ -97,16 +97,6 @@ struct BladeBuilder {
         return *this;
     }
 
-    BladeBuilder& SetNodeSpacingLinear() {
-        input.node_spacing = BladeInput::NodeSpacing::Linear;
-        return *this;
-    }
-
-    BladeBuilder& SetNodeSpacingGaussLobattoLegendre() {
-        input.node_spacing = BladeInput::NodeSpacing::GaussLobattoLegendre;
-        return *this;
-    }
-
     [[nodiscard]] Blade Build(Model& model) const { return {this->input, model}; }
 
     [[nodiscard]] const BladeInput& Input() const { return this->input; }

--- a/src/interfaces/components/blade_input.hpp
+++ b/src/interfaces/components/blade_input.hpp
@@ -47,16 +47,8 @@ struct Root {
 };
 
 struct BladeInput {
-    enum class NodeSpacing : std::uint8_t {
-        GaussLobattoLegendre = 1,
-        Linear = 2,
-    };
-
     /// @brief Spectral element order (num nodes - 1)
     size_t element_order{10};
-
-    /// @brief Node spacing specification
-    NodeSpacing node_spacing{NodeSpacing::GaussLobattoLegendre};
 
     /// @brief Trapezoidal quadrature point refinement (0 = none)
     size_t section_refinement{0};

--- a/tests/regression_tests/interfaces/test_blade_interface.cpp
+++ b/tests/regression_tests/interfaces/test_blade_interface.cpp
@@ -348,7 +348,6 @@ TEST(BladeInterfaceTest, StaticCurledBeam) {
 
     builder.Blade()
         .SetElementOrder(10)
-        .SetNodeSpacingLinear()
         .SetSectionRefinement(1)
         .PrescribedRootMotion(true)
         .AddRefAxisTwist(0., 0.)
@@ -417,25 +416,25 @@ TEST(BladeInterfaceTest, StaticCurledBeam) {
     EXPECT_NEAR(tip_positions[0][1], 0., 1e-8);
     EXPECT_NEAR(tip_positions[0][2], 0., 1e-8);
 
-    EXPECT_NEAR(tip_positions[1][0], 7.5353117904309216, 1e-8);
+    EXPECT_NEAR(tip_positions[1][0], 7.535457547469286, 1e-8);
     EXPECT_NEAR(tip_positions[1][1], 0., 1e-8);
-    EXPECT_NEAR(tip_positions[1][2], 5.5406541545431187, 1e-8);
+    EXPECT_NEAR(tip_positions[1][2], 5.5405833775092788, 1e-8);
 
-    EXPECT_NEAR(tip_positions[2][0], 2.2747128775224663, 1e-8);
+    EXPECT_NEAR(tip_positions[2][0], 2.275140291113245, 1e-8);
     EXPECT_NEAR(tip_positions[2][1], 0., 1e-8);
-    EXPECT_NEAR(tip_positions[2][2], 7.2169136787384982, 1e-8);
+    EXPECT_NEAR(tip_positions[2][2], 7.2175190489085246, 1e-8);
 
-    EXPECT_NEAR(tip_positions[3][0], -1.614379006780613, 1e-8);
+    EXPECT_NEAR(tip_positions[3][0], -1.6157938054255538, 1e-8);
     EXPECT_NEAR(tip_positions[3][1], 0., 1e-8);
-    EXPECT_NEAR(tip_positions[3][2], 4.7774238337109498, 1e-8);
+    EXPECT_NEAR(tip_positions[3][2], 4.7783647698451075, 1e-8);
 
-    EXPECT_NEAR(tip_positions[4][0], -1.9031340843824651, 1e-8);
+    EXPECT_NEAR(tip_positions[4][0], -1.9061447828587319, 1e-8);
     EXPECT_NEAR(tip_positions[4][1], 0., 1e-8);
-    EXPECT_NEAR(tip_positions[4][2], 1.3327034304088525, 1e-8);
+    EXPECT_NEAR(tip_positions[4][2], 1.332200967141842, 1e-8);
 
-    EXPECT_NEAR(tip_positions[5][0], 0.025236057024605074, 1e-8);
+    EXPECT_NEAR(tip_positions[5][0], 0.022656037313893762, 1e-8);
     EXPECT_NEAR(tip_positions[5][1], 0., 1e-8);
-    EXPECT_NEAR(tip_positions[5][2], 0.0019647592579388196, 1e-8);
+    EXPECT_NEAR(tip_positions[5][2], 0.0022466646330885354, 1e-8);
 }
 
 }  // namespace openturbine::tests


### PR DESCRIPTION
The blade interface included an option to space the nodes linearly along the beam instead of at the GLL points. Based on feedback, this option is being removed and the StaticCurledBeam regression test results are updated to match (minor numerical differences)