### PR TITLE
Removed IO from TwoBeams test and added a check for convergence.

### DIFF
--- a/tests/regression_tests/interfaces/test_blade_interface.cpp
+++ b/tests/regression_tests/interfaces/test_blade_interface.cpp
@@ -367,12 +367,10 @@ TEST(BladeInterfaceTest, TwoBeams) {
     auto [state, elements, constraints] = model.CreateSystem();
     auto solver = CreateSolver<>(state, elements, constraints);
 
-    Step(parameters, solver, elements, state, constraints);
-
-    for (auto i = 0U; i < solver.b.size(); ++i) {
-        std::cout << "b[" << i << "] = " << solver.b(i, 0) << "\n";
+    for (auto step = 0; step < 1000; ++step) {
+        const auto converged = Step(parameters, solver, elements, state, constraints);
+        ASSERT_TRUE(converged);
     }
-    KokkosSparse::Impl::write_kokkos_crst_matrix(solver.A, "A.mtx");
 }
 
 TEST(BladeInterfaceTest, StaticCurledBeam) {

--- a/tests/regression_tests/regression/test_rotating_beam.cpp
+++ b/tests/regression_tests/regression/test_rotating_beam.cpp
@@ -198,9 +198,9 @@ inline void CreateTwoBeamSolverWithSameBeamsAndStep() {
             constexpr auto q_root = std::array{1., 0., 0., 0.};
 
             // Declare list of element nodes
-            std::vector<size_t> beam_node_ids;
+            std::vector<size_t> beam_node_ids(node_s.size());
             std::transform(
-                std::cbegin(node_s), std::cend(node_s), std::back_inserter(beam_node_ids),
+                std::cbegin(node_s), std::cend(node_s), std::begin(beam_node_ids),
                 [&](auto s) {
                     const auto pos = RotateVectorByQuaternion(q_root, {10. * s + 2., 0., 0.});
                     const auto v = CrossProduct(omega, pos);
@@ -293,9 +293,9 @@ TEST(RotatingBeamTest, ThreeBladeRotor) {
             const auto q_root = RotationVectorToQuaternion({0., 0., 2. * M_PI * i / num_blades});
 
             // Declare list of element nodes
-            std::vector<size_t> beam_node_ids;
+            std::vector<size_t> beam_node_ids(node_s.size());
             std::transform(
-                std::cbegin(node_s), std::cend(node_s), std::back_inserter(beam_node_ids),
+                std::cbegin(node_s), std::cend(node_s), std::begin(beam_node_ids),
                 [&](auto s) {
                     const auto pos = RotateVectorByQuaternion(q_root, {10. * s + 2., 0., 0.});
                     auto v = CrossProduct(omega, pos);


### PR DESCRIPTION
I could not add a test for changes in the values - the changes are very small and are different with different solvers, even when many iterations are performed.

Also fixed warning that showed up in test_rotating_beam