### PR TITLE
Proliferated Kokkos::atomic_add usage to places where it may be necessary.

### DIFF
--- a/src/constraints/update_lambda_prediction.hpp
+++ b/src/constraints/update_lambda_prediction.hpp
@@ -21,7 +21,9 @@ struct UpdateLambdaPrediction {
             !std::is_same_v<typename DeviceType::execution_space, Kokkos::Serial>;
         for (auto row = first_index; row < max_index; ++row) {
             if constexpr (force_atomic) {
-                Kokkos::atomic_add(&lambda(i_constraint, row - first_index), x(num_system_dofs + row, 0));
+                Kokkos::atomic_add(
+                    &lambda(i_constraint, row - first_index), x(num_system_dofs + row, 0)
+                );
             } else {
                 lambda(i_constraint, row - first_index) += x(num_system_dofs + row, 0);
             }

--- a/src/solver/contribute_constraints_system_residual_to_vector.hpp
+++ b/src/solver/contribute_constraints_system_residual_to_vector.hpp
@@ -14,9 +14,15 @@ struct ContributeConstraintsSystemResidualToVector {
     KOKKOS_FUNCTION
     void operator()(size_t i_constraint) const {
         const auto num_dofs = target_active_dofs(i_constraint);
+        constexpr auto force_atomic =
+            !std::is_same_v<typename DeviceType::execution_space, Kokkos::Serial>;
         for (auto i = 0U; i < num_dofs; ++i) {
-            residual(target_node_freedom_table(i_constraint, i), 0) +=
-                system_residual_terms(i_constraint, i);
+            if constexpr (force_atomic) {
+                Kokkos::atomic_add(&residual(target_node_freedom_table(i_constraint, i), 0), system_residual_terms(i_constraint, i));
+            } else {
+                residual(target_node_freedom_table(i_constraint, i), 0) +=
+                    system_residual_terms(i_constraint, i);
+            }
         }
     }
 };

--- a/src/solver/contribute_constraints_system_residual_to_vector.hpp
+++ b/src/solver/contribute_constraints_system_residual_to_vector.hpp
@@ -18,7 +18,10 @@ struct ContributeConstraintsSystemResidualToVector {
             !std::is_same_v<typename DeviceType::execution_space, Kokkos::Serial>;
         for (auto i = 0U; i < num_dofs; ++i) {
             if constexpr (force_atomic) {
-                Kokkos::atomic_add(&residual(target_node_freedom_table(i_constraint, i), 0), system_residual_terms(i_constraint, i));
+                Kokkos::atomic_add(
+                    &residual(target_node_freedom_table(i_constraint, i), 0),
+                    system_residual_terms(i_constraint, i)
+                );
             } else {
                 residual(target_node_freedom_table(i_constraint, i), 0) +=
                     system_residual_terms(i_constraint, i);

--- a/src/solver/contribute_masses_to_vector.hpp
+++ b/src/solver/contribute_masses_to_vector.hpp
@@ -16,7 +16,9 @@ struct ContributeMassesToVector {
             !std::is_same_v<typename DeviceType::execution_space, Kokkos::Serial>;
         for (auto j = 0U; j < element_freedom_table.extent(1); ++j) {
             if constexpr (force_atomic) {
-                Kokkos::atomic_add(&vector(element_freedom_table(i_elem, j), 0), elements(i_elem, j));
+                Kokkos::atomic_add(
+                    &vector(element_freedom_table(i_elem, j), 0), elements(i_elem, j)
+                );
             } else {
                 vector(element_freedom_table(i_elem, j), 0) += elements(i_elem, j);
             }

--- a/src/solver/contribute_masses_to_vector.hpp
+++ b/src/solver/contribute_masses_to_vector.hpp
@@ -12,8 +12,14 @@ struct ContributeMassesToVector {
 
     KOKKOS_FUNCTION
     void operator()(size_t i_elem) const {
+        constexpr auto force_atomic =
+            !std::is_same_v<typename DeviceType::execution_space, Kokkos::Serial>;
         for (auto j = 0U; j < element_freedom_table.extent(1); ++j) {
-            vector(element_freedom_table(i_elem, j), 0) += elements(i_elem, j);
+            if constexpr (force_atomic) {
+                Kokkos::atomic_add(&vector(element_freedom_table(i_elem, j), 0), elements(i_elem, j));
+            } else {
+                vector(element_freedom_table(i_elem, j), 0) += elements(i_elem, j);
+            }
         }
     }
 };

--- a/src/solver/copy_constraints_residual_to_vector.hpp
+++ b/src/solver/copy_constraints_residual_to_vector.hpp
@@ -15,8 +15,14 @@ struct CopyConstraintsResidualToVector {
     void operator()(size_t i_constraint) const {
         const auto first_row = row_range(i_constraint).first + start_row;
         const auto num_rows = row_range(i_constraint).second - row_range(i_constraint).first;
+        constexpr auto force_atomic =
+            !std::is_same_v<typename DeviceType::execution_space, Kokkos::Serial>;
         for (auto i = 0U; i < num_rows; ++i) {
-            residual(first_row + i, 0) = constraint_residual_terms(i_constraint, i);
+            if constexpr (force_atomic) {
+                Kokkos::atomic_add(&residual(first_row + i, 0), constraint_residual_terms(i_constraint, i));
+            } else {
+                residual(first_row + i, 0) = constraint_residual_terms(i_constraint, i);
+            }
         }
     }
 };

--- a/src/solver/copy_constraints_residual_to_vector.hpp
+++ b/src/solver/copy_constraints_residual_to_vector.hpp
@@ -19,7 +19,9 @@ struct CopyConstraintsResidualToVector {
             !std::is_same_v<typename DeviceType::execution_space, Kokkos::Serial>;
         for (auto i = 0U; i < num_rows; ++i) {
             if constexpr (force_atomic) {
-                Kokkos::atomic_add(&residual(first_row + i, 0), constraint_residual_terms(i_constraint, i));
+                Kokkos::atomic_add(
+                    &residual(first_row + i, 0), constraint_residual_terms(i_constraint, i)
+                );
             } else {
                 residual(first_row + i, 0) = constraint_residual_terms(i_constraint, i);
             }

--- a/src/solver/copy_constraints_to_sparse_matrix.hpp
+++ b/src/solver/copy_constraints_to_sparse_matrix.hpp
@@ -45,7 +45,9 @@ struct CopyConstraintsToSparseMatrix {
             );
             for (auto entry = 0U; entry < num_base_dofs; ++entry, ++offset) {
                 if constexpr (force_atomic) {
-                    Kokkos::atomic_add(&row.value(offset), base_dense(i_constraint, row_number, entry));
+                    Kokkos::atomic_add(
+                        &row.value(offset), base_dense(i_constraint, row_number, entry)
+                    );
                 } else {
                     row.value(offset) = base_dense(i_constraint, row_number, entry);
                 }
@@ -59,7 +61,9 @@ struct CopyConstraintsToSparseMatrix {
             );
             for (auto entry = 0U; entry < num_target_dofs; ++entry, ++offset) {
                 if constexpr (force_atomic) {
-                    Kokkos::atomic_add(&row.value(offset), target_dense(i_constraint, row_number, entry));
+                    Kokkos::atomic_add(
+                        &row.value(offset), target_dense(i_constraint, row_number, entry)
+                    );
                 } else {
                     row.value(offset) = target_dense(i_constraint, row_number, entry);
                 }

--- a/src/solver/copy_constraints_transpose_to_sparse_matrix.hpp
+++ b/src/solver/copy_constraints_transpose_to_sparse_matrix.hpp
@@ -48,7 +48,9 @@ struct CopyConstraintsTransposeToSparseMatrix {
                 );
                 for (auto entry = 0; entry < num_cols; ++entry, ++offset) {
                     if constexpr (force_atomic) {
-                        Kokkos::atomic_add(&row.value(offset), base_dense(i_constraint, row_number, entry));
+                        Kokkos::atomic_add(
+                            &row.value(offset), base_dense(i_constraint, row_number, entry)
+                        );
                     } else {
                         row.value(offset) = base_dense(i_constraint, row_number, entry);
                     }
@@ -72,7 +74,9 @@ struct CopyConstraintsTransposeToSparseMatrix {
                 );
                 for (auto entry = 0; entry < num_cols; ++entry, ++offset) {
                     if constexpr (force_atomic) {
-                        Kokkos::atomic_add(&row.value(offset), target_dense(i_constraint, row_number, entry));
+                        Kokkos::atomic_add(
+                            &row.value(offset), target_dense(i_constraint, row_number, entry)
+                        );
                     } else {
                         row.value(offset) = target_dense(i_constraint, row_number, entry);
                     }

--- a/src/solver/copy_constraints_transpose_to_sparse_matrix.hpp
+++ b/src/solver/copy_constraints_transpose_to_sparse_matrix.hpp
@@ -25,6 +25,8 @@ struct CopyConstraintsTransposeToSparseMatrix {
     void operator()(member_type member) const {
         const auto i_constraint = member.league_rank();
         constexpr bool is_sorted = true;
+        constexpr auto force_atomic =
+            !std::is_same_v<typename DeviceType::execution_space, Kokkos::Serial>;
         const auto num_cols =
             static_cast<int>(row_range(i_constraint).second - row_range(i_constraint).first);
         const auto first_col = static_cast<typename CrsMatrixType::ordinal_type>(
@@ -45,7 +47,11 @@ struct CopyConstraintsTransposeToSparseMatrix {
                     &(row.colidx(0)), row.length, first_col, hint, is_sorted
                 );
                 for (auto entry = 0; entry < num_cols; ++entry, ++offset) {
-                    row.value(offset) = base_dense(i_constraint, row_number, entry);
+                    if constexpr (force_atomic) {
+                        Kokkos::atomic_add(&row.value(offset), base_dense(i_constraint, row_number, entry));
+                    } else {
+                        row.value(offset) = base_dense(i_constraint, row_number, entry);
+                    }
                 }
             }
         );
@@ -65,7 +71,11 @@ struct CopyConstraintsTransposeToSparseMatrix {
                     &(row.colidx(0)), row.length, first_col, hint, is_sorted
                 );
                 for (auto entry = 0; entry < num_cols; ++entry, ++offset) {
-                    row.value(offset) = target_dense(i_constraint, row_number, entry);
+                    if constexpr (force_atomic) {
+                        Kokkos::atomic_add(&row.value(offset), target_dense(i_constraint, row_number, entry));
+                    } else {
+                        row.value(offset) = target_dense(i_constraint, row_number, entry);
+                    }
                 }
             }
         );


### PR DESCRIPTION
While we don't have any configurations that need this now, it makes sense to provide this extra protection for GPU runs.  This was a source of uncertainty in recent debugging work.