### PR TITLE
Changed interface tests to no longer write to disk by default.

### DIFF
--- a/tests/regression_tests/interfaces/test_blade_interface.cpp
+++ b/tests/regression_tests/interfaces/test_blade_interface.cpp
@@ -12,6 +12,7 @@ TEST(BladeInterfaceTest, BladeWindIO) {
     // Read WindIO yaml file
     const YAML::Node wio = YAML::LoadFile("interfaces_test_files/IEA-15-240-RWT.yaml");
     const auto& wio_blade = wio["components"]["blade"];
+    const auto write_output{false};
 
     // Create interface builder
     auto builder = interfaces::BladeInterfaceBuilder{};
@@ -24,8 +25,11 @@ TEST(BladeInterfaceTest, BladeWindIO) {
         .SetDampingFactor(0.0)
         .SetMaximumNonlinearIterations(6)
         .SetAbsoluteErrorTolerance(1e-6)
-        .SetRelativeErrorTolerance(1e-4)
-        .SetOutputFile("BladeInterfaceTest.BladeWindIO");
+        .SetRelativeErrorTolerance(1e-4);
+
+    if (write_output) {
+        builder.Solution().SetOutputFile("BladeInterfaceTest.BladeWindIO");
+    }
 
     // Set blade parameters
     // Use prescribed root motion to fix root rotation
@@ -125,6 +129,7 @@ TEST(BladeInterfaceTest, RotatingBeam) {
     const Array_3 omega{0., 0., 1.};
     const Array_3 x0_root{2., 0., 0.};
     const auto root_vel = CrossProduct(omega, x0_root);
+    const auto write_output{false};
 
     // Create interface builder
     auto builder = interfaces::BladeInterfaceBuilder{};
@@ -136,8 +141,12 @@ TEST(BladeInterfaceTest, RotatingBeam) {
         .SetDampingFactor(0.0)
         .SetMaximumNonlinearIterations(6)
         .SetAbsoluteErrorTolerance(1e-6)
-        .SetRelativeErrorTolerance(1e-4)
-        .SetOutputFile("BladeInterfaceTest.RotatingBeam");
+        .SetRelativeErrorTolerance(1e-4);
+
+    if (write_output) {
+        builder.Solution().SetOutputFile("BladeInterfaceTest.RotatingBeam");
+    }
+
     // Node locations (GLL quadrature)
     const auto node_s = std::vector{
         0., 0.11747233803526763, 0.35738424175967748, 0.64261575824032247, 0.88252766196473242, 1.
@@ -376,6 +385,7 @@ TEST(BladeInterfaceTest, TwoBeams) {
 TEST(BladeInterfaceTest, StaticCurledBeam) {
     // Create interface builder
     auto builder = interfaces::BladeInterfaceBuilder{};
+    const auto write_output{false};
 
     builder.Solution()
         .EnableStaticSolve()
@@ -383,8 +393,11 @@ TEST(BladeInterfaceTest, StaticCurledBeam) {
         .SetDampingFactor(1.)
         .SetMaximumNonlinearIterations(10)
         .SetAbsoluteErrorTolerance(1e-5)
-        .SetRelativeErrorTolerance(1e-3)
-        .SetOutputFile("BladeInterfaceTest.StaticCurledBeam");
+        .SetRelativeErrorTolerance(1e-3);
+
+    if (write_output) {
+        builder.Solution().SetOutputFile("BladeInterfaceTest.StaticCurledBeam");
+    }
 
     // Node locations
     const std::vector<double> kp_s{0., 1.};

--- a/tests/regression_tests/interfaces/test_blade_interface.cpp
+++ b/tests/regression_tests/interfaces/test_blade_interface.cpp
@@ -12,7 +12,7 @@ TEST(BladeInterfaceTest, BladeWindIO) {
     // Read WindIO yaml file
     const YAML::Node wio = YAML::LoadFile("interfaces_test_files/IEA-15-240-RWT.yaml");
     const auto& wio_blade = wio["components"]["blade"];
-    const auto write_output{false};
+    const auto write_output{true};
 
     // Create interface builder
     auto builder = interfaces::BladeInterfaceBuilder{};

--- a/tests/regression_tests/interfaces/test_cfd_interface.cpp
+++ b/tests/regression_tests/interfaces/test_cfd_interface.cpp
@@ -17,13 +17,13 @@ TEST(CFDInterfaceTest, PrecessionTest) {
     const auto write_output{true};
 
     auto builder = InterfaceBuilder{}
-                         .SetTimeStep(0.01)
-                         .SetDampingFactor(1.)
-                         .SetMaximumNonlinearIterations(5U)
-                         .EnableFloatingPlatform(true)
-                         .SetFloatingPlatformVelocity({0., 0., 0., 0.5, 0.5, 1.})
-                         .SetFloatingPlatformMassMatrix(mass_matrix);
-			 
+                       .SetTimeStep(0.01)
+                       .SetDampingFactor(1.)
+                       .SetMaximumNonlinearIterations(5U)
+                       .EnableFloatingPlatform(true)
+                       .SetFloatingPlatformVelocity({0., 0., 0., 0.5, 0.5, 1.})
+                       .SetFloatingPlatformMassMatrix(mass_matrix);
+
     if (write_output) {
         builder.SetOutputFile("CFDInterfaceTest.PrecessionTest");
     }
@@ -150,26 +150,26 @@ TEST(CFDInterfaceTest, FloatingPlatform) {
 
     // Create cfd interface
     auto builder = InterfaceBuilder{}
-                         .SetGravity(gravity)
-                         .SetTimeStep(time_step)
-                         .SetDampingFactor(rho_inf)
-                         .SetMaximumNonlinearIterations(max_iter)
-                         .EnableFloatingPlatform(true)
-                         .SetFloatingPlatformPosition({0., 0., -7.53, 1., 0., 0., 0.})
-                         .SetFloatingPlatformMassMatrix(platform_mass_matrix)
-                         .SetNumberOfMooringLines(3)
-                         .SetMooringLineStiffness(0, mooring_line_stiffness)
-                         .SetMooringLineUndeformedLength(0, mooring_line_initial_length)
-                         .SetMooringLineFairleadPosition(0, {-40.87, 0.0, -14.})
-                         .SetMooringLineAnchorPosition(0, {-105.47, 0.0, -58.4})
-                         .SetMooringLineStiffness(1, mooring_line_stiffness)
-                         .SetMooringLineUndeformedLength(1, mooring_line_initial_length)
-                         .SetMooringLineFairleadPosition(1, {20.43, -35.39, -14.})
-                         .SetMooringLineAnchorPosition(1, {52.73, -91.34, -58.4})
-                         .SetMooringLineStiffness(2, mooring_line_stiffness)
-                         .SetMooringLineUndeformedLength(2, mooring_line_initial_length)
-                         .SetMooringLineFairleadPosition(2, {20.43, 35.39, -14.})
-                         .SetMooringLineAnchorPosition(2, {52.73, 91.34, -58.4});
+                       .SetGravity(gravity)
+                       .SetTimeStep(time_step)
+                       .SetDampingFactor(rho_inf)
+                       .SetMaximumNonlinearIterations(max_iter)
+                       .EnableFloatingPlatform(true)
+                       .SetFloatingPlatformPosition({0., 0., -7.53, 1., 0., 0., 0.})
+                       .SetFloatingPlatformMassMatrix(platform_mass_matrix)
+                       .SetNumberOfMooringLines(3)
+                       .SetMooringLineStiffness(0, mooring_line_stiffness)
+                       .SetMooringLineUndeformedLength(0, mooring_line_initial_length)
+                       .SetMooringLineFairleadPosition(0, {-40.87, 0.0, -14.})
+                       .SetMooringLineAnchorPosition(0, {-105.47, 0.0, -58.4})
+                       .SetMooringLineStiffness(1, mooring_line_stiffness)
+                       .SetMooringLineUndeformedLength(1, mooring_line_initial_length)
+                       .SetMooringLineFairleadPosition(1, {20.43, -35.39, -14.})
+                       .SetMooringLineAnchorPosition(1, {52.73, -91.34, -58.4})
+                       .SetMooringLineStiffness(2, mooring_line_stiffness)
+                       .SetMooringLineUndeformedLength(2, mooring_line_initial_length)
+                       .SetMooringLineFairleadPosition(2, {20.43, 35.39, -14.})
+                       .SetMooringLineAnchorPosition(2, {52.73, 91.34, -58.4});
     if (write_output) {
         builder.SetOutputFile("CFDInterfaceTest.FloatingPlatform");
     }

--- a/tests/regression_tests/interfaces/test_turbine_interface.cpp
+++ b/tests/regression_tests/interfaces/test_turbine_interface.cpp
@@ -11,11 +11,11 @@ namespace openturbine::tests {
 // and applies a tower load, generator torque, blade pitch, and yaw angle to test the
 // structure's response.
 TEST(TurbineInterfaceTest, IEA15_Structure) {
-    const auto duration{0.1};      // Simulation duration in seconds
-    const auto time_step{0.01};    // Time step for the simulation
-    const auto n_blades{3};        // Number of blades in turbine
-    const auto n_blade_nodes{11};  // Number of nodes per blade
-    const auto n_tower_nodes{11};  // Number of nodes in tower
+    const auto duration{0.1};        // Simulation duration in seconds
+    const auto time_step{0.01};      // Time step for the simulation
+    const auto n_blades{3};          // Number of blades in turbine
+    const auto n_blade_nodes{11};    // Number of nodes per blade
+    const auto n_tower_nodes{11};    // Number of nodes in tower
     const auto write_output{false};  // Write output file
 
     // Create interface builder

--- a/tests/regression_tests/interfaces/test_turbine_interface.cpp
+++ b/tests/regression_tests/interfaces/test_turbine_interface.cpp
@@ -12,11 +12,11 @@ namespace openturbine::tests {
 // structure's response.
 TEST(TurbineInterfaceTest, IEA15_Structure) {
     const auto duration{0.1};      // Simulation duration in seconds
-    const auto time_step{0.01};     // Time step for the simulation
-    const auto n_blades{3};         // Number of blades in turbine
-    const auto n_blade_nodes{11};   // Number of nodes per blade
-    const auto n_tower_nodes{11};   // Number of nodes in tower
-    const auto write_output{false}; // Write output file
+    const auto time_step{0.01};    // Time step for the simulation
+    const auto n_blades{3};        // Number of blades in turbine
+    const auto n_blade_nodes{11};  // Number of nodes per blade
+    const auto n_tower_nodes{11};  // Number of nodes in tower
+    const auto write_output{false};  // Write output file
 
     // Create interface builder
     auto builder = interfaces::TurbineInterfaceBuilder{};

--- a/tests/regression_tests/interfaces/test_turbine_interface.cpp
+++ b/tests/regression_tests/interfaces/test_turbine_interface.cpp
@@ -12,10 +12,11 @@ namespace openturbine::tests {
 // structure's response.
 TEST(TurbineInterfaceTest, IEA15_Structure) {
     const auto duration{0.1};      // Simulation duration in seconds
-    const auto time_step{0.01};    // Time step for the simulation
-    const auto n_blades{3};        // Number of blades in turbine
-    const auto n_blade_nodes{11};  // Number of nodes per blade
-    const auto n_tower_nodes{11};  // Number of nodes in tower
+    const auto time_step{0.01};     // Time step for the simulation
+    const auto n_blades{3};         // Number of blades in turbine
+    const auto n_blade_nodes{11};   // Number of nodes per blade
+    const auto n_tower_nodes{11};   // Number of nodes in tower
+    const auto write_output{false}; // Write output file
 
     // Create interface builder
     auto builder = interfaces::TurbineInterfaceBuilder{};
@@ -28,8 +29,11 @@ TEST(TurbineInterfaceTest, IEA15_Structure) {
         .SetGravity({0., 0., -9.81})
         .SetMaximumNonlinearIterations(6)
         .SetAbsoluteErrorTolerance(1e-6)
-        .SetRelativeErrorTolerance(1e-4)
-        .SetOutputFile("TurbineInterfaceTest.IEA15");
+        .SetRelativeErrorTolerance(1e-4);
+
+    if (write_output) {
+        builder.Solution().SetOutputFile("TurbineInterfaceTest.IEA15");
+    }
 
     // Read WindIO yaml file
     const YAML::Node wio = YAML::LoadFile("interfaces_test_files/IEA-15-240-RWT.yaml");


### PR DESCRIPTION
This cleans up the directory where regression tests are written and removes the performance hit (about 10%) from the iteration loop by default.

Writing output can be reenabled by changing the write_output option to true.