### PR TITLE
Changes tests of YAML writing capability to not create files on disk

### DIFF
--- a/src/model/mesh_connectivity.hpp
+++ b/src/model/mesh_connectivity.hpp
@@ -1,6 +1,6 @@
 #pragma once
+
 #include <fstream>
-#include <iostream>
 #include <unordered_map>
 #include <vector>
 
@@ -110,7 +110,6 @@ public:
      * @param filename Path to the output YAML file
      */
     void ExportToYAML(const std::string& filename) const {
-        std::cout << "Exporting " << std::endl;
         std::ofstream file(filename);
         ExportToYAML(file);
     }

--- a/src/model/mesh_connectivity.hpp
+++ b/src/model/mesh_connectivity.hpp
@@ -1,6 +1,6 @@
 #pragma once
-#include <iostream>
 #include <fstream>
+#include <iostream>
 #include <unordered_map>
 #include <vector>
 
@@ -93,8 +93,8 @@ public:
     /**
      * @brief Export mesh connectivity inforation to a YAML file
      * @param file Stream to output YAML file
-     */ 
-     void ExportToYAML(std::ostream& file) const {
+     */
+    void ExportToYAML(std::ostream& file) const {
         YAML::Node root;
 
         ExportElementTypeToYAML(root, "beams", beams_);
@@ -103,14 +103,14 @@ public:
         ExportElementTypeToYAML(root, "constraints", constraints_);
 
         file << root;
-     }
+    }
 
     /**
      * @brief Export mesh connectivity information to a YAML file
      * @param filename Path to the output YAML file
      */
     void ExportToYAML(const std::string& filename) const {
-std::cout << "Exporting " << std::endl;
+        std::cout << "Exporting " << std::endl;
         std::ofstream file(filename);
         ExportToYAML(file);
     }

--- a/src/model/mesh_connectivity.hpp
+++ b/src/model/mesh_connectivity.hpp
@@ -118,7 +118,7 @@ public:
      * @brief Import mesh connectivity information from a YAML file
      * @param root YAML node with the input YAML file loaded
      */
-    void ImportFromYAML(YAML::Node& root) {
+    void ImportFromYAML(const YAML::Node& root) {
         masses_.clear();
         springs_.clear();
         beams_.clear();
@@ -162,8 +162,7 @@ public:
      * @param filename Path to the input YAML file
      */
     void ImportFromYAML(const std::string& filename) {
-        YAML::Node root = YAML::LoadFile(filename);
-        ImportFromYAML(root);
+        ImportFromYAML(YAML::LoadFile(filename));
     }
 
 private:

--- a/src/model/mesh_connectivity.hpp
+++ b/src/model/mesh_connectivity.hpp
@@ -161,9 +161,7 @@ public:
      * @brief Import mesh connectivity information from a YAML file
      * @param filename Path to the input YAML file
      */
-    void ImportFromYAML(const std::string& filename) {
-        ImportFromYAML(YAML::LoadFile(filename));
-    }
+    void ImportFromYAML(const std::string& filename) { ImportFromYAML(YAML::LoadFile(filename)); }
 
 private:
     std::unordered_map<size_t, std::vector<size_t>> beams_;

--- a/src/model/mesh_connectivity.hpp
+++ b/src/model/mesh_connectivity.hpp
@@ -1,5 +1,5 @@
 #pragma once
-
+#include <iostream>
 #include <fstream>
 #include <unordered_map>
 #include <vector>
@@ -91,10 +91,10 @@ public:
     }
 
     /**
-     * @brief Export mesh connectivity information to a YAML file
-     * @param filename Path to the output YAML file
-     */
-    void ExportToYAML(const std::string& filename) const {
+     * @brief Export mesh connectivity inforation to a YAML file
+     * @param file Stream to output YAML file
+     */ 
+     void ExportToYAML(std::ostream& file) const {
         YAML::Node root;
 
         ExportElementTypeToYAML(root, "beams", beams_);
@@ -102,17 +102,24 @@ public:
         ExportElementTypeToYAML(root, "springs", springs_);
         ExportElementTypeToYAML(root, "constraints", constraints_);
 
-        std::ofstream file(filename);
         file << root;
+     }
+
+    /**
+     * @brief Export mesh connectivity information to a YAML file
+     * @param filename Path to the output YAML file
+     */
+    void ExportToYAML(const std::string& filename) const {
+std::cout << "Exporting " << std::endl;
+        std::ofstream file(filename);
+        ExportToYAML(file);
     }
 
     /**
      * @brief Import mesh connectivity information from a YAML file
-     * @param filename Path to the input YAML file
+     * @param root YAML node with the input YAML file loaded
      */
-    void ImportFromYAML(const std::string& filename) {
-        YAML::Node root = YAML::LoadFile(filename);
-
+    void ImportFromYAML(YAML::Node& root) {
         masses_.clear();
         springs_.clear();
         beams_.clear();
@@ -149,6 +156,15 @@ public:
                 constraints_[id] = entry.second.as<std::vector<size_t>>();
             }
         }
+    }
+
+    /**
+     * @brief Import mesh connectivity information from a YAML file
+     * @param filename Path to the input YAML file
+     */
+    void ImportFromYAML(const std::string& filename) {
+        YAML::Node root = YAML::LoadFile(filename);
+        ImportFromYAML(root);
     }
 
 private:

--- a/tests/unit_tests/model/test_mesh_connectivity.cpp
+++ b/tests/unit_tests/model/test_mesh_connectivity.cpp
@@ -149,8 +149,7 @@ TEST_F(MeshConnectivityTest, ImportFromYAML) {
     mesh_connectivity.ExportToYAML(yaml_stream);
 
     MeshConnectivity imported_mesh;
-    auto root = YAML::Load(yaml_stream.str());
-    imported_mesh.ImportFromYAML(root);
+    imported_mesh.ImportFromYAML(YAML::Load(yaml_stream.str()));
 
     // Beam elements
     ASSERT_EQ(imported_mesh.GetBeamElementConnectivity(1).size(), 5);

--- a/tests/unit_tests/model/test_mesh_connectivity.cpp
+++ b/tests/unit_tests/model/test_mesh_connectivity.cpp
@@ -108,9 +108,9 @@ TEST_F(MeshConnectivityTest, ConstraintConnectivity) {
 }
 
 TEST_F(MeshConnectivityTest, ExportToYAML) {
-    mesh_connectivity.ExportToYAML("test_connectivity.yaml");
-
-    YAML::Node root = YAML::LoadFile("test_connectivity.yaml");
+    auto yaml_stream = std::ostringstream();
+    mesh_connectivity.ExportToYAML(yaml_stream);
+    YAML::Node root = YAML::Load(yaml_stream.str());
 
     // Mass elements
     ASSERT_TRUE(root["masses"]);
@@ -145,11 +145,12 @@ TEST_F(MeshConnectivityTest, ExportToYAML) {
 }
 
 TEST_F(MeshConnectivityTest, ImportFromYAML) {
-    mesh_connectivity.ExportToYAML("test_import.yaml");
-    ASSERT_TRUE(std::filesystem::exists("test_import.yaml"));
+    auto yaml_stream = std::ostringstream();
+    mesh_connectivity.ExportToYAML(yaml_stream);
 
     MeshConnectivity imported_mesh;
-    imported_mesh.ImportFromYAML("test_import.yaml");
+    auto root = YAML::Load(yaml_stream.str());
+    imported_mesh.ImportFromYAML(root);
 
     // Beam elements
     ASSERT_EQ(imported_mesh.GetBeamElementConnectivity(1).size(), 5);
@@ -187,10 +188,6 @@ TEST_F(MeshConnectivityTest, ImportFromYAML) {
     ASSERT_EQ(imported_mesh.GetConstraintConnectivity(3).size(), 2);
     EXPECT_EQ(imported_mesh.GetConstraintConnectivity(3)[0], 8);
     EXPECT_EQ(imported_mesh.GetConstraintConnectivity(3)[1], 9);
-
-    if (std::filesystem::exists("test_import.yaml")) {
-        std::filesystem::remove("test_import.yaml");
-    }
 }
 
 }  // namespace openturbine::tests


### PR DESCRIPTION
Reading from/writing to disk seems to be causing flickering tests in CI, this change decouples the reading/writing implementation from determining where this should be done.  The primary filename-based interface remains the same.