### PR TITLE
Rename OpenTurbine_BUILD_OPENFAST_ADI and OpenTurbine_BUILD_ROSCO_CONTROLLER to ENABLE

### DIFF
--- a/.github/workflows/correctness-linux.yaml
+++ b/.github/workflows/correctness-linux.yaml
@@ -66,8 +66,8 @@ jobs:
           -DOpenTurbine_ENABLE_CPPCHECK=ON \
           -DOpenTurbine_ENABLE_CLANG_TIDY=ON \
           -DOpenTurbine_WARNINGS_AS_ERRORS=ON \
-          -DOpenTurbine_BUILD_OPENFAST_ADI=${{ matrix.build_external == 'all' }} \
-          -DOpenTurbine_BUILD_ROSCO_CONTROLLER=${{ matrix.build_external == 'all' }} \
+          -DOpenTurbine_ENABLE_OPENFAST_ADI=${{ matrix.build_external == 'all' }} \
+          -DOpenTurbine_ENABLE_ROSCO_CONTROLLER=${{ matrix.build_external == 'all' }} \
           -DOpenTurbine_ENABLE_KLU=ON \
           -DOpenTurbine_ENABLE_UMFPACK=ON \
           -DOpenTurbine_ENABLE_SUPERLU=ON \

--- a/.github/workflows/correctness-macos.yaml
+++ b/.github/workflows/correctness-macos.yaml
@@ -69,8 +69,8 @@ jobs:
           -DOpenTurbine_ENABLE_CLANG_TIDY=ON \
           -DOpenTurbine_WRITE_OUTPUTS=ON \
           -DOpenTurbine_WARNINGS_AS_ERRORS=ON \
-          -DOpenTurbine_BUILD_OPENFAST_ADI=${{ matrix.build_external == 'all' }} \
-          -DOpenTurbine_BUILD_ROSCO_CONTROLLER=${{ matrix.build_external == 'all' }} \
+          -DOpenTurbine_ENABLE_OPENFAST_ADI=${{ matrix.build_external == 'all' }} \
+          -DOpenTurbine_ENABLE_ROSCO_CONTROLLER=${{ matrix.build_external == 'all' }} \
           -DOpenTurbine_ENABLE_KLU=ON \
           -DOpenTurbine_ENABLE_UMFPACK=ON \
           -DOpenTurbine_ENABLE_SUPERLU=ON \

--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -68,7 +68,7 @@ function(openturbine_setup_dependencies)
   #----------------------------------------
   # OpenFAST/AerodynInflow (ADI) library
   #----------------------------------------
-  if(OpenTurbine_BUILD_OPENFAST_ADI)
+  if(OpenTurbine_ENABLE_OPENFAST_ADI)
     message(STATUS "Building OpenFAST AerodynInflow (ADI) library")
     include(ExternalProject)
     ExternalProject_Add(OpenFAST_ADI
@@ -95,7 +95,7 @@ function(openturbine_setup_dependencies)
   #----------------------------------------
   # ROSCO Controller library
   #----------------------------------------
-  if(OpenTurbine_BUILD_ROSCO_CONTROLLER)
+  if(OpenTurbine_ENABLE_ROSCO_CONTROLLER)
     if (NOT ROSCO_BUILD_TAG)
       set(ROSCO_BUILD_TAG "v2.9.4")
     endif()

--- a/cmake/OpenTurbineOptions.cmake
+++ b/cmake/OpenTurbineOptions.cmake
@@ -44,8 +44,8 @@ macro(openturbine_setup_options)
   option(OpenTurbine_ENABLE_UMFPACK "Use UMFPACK for sparse linear solver when running on CPU" OFF)
   option(OpenTurbine_ENABLE_SUPERLU "Use SuperLU for sparse linear solver when running on CPU" OFF)
   option(OpenTurbine_ENABLE_SUPERLU_MT "Use SuperLU-MT for sparse linear solver when running on CPU" OFF)
-  option(OpenTurbine_BUILD_OPENFAST_ADI "Build the OpenFAST ADI external project" OFF)
-  option(OpenTurbine_BUILD_ROSCO_CONTROLLER "Build the ROSCO controller external project" OFF)
+  option(OpenTurbine_ENABLE_OPENFAST_ADI "Build the OpenFAST ADI external project" OFF)
+  option(OpenTurbine_ENABLE_ROSCO_CONTROLLER "Build the ROSCO controller external project" OFF)
 endmacro()
 
 #--------------------------------------------------------------------------

--- a/recipes/Dockerfile
+++ b/recipes/Dockerfile
@@ -47,8 +47,8 @@ COPY . .
 
 # Step 4: Load necessary libraries and build the project
 ARG CMAKE_OPTIONS="-DOpenTurbine_WRITE_OUTPUTS=ON \
-    -DOpenTurbine_BUILD_OPENFAST_ADI=ON \
-    -DOpenTurbine_BUILD_ROSCO_CONTROLLER=ON \
+    -DOpenTurbine_ENABLE_OPENFAST_ADI=ON \
+    -DOpenTurbine_ENABLE_ROSCO_CONTROLLER=ON \
     -DCMAKE_BUILD_TYPE=Release"
 
 ARG N_PARALLEL_JOBS=4

--- a/recipes/build_recipe_cuda.sh
+++ b/recipes/build_recipe_cuda.sh
@@ -65,8 +65,8 @@ cd build-from-script
 cmake .. \
   -DCMAKE_CXX_COMPILER=nvcc_wrapper \
   -DOpenTurbine_WRITE_OUTPUTS=ON \
-  -DOpenTurbine_BUILD_OPENFAST_ADI=ON \
-  -DOpenTurbine_BUILD_ROSCO_CONTROLLER=ON \
+  -DOpenTurbine_ENABLE_OPENFAST_ADI=ON \
+  -DOpenTurbine_ENABLE_ROSCO_CONTROLLER=ON \
   -DOpenTurbine_ENABLE_CUSOLVERSP=ON \
   -DCMAKE_BUILD_TYPE="Release"
 

--- a/recipes/build_recipe_linux.sh
+++ b/recipes/build_recipe_linux.sh
@@ -57,8 +57,8 @@ mkdir -p build-from-script
 cd build-from-script
 cmake .. \
   -DOpenTurbine_WRITE_OUTPUTS=ON \
-  -DOpenTurbine_BUILD_OPENFAST_ADI=ON \
-  -DOpenTurbine_BUILD_ROSCO_CONTROLLER=ON \
+  -DOpenTurbine_ENABLE_OPENFAST_ADI=ON \
+  -DOpenTurbine_ENABLE_ROSCO_CONTROLLER=ON \
   -DOpenTurbine_ENABLE_KLU=ON \
   -DCMAKE_BUILD_TYPE="Release"
 

--- a/recipes/build_recipe_macos.sh
+++ b/recipes/build_recipe_macos.sh
@@ -57,8 +57,8 @@ mkdir -p build-from-script
 cd build-from-script
 cmake .. \
   -DOpenTurbine_WRITE_OUTPUTS=ON \
-  -DOpenTurbine_BUILD_OPENFAST_ADI=ON \
-  -DOpenTurbine_BUILD_ROSCO_CONTROLLER=ON \
+  -DOpenTurbine_ENABLE_OPENFAST_ADI=ON \
+  -DOpenTurbine_ENABLE_ROSCO_CONTROLLER=ON \
   -DOpenTurbine_ENABLE_KLU=ON \
   -DCMAKE_BUILD_TYPE="Release"
 

--- a/recipes/build_recipe_rocm.sh
+++ b/recipes/build_recipe_rocm.sh
@@ -66,8 +66,8 @@ cd build-from-script
 cmake .. \
   -DCMAKE_CXX_COMPILER=hipcc \
   -DOpenTurbine_WRITE_OUTPUTS=ON \
-  -DOpenTurbine_BUILD_OPENFAST_ADI=ON \
-  -DOpenTurbine_BUILD_ROSCO_CONTROLLER=ON \
+  -DOpenTurbine_ENABLE_OPENFAST_ADI=ON \
+  -DOpenTurbine_ENABLE_ROSCO_CONTROLLER=ON \
   -DOpenTUrbine_ENABLE_KLU=ON \
   -DCMAKE_BUILD_TYPE="Release"
 

--- a/tests/regression_tests/CMakeLists.txt
+++ b/tests/regression_tests/CMakeLists.txt
@@ -48,9 +48,9 @@ if(OpenTurbine_WRITE_OUTPUTS)
   target_compile_definitions(openturbine_regression_tests PRIVATE OpenTurbine_WRITE_OUTPUTS)
 endif()
 
-# Add compile definitions for OpenTurbine_BUILD_OPENFAST_ADI if enabled
-if(OpenTurbine_BUILD_OPENFAST_ADI)
-  target_compile_definitions(openturbine_regression_tests PRIVATE OpenTurbine_BUILD_OPENFAST_ADI)
+# Add compile definitions for OpenTurbine_ENABLE_OPENFAST_ADI if enabled
+if(OpenTurbine_ENABLE_OPENFAST_ADI)
+  target_compile_definitions(openturbine_regression_tests PRIVATE OpenTurbine_ENABLE_OPENFAST_ADI)
 endif()
 
 target_include_directories(openturbine_regression_tests PRIVATE

--- a/tests/regression_tests/external/CMakeLists.txt
+++ b/tests/regression_tests/external/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Test ROSCO controller
-if (OpenTurbine_BUILD_ROSCO_CONTROLLER AND
+if (OpenTurbine_ENABLE_ROSCO_CONTROLLER AND
     (NOT OpenTurbine_ENABLE_SANITIZER_LEAK))
     target_sources(
         openturbine_regression_tests
@@ -9,8 +9,8 @@ if (OpenTurbine_BUILD_ROSCO_CONTROLLER AND
 endif()
 
 # Test AeroDyn Inflow
-if (OpenTurbine_BUILD_OPENFAST_ADI AND
-    OpenTurbine_BUILD_ROSCO_CONTROLLER AND
+if (OpenTurbine_ENABLE_OPENFAST_ADI AND
+    OpenTurbine_ENABLE_ROSCO_CONTROLLER AND
     (NOT OpenTurbine_ENABLE_SANITIZER_LEAK))
     target_sources(
         openturbine_regression_tests


### PR DESCRIPTION
Now that we don't build these TPLs, the new name is more descriptive.