### PR TITLE
Update to use Kokkos 4.6 and remove usage of KokkosKernels' gesv call which breaks Spack

### DIFF
--- a/.github/workflows/correctness-linux.yaml
+++ b/.github/workflows/correctness-linux.yaml
@@ -38,7 +38,7 @@ jobs:
         spack install yaml-cpp
         spack install suite-sparse
         spack install superlu
-        spack install lapacke
+        spack install lapack
         spack install kokkos-kernels
     - name: Clone
       uses: actions/checkout@v4
@@ -55,7 +55,7 @@ jobs:
         spack load cppcheck
         spack load netcdf-c
         spack load yaml-cpp
-        spack load lapacke
+        spack load lapack
         cd openturbine
         mkdir build
         cd build

--- a/.github/workflows/correctness-linux.yaml
+++ b/.github/workflows/correctness-linux.yaml
@@ -38,7 +38,7 @@ jobs:
         spack install yaml-cpp
         spack install suite-sparse
         spack install superlu
-        spack install lapack
+        spack install lapacke
         spack install kokkos-kernels
     - name: Clone
       uses: actions/checkout@v4
@@ -55,7 +55,7 @@ jobs:
         spack load cppcheck
         spack load netcdf-c
         spack load yaml-cpp
-        spack load lapack
+        spack load lapacke
         cd openturbine
         mkdir build
         cd build

--- a/.github/workflows/correctness-linux.yaml
+++ b/.github/workflows/correctness-linux.yaml
@@ -25,11 +25,11 @@ jobs:
       uses: actions/cache@v3
       with:
         path: ${{ github.workspace }}/spack
-        key: linux-spack_v2
+        key: linux-spack_v3
     - name: Install Dependencies
       if: steps.cache-dependencies.outputs.cache-hit != 'true'
       run: |
-        git clone -b before-compiler-dependencies https://github.com/spack/spack.git
+        git clone https://github.com/spack/spack.git
         source spack/share/spack/setup-env.sh
         spack compiler find
         spack install googletest
@@ -38,7 +38,8 @@ jobs:
         spack install yaml-cpp
         spack install suite-sparse
         spack install superlu
-        spack install kokkos-kernels+blas+lapack
+        spack install lapack
+        spack install kokkos-kernels
     - name: Clone
       uses: actions/checkout@v4
       with:
@@ -54,6 +55,7 @@ jobs:
         spack load cppcheck
         spack load netcdf-c
         spack load yaml-cpp
+        spack load lapack
         cd openturbine
         mkdir build
         cd build

--- a/.github/workflows/correctness-macos.yaml
+++ b/.github/workflows/correctness-macos.yaml
@@ -37,7 +37,7 @@ jobs:
         spack install yaml-cpp
         spack install suite-sparse
         spack install superlu
-        spack install lapack
+        spack install lapacke
         spack install kokkos-kernels
     - name: Clone
       uses: actions/checkout@v4
@@ -57,7 +57,7 @@ jobs:
         spack load cppcheck
         spack load googletest
         spack load yaml-cpp
-        spack load lapack
+        spack load lapacke
         cd openturbine
         mkdir build
         cd build

--- a/.github/workflows/correctness-macos.yaml
+++ b/.github/workflows/correctness-macos.yaml
@@ -37,7 +37,7 @@ jobs:
         spack install yaml-cpp
         spack install suite-sparse
         spack install superlu
-        spack install lapacke
+        spack install lapack
         spack install kokkos-kernels
     - name: Clone
       uses: actions/checkout@v4
@@ -57,7 +57,7 @@ jobs:
         spack load cppcheck
         spack load googletest
         spack load yaml-cpp
-        spack load lapacke
+        spack load lapack
         cd openturbine
         mkdir build
         cd build

--- a/.github/workflows/correctness-macos.yaml
+++ b/.github/workflows/correctness-macos.yaml
@@ -24,11 +24,11 @@ jobs:
       uses: actions/cache@v3
       with:
         path: ${{ github.workspace }}/spack
-        key: macos-spack_v2
+        key: macos-spack_v3
     - name: Install Dependencies
       if: steps.cache-dependencies.outputs.cache-hit != 'true'
       run: |
-        git clone -b before-compiler-dependencies https://github.com/spack/spack.git
+        git clone https://github.com/spack/spack.git
         source spack/share/spack/setup-env.sh
         spack compiler find
         spack external find
@@ -37,7 +37,8 @@ jobs:
         spack install yaml-cpp
         spack install suite-sparse
         spack install superlu
-        spack install kokkos-kernels+blas+lapack
+        spack install lapack
+        spack install kokkos-kernels
     - name: Clone
       uses: actions/checkout@v4
       with:
@@ -56,6 +57,7 @@ jobs:
         spack load cppcheck
         spack load googletest
         spack load yaml-cpp
+        spack load lapack
         cd openturbine
         mkdir build
         cd build

--- a/.github/workflows/deploy_docs.yaml
+++ b/.github/workflows/deploy_docs.yaml
@@ -32,7 +32,7 @@ jobs:
         spack install yaml-cpp
         spack install suite-sparse
         spack install superlu
-        spack install lapacke
+        spack install lapack
         spack install kokkos-kernels
     - name: Set up Python
       uses: actions/setup-python@v5
@@ -51,7 +51,7 @@ jobs:
     - name: Build OpenTurbine with documentation
       run: |
         source spack/share/spack/setup-env.sh
-        spack load kokkos-kernels yaml-cpp netcdf-c suite-sparse superlu lapacke
+        spack load kokkos-kernels yaml-cpp netcdf-c suite-sparse superlu lapack
         cd openturbine
         mkdir build
         cd build

--- a/.github/workflows/deploy_docs.yaml
+++ b/.github/workflows/deploy_docs.yaml
@@ -32,7 +32,7 @@ jobs:
         spack install yaml-cpp
         spack install suite-sparse
         spack install superlu
-        spack install lapack
+        spack install lapacke
         spack install kokkos-kernels
     - name: Set up Python
       uses: actions/setup-python@v5
@@ -51,7 +51,7 @@ jobs:
     - name: Build OpenTurbine with documentation
       run: |
         source spack/share/spack/setup-env.sh
-        spack load kokkos-kernels yaml-cpp netcdf-c suite-sparse superlu lapack
+        spack load kokkos-kernels yaml-cpp netcdf-c suite-sparse superlu lapacke
         cd openturbine
         mkdir build
         cd build

--- a/.github/workflows/deploy_docs.yaml
+++ b/.github/workflows/deploy_docs.yaml
@@ -23,7 +23,7 @@ jobs:
     - name: Install Dependencies
       if: steps.cache-dependencies.outputs.cache-hit != 'true'
       run: |
-        git clone -b before-compiler-dependencies https://github.com/spack/spack.git
+        git clone https://github.com/spack/spack.git
         source spack/share/spack/setup-env.sh
         spack compiler find
         spack install googletest

--- a/.github/workflows/deploy_docs.yaml
+++ b/.github/workflows/deploy_docs.yaml
@@ -19,7 +19,7 @@ jobs:
       uses: actions/cache@v3
       with:
         path: ${{ github.workspace }}/spack
-        key: linux-spack_v2
+        key: linux-spack_v3
     - name: Install Dependencies
       if: steps.cache-dependencies.outputs.cache-hit != 'true'
       run: |
@@ -32,7 +32,8 @@ jobs:
         spack install yaml-cpp
         spack install suite-sparse
         spack install superlu
-        spack install kokkos-kernels+blas+lapack
+        spack install lapack
+        spack install kokkos-kernels
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
@@ -50,7 +51,7 @@ jobs:
     - name: Build OpenTurbine with documentation
       run: |
         source spack/share/spack/setup-env.sh
-        spack load kokkos-kernels yaml-cpp netcdf-c suite-sparse superlu
+        spack load kokkos-kernels yaml-cpp netcdf-c suite-sparse superlu lapack
         cd openturbine
         mkdir build
         cd build

--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -6,7 +6,7 @@ function(openturbine_setup_dependencies)
   find_package(yaml-cpp REQUIRED)
   find_package(HDF5 REQUIRED)
   find_package(NetCDF REQUIRED)
-  find_package(LAPACKE REQUIRED)
+  find_package(LAPACK REQUIRED)
 
   #--------------------------------------------------------------------------
   # Optional packages

--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -6,6 +6,7 @@ function(openturbine_setup_dependencies)
   find_package(yaml-cpp REQUIRED)
   find_package(HDF5 REQUIRED)
   find_package(NetCDF REQUIRED)
+  find_package(LAPACKE REQUIRED)
 
   #--------------------------------------------------------------------------
   # Optional packages

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -60,7 +60,6 @@ endif()
 target_link_system_libraries(openturbine_library PUBLIC
   KokkosKernels::kokkoskernels
   LAPACK::LAPACK
-  -llapacke
   ${YAML_CPP_TARGET}
   ${FS_LIB}
   ${NETCDF_TARGET}
@@ -117,9 +116,13 @@ add_shared_library(DISCON_ROTOR_TEST_CONTROLLER)
 # Set include directories
 #----------------------------------------
 find_path(LAPACKE_INCLUDE_DIRS lapacke.h)
-target_include_directories(openturbine_library
+target_include_directories(openturbine_library SYSTEM
   PUBLIC
   ${LAPACKE_INCLUDE_DIRS}
+)
+
+target_include_directories(openturbine_library
+  PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
   $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/src>
   $<INSTALL_INTERFACE:include/OpenTurbine>

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -59,6 +59,7 @@ endif()
 #--------------------------------------------------------------------------
 target_link_system_libraries(openturbine_library PUBLIC
   KokkosKernels::kokkoskernels
+  lapacke
   ${YAML_CPP_TARGET}
   ${FS_LIB}
   ${NETCDF_TARGET}

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -59,7 +59,8 @@ endif()
 #--------------------------------------------------------------------------
 target_link_system_libraries(openturbine_library PUBLIC
   KokkosKernels::kokkoskernels
-  lapacke
+  LAPACK::LAPACK
+  -llapacke
   ${YAML_CPP_TARGET}
   ${FS_LIB}
   ${NETCDF_TARGET}
@@ -115,8 +116,10 @@ add_shared_library(DISCON_ROTOR_TEST_CONTROLLER)
 #----------------------------------------
 # Set include directories
 #----------------------------------------
+find_path(LAPACKE_INCLUDE_DIRS lapacke.h)
 target_include_directories(openturbine_library
   PUBLIC
+  ${LAPACKE_INCLUDE_DIRS}
   $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
   $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/src>
   $<INSTALL_INTERFACE:include/OpenTurbine>

--- a/src/math/least_squares_fit.hpp
+++ b/src/math/least_squares_fit.hpp
@@ -4,8 +4,8 @@
 #include <stdexcept>
 #include <vector>
 
-#include <KokkosLapack_gesv.hpp>
 #include <Kokkos_Core.hpp>
+#include <lapacke.h>
 
 #include "elements/beams/interpolation.hpp"
 
@@ -166,7 +166,10 @@ inline std::vector<std::array<double, 3>> PerformLeastSquaresFitting(
     // Solve the least squares problem for each dimension of B
     const auto IPIV = Kokkos::View<int*, Kokkos::LayoutLeft, Kokkos::HostSpace>("IPIV", B.extent(0));
 
-    KokkosLapack::gesv(A, B, IPIV);
+    LAPACKE_dgesv(
+        LAPACK_COL_MAJOR, static_cast<int>(p), 3, A.data(), static_cast<int>(p), IPIV.data(),
+        B.data(), static_cast<int>(p)
+    );
 
     auto result = std::vector<std::array<double, 3>>(B.extent(0));
 

--- a/src/system/beams/calculate_quadrature_point_values.hpp
+++ b/src/system/beams/calculate_quadrature_point_values.hpp
@@ -38,7 +38,7 @@ struct CalculateQuadraturePointValues {
 
     KOKKOS_FUNCTION
     void operator()(Kokkos::TeamPolicy<>::member_type member) const {
-        using simd_type = Kokkos::Experimental::native_simd<double>;
+        using simd_type = Kokkos::Experimental::simd<double>;
         const auto i_elem = static_cast<size_t>(member.league_rank());
         const auto num_nodes = num_nodes_per_element(i_elem);
         const auto num_qps = num_qps_per_element(i_elem);

--- a/src/system/beams/integrate_stiffness_matrix.hpp
+++ b/src/system/beams/integrate_stiffness_matrix.hpp
@@ -21,8 +21,8 @@ struct IntegrateStiffnessMatrixElement {
 
     KOKKOS_FUNCTION
     void operator()(size_t ij_index) const {
-        using simd_type = Kokkos::Experimental::native_simd<double>;
-        using mask_type = Kokkos::Experimental::native_simd_mask<double>;
+        using simd_type = Kokkos::Experimental::simd<double>;
+        using mask_type = Kokkos::Experimental::simd_mask<double>;
         using tag_type = Kokkos::Experimental::element_aligned_tag;
         constexpr auto width = simd_type::size();
         const auto extra_component = num_nodes % width == 0U ? 0U : 1U;
@@ -36,33 +36,39 @@ struct IntegrateStiffnessMatrixElement {
         auto local_M_data = Kokkos::Array<simd_type, 36>{};
         const auto local_M = Kokkos::View<simd_type[6][6]>(local_M_data.data());
         for (auto k = 0U; k < num_qps; ++k) {
-            const auto w = qp_weight_(k);
-            const auto jacobian = qp_jacobian_(k);
-            const auto phi_i = shape_interp_(i_index, k);
+            const auto w = simd_type(qp_weight_(k));
+            const auto jacobian = simd_type(qp_jacobian_(k));
+            const auto phi_i = simd_type(shape_interp_(i_index, k));
             auto phi_j = simd_type{};
             Kokkos::Experimental::where(mask, phi_j)
                 .copy_from(&shape_interp_(j_index, k), tag_type());
-            const auto phi_prime_i = shape_deriv_(i_index, k);
+            const auto phi_prime_i = simd_type(shape_deriv_(i_index, k));
             auto phi_prime_j = simd_type{};
             Kokkos::Experimental::where(mask, phi_prime_j)
                 .copy_from(&shape_deriv_(j_index, k), tag_type());
-            const auto K = w * phi_i * phi_j * jacobian;
-            const auto P = w * (phi_i * phi_prime_j);
-            const auto C = w * (phi_prime_i * phi_prime_j / jacobian);
-            const auto O = w * (phi_prime_i * phi_j);
+            const auto K = (phi_i * phi_j) * (w * jacobian);
+            const auto P = (phi_i * phi_prime_j) * w;
+            const auto C = (phi_prime_i * phi_prime_j) * (w / jacobian);
+            const auto O = (phi_prime_i * phi_j) * w;
             for (auto m = 0U; m < 6U; ++m) {
-                local_M(m, 0) += K * (qp_Kuu_(k, m, 0) + qp_Quu_(k, m, 0)) + P * qp_Puu_(k, m, 0) +
-                                 C * qp_Cuu_(k, m, 0) + O * qp_Ouu_(k, m, 0);
-                local_M(m, 1) += K * (qp_Kuu_(k, m, 1) + qp_Quu_(k, m, 1)) + P * qp_Puu_(k, m, 1) +
-                                 C * qp_Cuu_(k, m, 1) + O * qp_Ouu_(k, m, 1);
-                local_M(m, 2) += K * (qp_Kuu_(k, m, 2) + qp_Quu_(k, m, 2)) + P * qp_Puu_(k, m, 2) +
-                                 C * qp_Cuu_(k, m, 2) + O * qp_Ouu_(k, m, 2);
-                local_M(m, 3) += K * (qp_Kuu_(k, m, 3) + qp_Quu_(k, m, 3)) + P * qp_Puu_(k, m, 3) +
-                                 C * qp_Cuu_(k, m, 3) + O * qp_Ouu_(k, m, 3);
-                local_M(m, 4) += K * (qp_Kuu_(k, m, 4) + qp_Quu_(k, m, 4)) + P * qp_Puu_(k, m, 4) +
-                                 C * qp_Cuu_(k, m, 4) + O * qp_Ouu_(k, m, 4);
-                local_M(m, 5) += K * (qp_Kuu_(k, m, 5) + qp_Quu_(k, m, 5)) + P * qp_Puu_(k, m, 5) +
-                                 C * qp_Cuu_(k, m, 5) + O * qp_Ouu_(k, m, 5);
+                local_M(m, 0) = local_M(m, 0) + K * simd_type(qp_Kuu_(k, m, 0) + qp_Quu_(k, m, 0)) +
+                                P * simd_type(qp_Puu_(k, m, 0)) + C * simd_type(qp_Cuu_(k, m, 0)) +
+                                O * simd_type(qp_Ouu_(k, m, 0));
+                local_M(m, 1) = local_M(m, 1) + K * simd_type(qp_Kuu_(k, m, 1) + qp_Quu_(k, m, 1)) +
+                                P * simd_type(qp_Puu_(k, m, 1)) + C * simd_type(qp_Cuu_(k, m, 1)) +
+                                O * simd_type(qp_Ouu_(k, m, 1));
+                local_M(m, 2) = local_M(m, 2) + K * simd_type(qp_Kuu_(k, m, 2) + qp_Quu_(k, m, 2)) +
+                                P * simd_type(qp_Puu_(k, m, 2)) + C * simd_type(qp_Cuu_(k, m, 2)) +
+                                O * simd_type(qp_Ouu_(k, m, 2));
+                local_M(m, 3) = local_M(m, 3) + K * simd_type(qp_Kuu_(k, m, 3) + qp_Quu_(k, m, 3)) +
+                                P * simd_type(qp_Puu_(k, m, 3)) + C * simd_type(qp_Cuu_(k, m, 3)) +
+                                O * simd_type(qp_Ouu_(k, m, 3));
+                local_M(m, 4) = local_M(m, 4) + K * simd_type(qp_Kuu_(k, m, 4) + qp_Quu_(k, m, 4)) +
+                                P * simd_type(qp_Puu_(k, m, 4)) + C * simd_type(qp_Cuu_(k, m, 4)) +
+                                O * simd_type(qp_Ouu_(k, m, 4));
+                local_M(m, 5) = local_M(m, 5) + K * simd_type(qp_Kuu_(k, m, 5) + qp_Quu_(k, m, 5)) +
+                                P * simd_type(qp_Puu_(k, m, 5)) + C * simd_type(qp_Cuu_(k, m, 5)) +
+                                O * simd_type(qp_Ouu_(k, m, 5));
             }
         }
         for (auto lane = 0U; lane < width && mask[lane]; ++lane) {

--- a/tests/regression_tests/CMakeLists.txt
+++ b/tests/regression_tests/CMakeLists.txt
@@ -54,7 +54,9 @@ if(OpenTurbine_BUILD_OPENFAST_ADI)
   target_compile_definitions(openturbine_regression_tests PRIVATE OpenTurbine_BUILD_OPENFAST_ADI)
 endif()
 
-target_include_directories(openturbine_regression_tests PRIVATE $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/tests/regression_tests>)
+target_include_directories(openturbine_regression_tests PRIVATE
+  $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/tests/regression_tests>
+)
 
 # Include GoogleTest module and discover tests
 include(GoogleTest)

--- a/tests/unit_tests/CMakeLists.txt
+++ b/tests/unit_tests/CMakeLists.txt
@@ -16,7 +16,9 @@ add_subdirectory(utilities)
 # Specify the source files for the unit tests
 target_sources(openturbine_unit_tests PRIVATE utest_main.cpp)
 
-target_include_directories(openturbine_unit_tests PRIVATE $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/tests/unit_tests>)
+target_include_directories(openturbine_unit_tests PRIVATE
+  $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/tests/unit_tests>
+)
 
 # Link internal libraries to the unit test executable
 target_link_libraries(openturbine_unit_tests PRIVATE

--- a/tests/unit_tests/system/beams/test_curved_beam.cpp
+++ b/tests/unit_tests/system/beams/test_curved_beam.cpp
@@ -275,7 +275,7 @@ TEST(CurvedBeamTests, IntegrateStiffnessMatrixForCurvedBeam) {
     const auto stiffness_matrix_terms =
         Kokkos::View<double[kNumNodes][kNumNodes][6][6]>("stiffness_matrix_terms");
 
-    constexpr auto simd_width = Kokkos::Experimental::native_simd<double>::size();
+    constexpr auto simd_width = Kokkos::Experimental::simd<double>::size();
     constexpr auto extra_component = kNumNodes % simd_width == 0U ? 0U : 1U;
     constexpr auto simd_nodes = kNumNodes / simd_width + extra_component;
     const auto policy = Kokkos::RangePolicy(0, kNumNodes * simd_nodes);

--- a/tests/unit_tests/system/beams/test_integrate_inertia_matrix.cpp
+++ b/tests/unit_tests/system/beams/test_integrate_inertia_matrix.cpp
@@ -108,7 +108,7 @@ TEST(IntegrateInertiaMatrixTests, OneElementOneNodeOneQP_Guu) {
 
 void IntegrateInertiaMatrix_TestOneElementTwoNodesOneQP() {
     constexpr auto number_of_nodes = size_t{2U};
-    constexpr auto simd_width = Kokkos::Experimental::native_simd<double>::size();
+    constexpr auto simd_width = Kokkos::Experimental::simd<double>::size();
     constexpr auto number_of_simd_nodes = (simd_width == 1) ? size_t{2U} : size_t{1U};
     constexpr auto number_of_qps = size_t{1U};
 

--- a/tests/unit_tests/system/beams/test_integrate_stiffness_matrix.cpp
+++ b/tests/unit_tests/system/beams/test_integrate_stiffness_matrix.cpp
@@ -202,7 +202,7 @@ void TestIntegrateStiffnessMatrix_1Element2Nodes1QP(
     const std::array<double, 144>& exact_M_data
 ) {
     constexpr auto number_of_nodes = size_t{2U};
-    constexpr auto simd_width = Kokkos::Experimental::native_simd<double>::size();
+    constexpr auto simd_width = Kokkos::Experimental::simd<double>::size();
     constexpr auto number_of_simd_nodes = (simd_width == 1) ? size_t{2U} : size_t{1U};
     constexpr auto number_of_qps = size_t{1U};
 


### PR DESCRIPTION
This will allow us to no longer require that Kokkos Kernels is built with +blas+lapack when building with Spack.  This circumvents a bug in their Spack packages which prevents building with those options enabled.

Due to API changes, the minimum required version of Kokkos/Kokkos Kernels is now 4.6