### PR TITLE
Fixes Turbine Interface test runs on GPU, which may fail due to uninitialized memory.

### DIFF
--- a/src/interfaces/turbine/turbine_interface.hpp
+++ b/src/interfaces/turbine/turbine_interface.hpp
@@ -86,6 +86,7 @@ public:
      */
     [[nodiscard]] bool Step() {
         // Update the host state with current node loads
+        Kokkos::deep_copy(this->host_state.f, 0.);
         this->turbine.SetLoads(this->host_state);
         Kokkos::deep_copy(this->state.f, this->host_state.f);
 


### PR DESCRIPTION
This change will also take into account if applied force locations are changed between steps