### PR TITLE
Changed .gitignore to ignore all folders starting with build.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
-build/
+build*
 _build/
 .vscode/


### PR DESCRIPTION
This cleans up `git status` calls when you have multiple build directories