### PR TITLE
Change cuDSS to use more accurate reordering algorithm

### DIFF
--- a/src/solver/linear_solver/dss_handle_cudss.hpp
+++ b/src/solver/linear_solver/dss_handle_cudss.hpp
@@ -13,6 +13,8 @@ class DSSHandle<DSSAlgorithm::CUDSS> {
         cudssDssHandleType() {
             cudssCreate(&handle);
             cudssConfigCreate(&solverConfig);
+            auto flag = CUDSS_ALG_1;
+            cudssConfigSet(solverConfig, CUDSS_CONFIG_REORDERING_ALG, &flag, sizeof(flag));
             cudssDataCreate(handle, &solverData);
         }
 

--- a/tests/regression_tests/interfaces/test_cfd_interface.cpp
+++ b/tests/regression_tests/interfaces/test_cfd_interface.cpp
@@ -284,7 +284,7 @@ TEST(CFDInterfaceTest, Restart) {
     const auto& platform_u_2 = interface2.turbine.floating_platform.node.displacement;
     // Ensure platform location is the same for original and restarted system
     for (auto i = 0U; i < 7U; ++i) {
-        EXPECT_EQ(platform_u_1[i], platform_u_2[i]);
+        EXPECT_NEAR(platform_u_1[i], platform_u_2[i], 1.e-12);
     }
 
     std::filesystem::remove("test_restart.dat");


### PR DESCRIPTION
This is necessary to prevent NaNs on the full turbine configuration.

For more details, see: https://docs.nvidia.com/cuda/cudss/types.html#cudssconfigparam-t