### PR TITLE
Optimize sparse matrix computation and solve

### DIFF
--- a/src/solver/contribute_beams_to_sparse_matrix.hpp
+++ b/src/solver/contribute_beams_to_sparse_matrix.hpp
@@ -49,14 +49,13 @@ struct ContributeBeamsToSparseMatrix {
                     auto offset = KokkosSparse::findRelOffset(
                         &(row.colidx(0)), row.length, first_column, hint, is_sorted
                     );
-                    auto* matrix_ptr = &(row.value(offset));
-                    for (auto component_2 = 0; component_2 < num_dofs; ++component_2, ++matrix_ptr) {
+                    for (auto component_2 = 0; component_2 < num_dofs; ++component_2, ++offset) {
                         const auto contribution =
                             local_dense(component_1, component_2) * conditioner;
                         if constexpr (force_atomic) {
-                            Kokkos::atomic_add(matrix_ptr, contribution);
+                            Kokkos::atomic_add(&(row.value(offset)), contribution);
                         } else {
-                            *matrix_ptr += contribution;
+                            row.value(offset) += contribution;
                         }
                     }
                 }

--- a/src/solver/contribute_beams_to_sparse_matrix.hpp
+++ b/src/solver/contribute_beams_to_sparse_matrix.hpp
@@ -40,7 +40,8 @@ struct ContributeBeamsToSparseMatrix {
                 const auto first_column = static_cast<typename CrsMatrixType::ordinal_type>(
                     element_freedom_table(i, node_2, 0)
                 );
-		const auto local_dense = Kokkos::subview(dense, i, node_1, node_2, Kokkos::ALL, Kokkos::ALL);
+                const auto local_dense =
+                    Kokkos::subview(dense, i, node_1, node_2, Kokkos::ALL, Kokkos::ALL);
                 for (auto component_1 = 0; component_1 < num_dofs; ++component_1) {
                     const auto row_num =
                         static_cast<int>(element_freedom_table(i, node_1, component_1));
@@ -48,14 +49,14 @@ struct ContributeBeamsToSparseMatrix {
                     auto offset = KokkosSparse::findRelOffset(
                         &(row.colidx(0)), row.length, first_column, hint, is_sorted
                     );
-		    auto* matrix_ptr = &(row.value(offset));
+                    auto* matrix_ptr = &(row.value(offset));
                     for (auto component_2 = 0; component_2 < num_dofs; ++component_2, ++matrix_ptr) {
                         const auto contribution =
                             local_dense(component_1, component_2) * conditioner;
                         if constexpr (force_atomic) {
-			    Kokkos::atomic_add(matrix_ptr, contribution);
+                            Kokkos::atomic_add(matrix_ptr, contribution);
                         } else {
-			    *matrix_ptr += contribution;
+                            *matrix_ptr += contribution;
                         }
                     }
                 }

--- a/src/solver/contribute_beams_to_sparse_matrix.hpp
+++ b/src/solver/contribute_beams_to_sparse_matrix.hpp
@@ -40,6 +40,7 @@ struct ContributeBeamsToSparseMatrix {
                 const auto first_column = static_cast<typename CrsMatrixType::ordinal_type>(
                     element_freedom_table(i, node_2, 0)
                 );
+		const auto local_dense = Kokkos::subview(dense, i, node_1, node_2, Kokkos::ALL, Kokkos::ALL);
                 for (auto component_1 = 0; component_1 < num_dofs; ++component_1) {
                     const auto row_num =
                         static_cast<int>(element_freedom_table(i, node_1, component_1));
@@ -47,13 +48,14 @@ struct ContributeBeamsToSparseMatrix {
                     auto offset = KokkosSparse::findRelOffset(
                         &(row.colidx(0)), row.length, first_column, hint, is_sorted
                     );
-                    for (auto component_2 = 0; component_2 < num_dofs; ++component_2, ++offset) {
+		    auto* matrix_ptr = &(row.value(offset));
+                    for (auto component_2 = 0; component_2 < num_dofs; ++component_2, ++matrix_ptr) {
                         const auto contribution =
-                            dense(i, node_1, node_2, component_1, component_2) * conditioner;
+                            local_dense(component_1, component_2) * conditioner;
                         if constexpr (force_atomic) {
-                            Kokkos::atomic_add(&(row.value(offset)), contribution);
+			    Kokkos::atomic_add(matrix_ptr, contribution);
                         } else {
-                            row.value(offset) += contribution;
+			    *matrix_ptr += contribution;
                         }
                     }
                 }

--- a/src/solver/linear_solver/dss_handle_klu.hpp
+++ b/src/solver/linear_solver/dss_handle_klu.hpp
@@ -10,7 +10,10 @@ class DSSHandle<DSSAlgorithm::KLU> {
         klu_numeric* Numeric = nullptr;
         klu_common Common{};
 
-        kluDssHandleType() { klu_defaults(&Common); }
+        kluDssHandleType() {
+	    klu_defaults(&Common);
+	    Common.ordering = 1;
+	}
 
         kluDssHandleType(kluDssHandleType&) = delete;
         void operator=(kluDssHandleType&) = delete;

--- a/src/solver/linear_solver/dss_handle_klu.hpp
+++ b/src/solver/linear_solver/dss_handle_klu.hpp
@@ -11,9 +11,9 @@ class DSSHandle<DSSAlgorithm::KLU> {
         klu_common Common{};
 
         kluDssHandleType() {
-	    klu_defaults(&Common);
-	    Common.ordering = 1;
-	}
+            klu_defaults(&Common);
+            Common.ordering = 1;
+        }
 
         kluDssHandleType(kluDssHandleType&) = delete;
         void operator=(kluDssHandleType&) = delete;

--- a/src/solver/linear_solver/dss_handle_umfpack.hpp
+++ b/src/solver/linear_solver/dss_handle_umfpack.hpp
@@ -2,6 +2,7 @@
 
 #include <array>
 #include <memory>
+
 #include <umfpack.h>
 
 namespace openturbine {
@@ -10,7 +11,7 @@ class DSSHandle<DSSAlgorithm::UMFPACK> {
     struct umfpackDssHandleType {
         void* Symbolic = nullptr;
         void* Numeric = nullptr;
-	std::array<double, UMFPACK_CONTROL> Control{};
+        std::array<double, UMFPACK_CONTROL> Control{};
 
         umfpackDssHandleType() {
             umfpack_di_defaults(Control.data());

--- a/src/solver/linear_solver/dss_handle_umfpack.hpp
+++ b/src/solver/linear_solver/dss_handle_umfpack.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <array>
+#include <memory>
 #include <umfpack.h>
 
 namespace openturbine {
@@ -8,10 +10,10 @@ class DSSHandle<DSSAlgorithm::UMFPACK> {
     struct umfpackDssHandleType {
         void* Symbolic = nullptr;
         void* Numeric = nullptr;
-        double Control[UMFPACK_CONTROL];
+	std::array<double, UMFPACK_CONTROL> Control{};
 
         umfpackDssHandleType() {
-            umfpack_di_defaults(Control);
+            umfpack_di_defaults(Control.data());
             Control[UMFPACK_ORDERING] = UMFPACK_ORDERING_BEST;
         }
 
@@ -34,7 +36,7 @@ public:
 
     void*& get_numeric() { return umfpack_dss_handle->Numeric; }
 
-    double* get_control() { return umfpack_dss_handle->Control; }
+    double* get_control() { return umfpack_dss_handle->Control.data(); }
 };
 
 }  // namespace openturbine

--- a/src/solver/linear_solver/dss_handle_umfpack.hpp
+++ b/src/solver/linear_solver/dss_handle_umfpack.hpp
@@ -8,12 +8,12 @@ class DSSHandle<DSSAlgorithm::UMFPACK> {
     struct umfpackDssHandleType {
         void* Symbolic = nullptr;
         void* Numeric = nullptr;
-	double Control[UMFPACK_CONTROL];
+        double Control[UMFPACK_CONTROL];
 
         umfpackDssHandleType() {
-	    umfpack_di_defaults(Control);
-	    Control[UMFPACK_ORDERING] = UMFPACK_ORDERING_BEST;
-	}
+            umfpack_di_defaults(Control);
+            Control[UMFPACK_ORDERING] = UMFPACK_ORDERING_BEST;
+        }
 
         umfpackDssHandleType(umfpackDssHandleType&) = delete;
         void operator=(umfpackDssHandleType&) = delete;

--- a/src/solver/linear_solver/dss_handle_umfpack.hpp
+++ b/src/solver/linear_solver/dss_handle_umfpack.hpp
@@ -8,8 +8,12 @@ class DSSHandle<DSSAlgorithm::UMFPACK> {
     struct umfpackDssHandleType {
         void* Symbolic = nullptr;
         void* Numeric = nullptr;
+	double Control[UMFPACK_CONTROL];
 
-        umfpackDssHandleType() = default;
+        umfpackDssHandleType() {
+	    umfpack_di_defaults(Control);
+	    Control[UMFPACK_ORDERING] = UMFPACK_ORDERING_BEST;
+	}
 
         umfpackDssHandleType(umfpackDssHandleType&) = delete;
         void operator=(umfpackDssHandleType&) = delete;
@@ -29,6 +33,8 @@ public:
     void*& get_symbolic() { return umfpack_dss_handle->Symbolic; }
 
     void*& get_numeric() { return umfpack_dss_handle->Numeric; }
+
+    double* get_control() { return umfpack_dss_handle->Control; }
 };
 
 }  // namespace openturbine

--- a/src/solver/linear_solver/dss_numeric_klu.hpp
+++ b/src/solver/linear_solver/dss_numeric_klu.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <Kokkos_Core.hpp>
 #include <klu.h>
 
 namespace openturbine {
@@ -15,11 +16,11 @@ struct DSSNumericFunction<DSSHandle<DSSAlgorithm::KLU>, CrsMatrixType> {
         auto& common = dss_handle.get_common();
 
         if (numeric != nullptr) {
-            klu_free_numeric(&numeric, &common);
+            klu_refactor(const_cast<int*>(row_ptrs.data()), col_inds.data(), values.data(), symbolic, numeric, &common);
         }
-        numeric = klu_factor(
-            const_cast<int*>(row_ptrs.data()), col_inds.data(), values.data(), symbolic, &common
-        );
+	else {
+            numeric = klu_factor(const_cast<int*>(row_ptrs.data()), col_inds.data(), values.data(), symbolic, &common);
+        }
     }
 };
 

--- a/src/solver/linear_solver/dss_numeric_klu.hpp
+++ b/src/solver/linear_solver/dss_numeric_klu.hpp
@@ -16,10 +16,14 @@ struct DSSNumericFunction<DSSHandle<DSSAlgorithm::KLU>, CrsMatrixType> {
         auto& common = dss_handle.get_common();
 
         if (numeric != nullptr) {
-            klu_refactor(const_cast<int*>(row_ptrs.data()), col_inds.data(), values.data(), symbolic, numeric, &common);
-        }
-	else {
-            numeric = klu_factor(const_cast<int*>(row_ptrs.data()), col_inds.data(), values.data(), symbolic, &common);
+            klu_refactor(
+                const_cast<int*>(row_ptrs.data()), col_inds.data(), values.data(), symbolic, numeric,
+                &common
+            );
+        } else {
+            numeric = klu_factor(
+                const_cast<int*>(row_ptrs.data()), col_inds.data(), values.data(), symbolic, &common
+            );
         }
     }
 };

--- a/src/solver/linear_solver/dss_numeric_umfpack.hpp
+++ b/src/solver/linear_solver/dss_numeric_umfpack.hpp
@@ -12,9 +12,10 @@ struct DSSNumericFunction<DSSHandle<DSSAlgorithm::UMFPACK>, CrsMatrixType> {
 
         auto*& symbolic = dss_handle.get_symbolic();
         auto*& numeric = dss_handle.get_numeric();
+	auto* control = dss_handle.get_control();
 
         umfpack_di_numeric(
-            row_ptrs.data(), col_inds.data(), values.data(), symbolic, &numeric, nullptr, nullptr
+            row_ptrs.data(), col_inds.data(), values.data(), symbolic, &numeric, control, nullptr
         );
     }
 };

--- a/src/solver/linear_solver/dss_numeric_umfpack.hpp
+++ b/src/solver/linear_solver/dss_numeric_umfpack.hpp
@@ -12,7 +12,7 @@ struct DSSNumericFunction<DSSHandle<DSSAlgorithm::UMFPACK>, CrsMatrixType> {
 
         auto*& symbolic = dss_handle.get_symbolic();
         auto*& numeric = dss_handle.get_numeric();
-	auto* control = dss_handle.get_control();
+        auto* control = dss_handle.get_control();
 
         umfpack_di_numeric(
             row_ptrs.data(), col_inds.data(), values.data(), symbolic, &numeric, control, nullptr

--- a/src/solver/linear_solver/dss_solve_umfpack.hpp
+++ b/src/solver/linear_solver/dss_solve_umfpack.hpp
@@ -19,9 +19,11 @@ struct DSSSolveFunction<DSSHandle<DSSAlgorithm::UMFPACK>, CrsMatrixType, MultiVe
         auto b_host = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), b);
 
         auto*& numeric = dss_handle.get_numeric();
+	auto* control = dss_handle.get_control();
+
         umfpack_di_solve(
             UMFPACK_At, row_ptrs.data(), col_inds.data(), values.data(), x_host.data(),
-            b_host.data(), numeric, nullptr, nullptr
+            b_host.data(), numeric, control, nullptr
         );
 
         Kokkos::deep_copy(x, x_host);

--- a/src/solver/linear_solver/dss_solve_umfpack.hpp
+++ b/src/solver/linear_solver/dss_solve_umfpack.hpp
@@ -19,7 +19,7 @@ struct DSSSolveFunction<DSSHandle<DSSAlgorithm::UMFPACK>, CrsMatrixType, MultiVe
         auto b_host = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), b);
 
         auto*& numeric = dss_handle.get_numeric();
-	auto* control = dss_handle.get_control();
+        auto* control = dss_handle.get_control();
 
         umfpack_di_solve(
             UMFPACK_At, row_ptrs.data(), col_inds.data(), values.data(), x_host.data(),

--- a/src/solver/linear_solver/dss_symbolic_klu.hpp
+++ b/src/solver/linear_solver/dss_symbolic_klu.hpp
@@ -19,9 +19,9 @@ struct DSSSymbolicFunction<DSSHandle<DSSAlgorithm::KLU>, CrsMatrixType> {
         if (symbolic != nullptr) {
             klu_free_symbolic(&symbolic, &common);
         }
-	if (numeric != nullptr) {
-	    klu_free_numeric(&numeric, &common);
-	}
+        if (numeric != nullptr) {
+            klu_free_numeric(&numeric, &common);
+        }
         symbolic =
             klu_analyze(num_rows, const_cast<int*>(row_ptrs.data()), col_inds.data(), &common);
     }

--- a/src/solver/linear_solver/dss_symbolic_klu.hpp
+++ b/src/solver/linear_solver/dss_symbolic_klu.hpp
@@ -1,8 +1,7 @@
 #pragma once
 
+#include <Kokkos_Core.hpp>
 #include <klu.h>
-
-#include "dss_handle_klu.hpp"
 
 namespace openturbine {
 template <typename CrsMatrixType>
@@ -14,10 +13,15 @@ struct DSSSymbolicFunction<DSSHandle<DSSAlgorithm::KLU>, CrsMatrixType> {
         auto col_inds = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), A.graph.entries);
 
         auto*& symbolic = dss_handle.get_symbolic();
+        auto*& numeric = dss_handle.get_numeric();
         auto& common = dss_handle.get_common();
+
         if (symbolic != nullptr) {
             klu_free_symbolic(&symbolic, &common);
         }
+	if (numeric != nullptr) {
+	    klu_free_numeric(&numeric, &common);
+	}
         symbolic =
             klu_analyze(num_rows, const_cast<int*>(row_ptrs.data()), col_inds.data(), &common);
     }

--- a/src/solver/linear_solver/dss_symbolic_umfpack.hpp
+++ b/src/solver/linear_solver/dss_symbolic_umfpack.hpp
@@ -15,7 +15,7 @@ struct DSSSymbolicFunction<DSSHandle<DSSAlgorithm::UMFPACK>, CrsMatrixType> {
         auto col_inds = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), A.graph.entries);
 
         auto*& symbolic = dss_handle.get_symbolic();
-	auto* control = dss_handle.get_control();
+        auto* control = dss_handle.get_control();
 
         umfpack_di_symbolic(
             num_rows, num_cols, row_ptrs.data(), col_inds.data(), nullptr, &symbolic, control,

--- a/src/solver/linear_solver/dss_symbolic_umfpack.hpp
+++ b/src/solver/linear_solver/dss_symbolic_umfpack.hpp
@@ -15,9 +15,10 @@ struct DSSSymbolicFunction<DSSHandle<DSSAlgorithm::UMFPACK>, CrsMatrixType> {
         auto col_inds = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), A.graph.entries);
 
         auto*& symbolic = dss_handle.get_symbolic();
+	auto* control = dss_handle.get_control();
 
         umfpack_di_symbolic(
-            num_rows, num_cols, row_ptrs.data(), col_inds.data(), nullptr, &symbolic, nullptr,
+            num_rows, num_cols, row_ptrs.data(), col_inds.data(), nullptr, &symbolic, control,
             nullptr
         );
     }

--- a/src/system/beams/integrate_inertia_matrix.hpp
+++ b/src/system/beams/integrate_inertia_matrix.hpp
@@ -43,18 +43,22 @@ struct IntegrateInertiaMatrixElement {
             auto phi_j = simd_type{};
             phi_j.copy_from(&shape_interp_(simd_node, qp), tag_type());
             const auto coeff = phi_i * phi_j * w * jacobian;
-	    const auto Muu_local = Kokkos::subview(qp_Muu, qp, Kokkos::ALL);
-	    const auto Guu_local = Kokkos::subview(qp_Guu, qp, Kokkos::ALL);
+            const auto Muu_local = Kokkos::subview(qp_Muu, qp, Kokkos::ALL);
+            const auto Guu_local = Kokkos::subview(qp_Guu, qp, Kokkos::ALL);
             for (auto component = 0; component < 36; ++component) {
-		const auto contribution = simd_type(beta_prime_ * Muu_local(component) + gamma_prime_ * Guu_local(component));
-		local_M[component] = local_M[component] + coeff * contribution;
+                const auto contribution = simd_type(
+                    beta_prime_ * Muu_local(component) + gamma_prime_ * Guu_local(component)
+                );
+                local_M[component] = local_M[component] + coeff * contribution;
             }
         }
 
-	const auto num_lanes = Kokkos::min(width, num_nodes-simd_node);
+        const auto num_lanes = Kokkos::min(width, num_nodes - simd_node);
         const auto global_M =
             Kokkos::View<double** [36], DeviceType>(gbl_M_.data(), num_nodes, num_nodes);
-	const auto M_slice = Kokkos::subview(global_M, node, Kokkos::make_pair(simd_node, simd_node + num_lanes), Kokkos::ALL);
+        const auto M_slice = Kokkos::subview(
+            global_M, node, Kokkos::make_pair(simd_node, simd_node + num_lanes), Kokkos::ALL
+        );
 
         for (auto lane = 0U; lane < num_lanes; ++lane) {
             for (auto component = 0; component < 36; ++component) {

--- a/src/system/beams/integrate_inertia_matrix.hpp
+++ b/src/system/beams/integrate_inertia_matrix.hpp
@@ -45,17 +45,18 @@ struct IntegrateInertiaMatrixElement {
             auto phi_j = simd_type{};
             phi_j.copy_from(&shape_interp_(simd_node, qp), tag_type());
             const auto coeff = phi_i * phi_j * w * jacobian;
+	    const auto Muu_local = Kokkos::subview(qp_Muu, qp, Kokkos::ALL);
+	    const auto Guu_local = Kokkos::subview(qp_Guu, qp, Kokkos::ALL);
             for (auto component = 0; component < 36; ++component) {
-                local_M[component] =
-                    local_M[component] + coeff * simd_type(
-                                                     beta_prime_ * qp_Muu(qp, component) +
-                                                     gamma_prime_ * qp_Guu(qp, component)
-                                                 );
+		const auto contribution = simd_type(beta_prime_ * Muu_local(component) + gamma_prime_ * Guu_local(component));
+		local_M[component] = local_M[component] + coeff * contribution;
             }
         }
+	const auto M_slice = Kokkos::subview(gbl_M, node, Kokkos::make_pair(simd_node, Kokkos::min(simd_node + width, num_nodes)), Kokkos::ALL);
+
         for (auto lane = 0U; lane < width && simd_node + lane < num_nodes; ++lane) {
             for (auto component = 0; component < 36; ++component) {
-                gbl_M(node, simd_node + lane, component) = local_M[component][lane];
+                M_slice(lane, component) = local_M[component][lane];
             }
         }
     }

--- a/src/system/beams/integrate_stiffness_matrix.hpp
+++ b/src/system/beams/integrate_stiffness_matrix.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <Kokkos_Core.hpp>
+#include <KokkosBatched_Copy_Decl.hpp>
 #include <Kokkos_SIMD.hpp>
 
 namespace openturbine::beams {
@@ -59,19 +60,28 @@ struct IntegrateStiffnessMatrixElement {
             const auto P = (phi_i * phi_prime_j) * w;
             const auto C = (phi_prime_i * phi_prime_j) * (w / jacobian);
             const auto O = (phi_prime_i * phi_j) * w;
+	    const auto Kuu_local = Kokkos::subview(qp_Kuu, qp, Kokkos::ALL);
+	    const auto Quu_local = Kokkos::subview(qp_Quu, qp, Kokkos::ALL);
+	    const auto Puu_local = Kokkos::subview(qp_Puu, qp, Kokkos::ALL);
+	    const auto Cuu_local = Kokkos::subview(qp_Cuu, qp, Kokkos::ALL);
+	    const auto Ouu_local = Kokkos::subview(qp_Ouu, qp, Kokkos::ALL);
             for (auto component = 0; component < 36; ++component) {
-                local_M[component] = local_M[component] +
-                                     K * simd_type(qp_Kuu(qp, component) + qp_Quu(qp, component)) +
-                                     P * simd_type(qp_Puu(qp, component)) +
-                                     C * simd_type(qp_Cuu(qp, component)) +
-                                     O * simd_type(qp_Ouu(qp, component));
+		const auto Kuu = simd_type(Kuu_local(component));
+		const auto Quu = simd_type(Quu_local(component));
+		const auto Puu = simd_type(Puu_local(component));
+		const auto Cuu = simd_type(Cuu_local(component));
+		const auto Ouu = simd_type(Ouu_local(component));
+		local_M[component] = local_M[component] + K * (Kuu + Quu) + P * Puu + C * Cuu + O * Ouu;
             }
         }
+	const auto M_slice = Kokkos::subview(gbl_M, node, Kokkos::make_pair(simd_node, Kokkos::min(simd_node + width, num_nodes)), Kokkos::ALL);
+
         for (auto lane = 0U; lane < width && simd_node + lane < num_nodes; ++lane) {
             for (auto component = 0; component < 36; ++component) {
-                gbl_M(node, simd_node + lane, component) = local_M[component][lane];
+                M_slice(lane, component) = local_M[component][lane];
             }
         }
+	
     }
 };
 


### PR DESCRIPTION
This introduces a few minor optimizations to the sparse matrix computation procedure (about 5% of Full Turbine runtime).  

It also changes KLU to use refactorization after the first numeric factorization, which saves about 30% of the full turbine runtime, a significant speed up.  