### PR TITLE
Fixed segfault when using SuperLU with larger problems

### DIFF
--- a/src/solver/linear_solver/dss_handle_superlu.hpp
+++ b/src/solver/linear_solver/dss_handle_superlu.hpp
@@ -14,7 +14,6 @@ class DSSHandle<DSSAlgorithm::SUPERLU> {
         std::vector<int> perm_r;
         std::vector<int> perm_c;
         std::vector<int> etree;
-        std::vector<char> work;
 
         superluDssHandleType() {
             set_default_options(&options);
@@ -47,7 +46,6 @@ public:
 
     std::vector<int>& get_perm_c() { return superlu_dss_handle->perm_c; }
     std::vector<int>& get_etree() { return superlu_dss_handle->etree; }
-    std::vector<char>& get_work() { return superlu_dss_handle->work; }
 };
 
 }  // namespace openturbine

--- a/src/solver/linear_solver/dss_numeric_superlu.hpp
+++ b/src/solver/linear_solver/dss_numeric_superlu.hpp
@@ -36,8 +36,8 @@ struct DSSNumericFunction<DSSHandle<DSSAlgorithm::SUPERLU>, CrsMatrixType> {
         SuperMatrix AC;
         sp_preorder(&options, &Amatrix, perm_c.data(), etree.data(), &AC);
         dgstrf(
-            &options, &AC, relax, panel_size, etree.data(), nullptr,
-            0, perm_c.data(), perm_r.data(), &L, &U, &Glu, &stat, &info
+            &options, &AC, relax, panel_size, etree.data(), nullptr, 0, perm_c.data(), perm_r.data(),
+            &L, &U, &Glu, &stat, &info
         );
 
         Destroy_CompCol_Permuted(&AC);

--- a/src/solver/linear_solver/dss_numeric_superlu.hpp
+++ b/src/solver/linear_solver/dss_numeric_superlu.hpp
@@ -23,7 +23,6 @@ struct DSSNumericFunction<DSSHandle<DSSAlgorithm::SUPERLU>, CrsMatrixType> {
         auto& perm_r = dss_handle.get_perm_r();
         auto& perm_c = dss_handle.get_perm_c();
         auto& etree = dss_handle.get_etree();
-        auto& work = dss_handle.get_work();
 
         SuperMatrix Amatrix;
         dCreate_CompCol_Matrix(
@@ -37,8 +36,8 @@ struct DSSNumericFunction<DSSHandle<DSSAlgorithm::SUPERLU>, CrsMatrixType> {
         SuperMatrix AC;
         sp_preorder(&options, &Amatrix, perm_c.data(), etree.data(), &AC);
         dgstrf(
-            &options, &AC, relax, panel_size, etree.data(), work.data(),
-            static_cast<int>(work.size()), perm_c.data(), perm_r.data(), &L, &U, &Glu, &stat, &info
+            &options, &AC, relax, panel_size, etree.data(), nullptr,
+            0, perm_c.data(), perm_r.data(), &L, &U, &Glu, &stat, &info
         );
 
         Destroy_CompCol_Permuted(&AC);

--- a/src/solver/linear_solver/dss_symbolic_superlu.hpp
+++ b/src/solver/linear_solver/dss_symbolic_superlu.hpp
@@ -17,14 +17,9 @@ struct DSSSymbolicFunction<DSSHandle<DSSAlgorithm::SUPERLU>, CrsMatrixType> {
 
         auto& options = dss_handle.get_options();
         options.Fact = DOFACT;
-        auto& stat = dss_handle.get_stat();
-        auto& L = dss_handle.get_L();
-        auto& U = dss_handle.get_U();
-        auto& Glu = dss_handle.get_Glu();
         auto& perm_r = dss_handle.get_perm_r();
         auto& perm_c = dss_handle.get_perm_c();
         auto& etree = dss_handle.get_etree();
-        auto& work = dss_handle.get_work();
 
         perm_r.resize(static_cast<size_t>(num_rows));
         perm_c.resize(static_cast<size_t>(num_cols));
@@ -36,20 +31,6 @@ struct DSSSymbolicFunction<DSSHandle<DSSAlgorithm::SUPERLU>, CrsMatrixType> {
             const_cast<int*>(row_ptrs.data()), SLU_NC, SLU_D, SLU_GE
         );
         get_perm_c(options.ColPerm, &Amatrix, perm_c.data());
-
-        constexpr auto relax = 1;
-        constexpr auto panel_size = 1;
-        auto info = 0;
-
-        SuperMatrix AC;
-        sp_preorder(&options, &Amatrix, perm_c.data(), etree.data(), &AC);
-        dgstrf(
-            &options, &AC, relax, panel_size, etree.data(), nullptr, -1, perm_c.data(),
-            perm_r.data(), &L, &U, &Glu, &stat, &info
-        );
-        if (static_cast<size_t>(info) > work.size()) {
-            work.resize(static_cast<size_t>(1.2 * info));
-        }
     }
 };
 


### PR DESCRIPTION
The preallocated work vector, even when given an expansion factor of 100x, was not enough memory for the larger problem.  While this comes with a performance penalty for small problems, the improved robustness is necessary