### PR TITLE
Moved math utilities to their own namespace to increase readability of Doxygen.

### DIFF
--- a/docs/sphinx/user/heavy_top.rst
+++ b/docs/sphinx/user/heavy_top.rst
@@ -43,7 +43,7 @@ Now, we define the mass matrix and initial position, velocity, and acceleration.
     constexpr auto inertia = std::array{0.234375, 0.46875, 0.234375};
     const auto x = std::array{0., 1., 0.};
     const auto omega = std::array{0., 150., -4.61538};
-    const auto x_dot = openturbine::CrossProduct(omega, x);
+    const auto x_dot = openturbine::math::CrossProduct(omega, x);
     const auto omega_dot = std::array{661.3461692307691919, 0., 0.};
     const auto x_ddot = std::array{0., -21.3017325444000001, -30.9608307692308244};
 

--- a/docs/sphinx/user/three_blade.rst
+++ b/docs/sphinx/user/three_blade.rst
@@ -122,7 +122,7 @@ rotor like one would see on a wind turbine.
             }
         );
         auto blade_elem_id = model.AddBeamElement(beam_node_ids, sections, quadrature);
-        auto rotation_quaternion = openturbine::RotationVectorToQuaternion(
+        auto rotation_quaternion = openturbine::math::RotationVectorToQuaternion(
             {0., 0., 2. * M_PI * blade_number / num_blades}
         );
         model.TranslateBeam(blade_elem_id, {hub_radius, 0., 0.});
@@ -183,7 +183,7 @@ For this problem, we will prescribe a rotation on the hub boundary condition, wh
 .. code-block:: cpp
 
     for (auto i = 0U; i < num_steps; ++i) {
-        const auto q_hub = openturbine::RotationVectorToQuaternion(
+        const auto q_hub = openturbine::math::RotationVectorToQuaternion(
             {step_size * (i + 1) * velocity[3], step_size * (i + 1) * velocity[4],
              step_size * (i + 1) * velocity[5]}
         );

--- a/src/constraints/calculate_fixed_bc_3DOF_constraint.hpp
+++ b/src/constraints/calculate_fixed_bc_3DOF_constraint.hpp
@@ -50,8 +50,8 @@ struct CalculateFixedBC3DOFConstraint {
         //----------------------------------------------------------------------
 
         // Phi(0:3) = u2 + X0 - u1 - R1*X0
-        QuaternionInverse(R1, R1t);
-        RotateVectorByQuaternion(R1, X0, R1_X0);
+	math::QuaternionInverse(R1, R1t);
+	math::RotateVectorByQuaternion(R1, X0, R1_X0);
         for (auto component = 0; component < 3; ++component) {
             residual_terms(component) =
                 u2(component) + X0(component) - u1(component) - R1_X0(component);

--- a/src/constraints/calculate_fixed_bc_3DOF_constraint.hpp
+++ b/src/constraints/calculate_fixed_bc_3DOF_constraint.hpp
@@ -50,8 +50,8 @@ struct CalculateFixedBC3DOFConstraint {
         //----------------------------------------------------------------------
 
         // Phi(0:3) = u2 + X0 - u1 - R1*X0
-	math::QuaternionInverse(R1, R1t);
-	math::RotateVectorByQuaternion(R1, X0, R1_X0);
+        math::QuaternionInverse(R1, R1t);
+        math::RotateVectorByQuaternion(R1, X0, R1_X0);
         for (auto component = 0; component < 3; ++component) {
             residual_terms(component) =
                 u2(component) + X0(component) - u1(component) - R1_X0(component);

--- a/src/constraints/calculate_fixed_bc_constraint.hpp
+++ b/src/constraints/calculate_fixed_bc_constraint.hpp
@@ -56,8 +56,8 @@ struct CalculateFixedBCConstraint {
         //----------------------------------------------------------------------
 
         // Phi(0:3) = u2 + X0 - u1 - R1*X0
-        QuaternionInverse(R1, R1t);
-        RotateVectorByQuaternion(R1, X0, R1_X0);
+	math::QuaternionInverse(R1, R1t);
+	math::RotateVectorByQuaternion(R1, X0, R1_X0);
         for (auto component = 0; component < 3; ++component) {
             residual_terms(component) =
                 u2(component) + X0(component) - u1(component) - R1_X0(component);
@@ -65,9 +65,9 @@ struct CalculateFixedBCConstraint {
 
         // Angular residual
         // Phi(3:6) = axial(R2*inv(RC)*inv(R1))
-        QuaternionCompose(R2, R1t, R2_R1t);
-        QuaternionToRotationMatrix(R2_R1t, C);
-        AxialVectorOfMatrix(C, V3);
+	math::QuaternionCompose(R2, R1t, R2_R1t);
+        math::QuaternionToRotationMatrix(R2_R1t, C);
+        math::AxialVectorOfMatrix(C, V3);
         CopyVector::invoke(V3, subview(residual_terms, make_pair(3, 6)));
 
         //----------------------------------------------------------------------
@@ -84,7 +84,7 @@ struct CalculateFixedBCConstraint {
         }
 
         // B(3:6,3:6) = AX(R1*RC*inv(R2)) = transpose(AX(R2*inv(RC)*inv(R1)))
-        AX_Matrix(C, A);
+	math::AX_Matrix(C, A);
         CopyMatrixTranspose::invoke(
             A, subview(target_gradient_terms, make_pair(3, 6), make_pair(3, 6))
         );

--- a/src/constraints/calculate_fixed_bc_constraint.hpp
+++ b/src/constraints/calculate_fixed_bc_constraint.hpp
@@ -56,8 +56,8 @@ struct CalculateFixedBCConstraint {
         //----------------------------------------------------------------------
 
         // Phi(0:3) = u2 + X0 - u1 - R1*X0
-	math::QuaternionInverse(R1, R1t);
-	math::RotateVectorByQuaternion(R1, X0, R1_X0);
+        math::QuaternionInverse(R1, R1t);
+        math::RotateVectorByQuaternion(R1, X0, R1_X0);
         for (auto component = 0; component < 3; ++component) {
             residual_terms(component) =
                 u2(component) + X0(component) - u1(component) - R1_X0(component);
@@ -65,7 +65,7 @@ struct CalculateFixedBCConstraint {
 
         // Angular residual
         // Phi(3:6) = axial(R2*inv(RC)*inv(R1))
-	math::QuaternionCompose(R2, R1t, R2_R1t);
+        math::QuaternionCompose(R2, R1t, R2_R1t);
         math::QuaternionToRotationMatrix(R2_R1t, C);
         math::AxialVectorOfMatrix(C, V3);
         CopyVector::invoke(V3, subview(residual_terms, make_pair(3, 6)));
@@ -84,7 +84,7 @@ struct CalculateFixedBCConstraint {
         }
 
         // B(3:6,3:6) = AX(R1*RC*inv(R2)) = transpose(AX(R2*inv(RC)*inv(R1)))
-	math::AX_Matrix(C, A);
+        math::AX_Matrix(C, A);
         CopyMatrixTranspose::invoke(
             A, subview(target_gradient_terms, make_pair(3, 6), make_pair(3, 6))
         );

--- a/src/constraints/calculate_prescribed_bc_3DOF_constraint.hpp
+++ b/src/constraints/calculate_prescribed_bc_3DOF_constraint.hpp
@@ -51,8 +51,8 @@ struct CalculatePrescribedBC3DOFConstraint {
         //----------------------------------------------------------------------
 
         // Phi(0:3) = u2 + X0 - u1 - R1*X0
-        QuaternionInverse(R1, R1t);
-        RotateVectorByQuaternion(R1, X0, R1_X0);
+	math::QuaternionInverse(R1, R1t);
+        math::RotateVectorByQuaternion(R1, X0, R1_X0);
         for (auto component = 0; component < 3; ++component) {
             residual_terms(component) =
                 u2(component) + X0(component) - u1(component) - R1_X0(component);

--- a/src/constraints/calculate_prescribed_bc_3DOF_constraint.hpp
+++ b/src/constraints/calculate_prescribed_bc_3DOF_constraint.hpp
@@ -51,7 +51,7 @@ struct CalculatePrescribedBC3DOFConstraint {
         //----------------------------------------------------------------------
 
         // Phi(0:3) = u2 + X0 - u1 - R1*X0
-	math::QuaternionInverse(R1, R1t);
+        math::QuaternionInverse(R1, R1t);
         math::RotateVectorByQuaternion(R1, X0, R1_X0);
         for (auto component = 0; component < 3; ++component) {
             residual_terms(component) =

--- a/src/constraints/calculate_prescribed_bc_constraint.hpp
+++ b/src/constraints/calculate_prescribed_bc_constraint.hpp
@@ -57,7 +57,7 @@ struct CalculatePrescribedBCConstraint {
         //----------------------------------------------------------------------
 
         // Phi(0:3) = u2 + X0 - u1 - R1*X0
-	math::QuaternionInverse(R1, R1t);
+        math::QuaternionInverse(R1, R1t);
         math::RotateVectorByQuaternion(R1, X0, R1_X0);
         for (auto component = 0; component < 3; ++component) {
             residual_terms(component) =
@@ -66,7 +66,7 @@ struct CalculatePrescribedBCConstraint {
 
         // Angular residual
         // Phi(3:6) = axial(R2*inv(RC)*inv(R1))
-	math::QuaternionCompose(R2, R1t, R2_R1t);
+        math::QuaternionCompose(R2, R1t, R2_R1t);
         math::QuaternionToRotationMatrix(R2_R1t, C);
         math::AxialVectorOfMatrix(C, V3);
         CopyVector::invoke(V3, subview(residual_terms, make_pair(3, 6)));
@@ -85,7 +85,7 @@ struct CalculatePrescribedBCConstraint {
         }
 
         // B(3:6,3:6) = AX(R1*RC*inv(R2)) = transpose(AX(R2*inv(RC)*inv(R1)))
-	math::AX_Matrix(C, A);
+        math::AX_Matrix(C, A);
         CopyTransposeMatrix::invoke(
             A, subview(target_gradient_terms, make_pair(3, 6), make_pair(3, 6))
         );

--- a/src/constraints/calculate_prescribed_bc_constraint.hpp
+++ b/src/constraints/calculate_prescribed_bc_constraint.hpp
@@ -57,8 +57,8 @@ struct CalculatePrescribedBCConstraint {
         //----------------------------------------------------------------------
 
         // Phi(0:3) = u2 + X0 - u1 - R1*X0
-        QuaternionInverse(R1, R1t);
-        RotateVectorByQuaternion(R1, X0, R1_X0);
+	math::QuaternionInverse(R1, R1t);
+        math::RotateVectorByQuaternion(R1, X0, R1_X0);
         for (auto component = 0; component < 3; ++component) {
             residual_terms(component) =
                 u2(component) + X0(component) - u1(component) - R1_X0(component);
@@ -66,9 +66,9 @@ struct CalculatePrescribedBCConstraint {
 
         // Angular residual
         // Phi(3:6) = axial(R2*inv(RC)*inv(R1))
-        QuaternionCompose(R2, R1t, R2_R1t);
-        QuaternionToRotationMatrix(R2_R1t, C);
-        AxialVectorOfMatrix(C, V3);
+	math::QuaternionCompose(R2, R1t, R2_R1t);
+        math::QuaternionToRotationMatrix(R2_R1t, C);
+        math::AxialVectorOfMatrix(C, V3);
         CopyVector::invoke(V3, subview(residual_terms, make_pair(3, 6)));
 
         //----------------------------------------------------------------------
@@ -85,7 +85,7 @@ struct CalculatePrescribedBCConstraint {
         }
 
         // B(3:6,3:6) = AX(R1*RC*inv(R2)) = transpose(AX(R2*inv(RC)*inv(R1)))
-        AX_Matrix(C, A);
+	math::AX_Matrix(C, A);
         CopyTransposeMatrix::invoke(
             A, subview(target_gradient_terms, make_pair(3, 6), make_pair(3, 6))
         );

--- a/src/constraints/calculate_revolute_joint_constraint.hpp
+++ b/src/constraints/calculate_revolute_joint_constraint.hpp
@@ -62,21 +62,21 @@ struct CalculateRevoluteJointConstraint {
         //----------------------------------------------------------------------
 
         // Phi(0:3) = u2 + X0 - u1 - R1*X0
-        QuaternionInverse(R1, R1t);
-        RotateVectorByQuaternion(R1, X0, R1_X0);
+        math::QuaternionInverse(R1, R1t);
+        math::RotateVectorByQuaternion(R1, X0, R1_X0);
         for (auto component = 0; component < 3; ++component) {
             residual_terms(component) =
                 u2(component) + X0(component) - u1(component) - R1_X0(component);
         }
 
         // Angular residual
-        RotateVectorByQuaternion(R1, x0, x);
-        RotateVectorByQuaternion(R2, y0, y);
-        RotateVectorByQuaternion(R2, z0, z);
+        math::RotateVectorByQuaternion(R1, x0, x);
+        math::RotateVectorByQuaternion(R2, y0, y);
+        math::RotateVectorByQuaternion(R2, z0, z);
         // Phi(3) = dot(R2 * z0_hat, R1 * x0_hat)
-        residual_terms(3) = DotProduct(z, x);
+        residual_terms(3) = math::DotProduct(z, x);
         // Phi(4) = dot(R2 * y0_hat, R1 * x0_hat)
-        residual_terms(4) = DotProduct(y, x);
+        residual_terms(4) = math::DotProduct(y, x);
 
         //----------------------------------------------------------------------
         // Constraint Gradient Matrix, B
@@ -90,9 +90,9 @@ struct CalculateRevoluteJointConstraint {
         }
 
         // B(3, 3:6) = -cross(R1 * x0_hat, transpose(R2 * z0_hat))
-        CrossProduct(x, z, xcz);
+        math::CrossProduct(x, z, xcz);
         // B(4, 3:6) = -cross(R1 * x0_hat, transpose(R2 * y0_hat))
-        CrossProduct(x, y, xcy);
+        math::CrossProduct(x, y, xcy);
         for (auto component = 0; component < 3; ++component) {
             target_gradient_terms(3, component + 3) = -xcz(component);
             target_gradient_terms(4, component + 3) = -xcy(component);

--- a/src/constraints/calculate_revolute_joint_force.hpp
+++ b/src/constraints/calculate_revolute_joint_force.hpp
@@ -37,7 +37,7 @@ struct CalculateRevoluteJointForce {
         //----------------------------------------------------------------------
 
         // Extract residual rows relevant to this constraint
-	math::RotateVectorByQuaternion(R2, X0, R2_X0);
+        math::RotateVectorByQuaternion(R2, X0, R2_X0);
 
         // Take axis_x and rotate it to right orientation
         system_residual_terms(3) = R2_X0(0) * inputs(0);

--- a/src/constraints/calculate_revolute_joint_force.hpp
+++ b/src/constraints/calculate_revolute_joint_force.hpp
@@ -37,7 +37,7 @@ struct CalculateRevoluteJointForce {
         //----------------------------------------------------------------------
 
         // Extract residual rows relevant to this constraint
-        RotateVectorByQuaternion(R2, X0, R2_X0);
+	math::RotateVectorByQuaternion(R2, X0, R2_X0);
 
         // Take axis_x and rotate it to right orientation
         system_residual_terms(3) = R2_X0(0) * inputs(0);

--- a/src/constraints/calculate_revolute_joint_output.hpp
+++ b/src/constraints/calculate_revolute_joint_output.hpp
@@ -52,12 +52,12 @@ struct CalculateRevoluteJointOutput {
         // Calculate current orientation
         auto RR0_data = Array<double, 4>{};
         auto RR0 = View<double[4]>(RR0_data.data());
-        QuaternionCompose(R, R0, RR0);
+        math::QuaternionCompose(R, R0, RR0);
 
         // Calculate rotational displacement as rotation vector
         auto RotVec_data = Array<double, 3>{};
         auto RotVec = View<double[3]>(RotVec_data.data());
-        QuaternionToRotationVector(R, RotVec);
+        math::QuaternionToRotationVector(R, RotVec);
 
         // Target node rotational velocity vector
         const auto omega_data =
@@ -72,16 +72,16 @@ struct CalculateRevoluteJointOutput {
         // Calculate joint axis in current configuration
         auto joint_axis_data = Array<double, 3>{};
         auto joint_axis = View<double[3]>{joint_axis_data.data()};
-        RotateVectorByQuaternion(R, joint_axis0, joint_axis);
+        math::RotateVectorByQuaternion(R, joint_axis0, joint_axis);
 
         // Calculate rotation about shaft axis
-        auto angular_rotation = DotProduct(joint_axis, RotVec);
+        auto angular_rotation = math::DotProduct(joint_axis, RotVec);
 
         // Angular velocity about joint axis (rad/s)
-        auto angular_velocity = DotProduct(joint_axis, omega);
+        auto angular_velocity = math::DotProduct(joint_axis, omega);
 
         // Angular acceleration about joint axis (rad/s)
-        auto angular_acceleration = DotProduct(joint_axis, omega_dot);
+        auto angular_acceleration = math::DotProduct(joint_axis, omega_dot);
 
         // Save outputs
         outputs(constraint, 0) = angular_rotation;

--- a/src/constraints/calculate_rigid_joint_3DOF_constraint.hpp
+++ b/src/constraints/calculate_rigid_joint_3DOF_constraint.hpp
@@ -50,7 +50,7 @@ struct CalculateRigidJoint3DOFConstraint {
         //----------------------------------------------------------------------
 
         // Phi(0:3) = u2 + X0 - u1 - R1*X0
-	math::QuaternionInverse(R1, R1t);
+        math::QuaternionInverse(R1, R1t);
         math::RotateVectorByQuaternion(R1, X0, R1_X0);
         for (auto constraint = 0; constraint < 3; ++constraint) {
             residual_terms(constraint) =
@@ -74,7 +74,7 @@ struct CalculateRigidJoint3DOFConstraint {
         }
 
         // B(0:3,3:6) = tilde(R1*X0)
-	math::VecTilde(R1_X0, A);
+        math::VecTilde(R1_X0, A);
         CopyMatrix::invoke(A, subview(base_gradient_terms, make_pair(0, 3), make_pair(3, 6)));
     }
 };

--- a/src/constraints/calculate_rigid_joint_3DOF_constraint.hpp
+++ b/src/constraints/calculate_rigid_joint_3DOF_constraint.hpp
@@ -50,8 +50,8 @@ struct CalculateRigidJoint3DOFConstraint {
         //----------------------------------------------------------------------
 
         // Phi(0:3) = u2 + X0 - u1 - R1*X0
-        QuaternionInverse(R1, R1t);
-        RotateVectorByQuaternion(R1, X0, R1_X0);
+	math::QuaternionInverse(R1, R1t);
+        math::RotateVectorByQuaternion(R1, X0, R1_X0);
         for (auto constraint = 0; constraint < 3; ++constraint) {
             residual_terms(constraint) =
                 u2(constraint) + X0(constraint) - u1(constraint) - R1_X0(constraint);
@@ -74,7 +74,7 @@ struct CalculateRigidJoint3DOFConstraint {
         }
 
         // B(0:3,3:6) = tilde(R1*X0)
-        VecTilde(R1_X0, A);
+	math::VecTilde(R1_X0, A);
         CopyMatrix::invoke(A, subview(base_gradient_terms, make_pair(0, 3), make_pair(3, 6)));
     }
 };

--- a/src/constraints/calculate_rigid_joint_constraint.hpp
+++ b/src/constraints/calculate_rigid_joint_constraint.hpp
@@ -61,17 +61,17 @@ struct CalculateRigidJointConstraint {
         //----------------------------------------------------------------------
 
         // Phi(0:3) = u2 + X0 - u1 - R1*X0
-        QuaternionInverse(R1, R1t);
-        RotateVectorByQuaternion(R1, X0, R1_X0);
+        math::QuaternionInverse(R1, R1t);
+        math::RotateVectorByQuaternion(R1, X0, R1_X0);
         for (auto component = 0; component < 3; ++component) {
             residual_terms(component) =
                 u2(component) + X0(component) - u1(component) - R1_X0(component);
         }
 
         // Phi(3:6) = axial(R2*inv(RC)*inv(R1))
-        QuaternionCompose(R2, R1t, R2_R1t);
-        QuaternionToRotationMatrix(R2_R1t, C);
-        AxialVectorOfMatrix(C, V3);
+	math::QuaternionCompose(R2, R1t, R2_R1t);
+        math::QuaternionToRotationMatrix(R2_R1t, C);
+        math::AxialVectorOfMatrix(C, V3);
         for (auto component = 0; component < 3; ++component) {
             residual_terms(component + 3) = V3(component);
         }
@@ -87,7 +87,7 @@ struct CalculateRigidJointConstraint {
         }
 
         // B(3:6,3:6) = AX(R1*RC*inv(R2)) = transpose(AX(R2*inv(RC)*inv(R1)))
-        AX_Matrix(C, A);
+	math::AX_Matrix(C, A);
         CopyMatrixTranspose::invoke(
             A, subview(target_gradient_terms, make_pair(3, 6), make_pair(3, 6))
         );
@@ -99,11 +99,11 @@ struct CalculateRigidJointConstraint {
         }
 
         // B(0:3,3:6) = tilde(R1*X0)
-        VecTilde(R1_X0, A);
+	math::VecTilde(R1_X0, A);
         CopyMatrix::invoke(A, subview(base_gradient_terms, make_pair(0, 3), make_pair(3, 6)));
 
         // B(3:6,3:6) = -AX(R2*inv(RC)*inv(R1))
-        AX_Matrix(C, A);
+	math::AX_Matrix(C, A);
         for (auto component_1 = 0; component_1 < 3; ++component_1) {
             for (auto component_2 = 0; component_2 < 3; ++component_2) {
                 base_gradient_terms(component_1 + 3, component_2 + 3) = -A(component_1, component_2);

--- a/src/constraints/calculate_rigid_joint_constraint.hpp
+++ b/src/constraints/calculate_rigid_joint_constraint.hpp
@@ -69,7 +69,7 @@ struct CalculateRigidJointConstraint {
         }
 
         // Phi(3:6) = axial(R2*inv(RC)*inv(R1))
-	math::QuaternionCompose(R2, R1t, R2_R1t);
+        math::QuaternionCompose(R2, R1t, R2_R1t);
         math::QuaternionToRotationMatrix(R2_R1t, C);
         math::AxialVectorOfMatrix(C, V3);
         for (auto component = 0; component < 3; ++component) {
@@ -87,7 +87,7 @@ struct CalculateRigidJointConstraint {
         }
 
         // B(3:6,3:6) = AX(R1*RC*inv(R2)) = transpose(AX(R2*inv(RC)*inv(R1)))
-	math::AX_Matrix(C, A);
+        math::AX_Matrix(C, A);
         CopyMatrixTranspose::invoke(
             A, subview(target_gradient_terms, make_pair(3, 6), make_pair(3, 6))
         );
@@ -99,11 +99,11 @@ struct CalculateRigidJointConstraint {
         }
 
         // B(0:3,3:6) = tilde(R1*X0)
-	math::VecTilde(R1_X0, A);
+        math::VecTilde(R1_X0, A);
         CopyMatrix::invoke(A, subview(base_gradient_terms, make_pair(0, 3), make_pair(3, 6)));
 
         // B(3:6,3:6) = -AX(R2*inv(RC)*inv(R1))
-	math::AX_Matrix(C, A);
+        math::AX_Matrix(C, A);
         for (auto component_1 = 0; component_1 < 3; ++component_1) {
             for (auto component_2 = 0; component_2 < 3; ++component_2) {
                 base_gradient_terms(component_1 + 3, component_2 + 3) = -A(component_1, component_2);

--- a/src/constraints/calculate_rotation_control_constraint.hpp
+++ b/src/constraints/calculate_rotation_control_constraint.hpp
@@ -98,7 +98,7 @@ struct CalculateRotationControlConstraint {
         math::QuaternionInverse(Rb, RbT);
         math::QuaternionCompose(Rt, RcT, Rt_RcT);
         math::QuaternionCompose(Rt_RcT, RbT, Rt_RcT_RbT);
-	math::QuaternionToRotationMatrix(Rt_RcT_RbT, C);
+        math::QuaternionToRotationMatrix(Rt_RcT_RbT, C);
         math::AxialVectorOfMatrix(C, V3);
         CopyVector::invoke(V3, subview(residual_terms, make_pair(3, 6)));
 
@@ -115,7 +115,7 @@ struct CalculateRotationControlConstraint {
         }
 
         // B(3:6,3:6) = AX(Rb*Rc*inv(Rt)) = transpose(AX(Rt*inv(Rc)*inv(Rb)))
-	math::AX_Matrix(C, A);
+        math::AX_Matrix(C, A);
         CopyMatrixTranspose::invoke(
             A, subview(target_gradient_terms, make_pair(3, 6), make_pair(3, 6))
         );
@@ -129,11 +129,11 @@ struct CalculateRotationControlConstraint {
         }
 
         // B(0:3,3:6) = tilde(Rb*X0)
-	math::VecTilde(Rb_X0, A);
+        math::VecTilde(Rb_X0, A);
         CopyMatrix::invoke(A, subview(base_gradient_terms, make_pair(0, 3), make_pair(3, 6)));
 
         // B(3:6,3:6) = -AX(Rt*inv(Rc)*inv(Rb))
-	math::AX_Matrix(C, A);
+        math::AX_Matrix(C, A);
         for (auto component_1 = 0; component_1 < 3; ++component_1) {
             for (auto component_2 = 0; component_2 < 3; ++component_2) {
                 base_gradient_terms(component_1 + 3, component_2 + 3) = -A(component_1, component_2);

--- a/src/constraints/calculate_rotation_control_constraint.hpp
+++ b/src/constraints/calculate_rotation_control_constraint.hpp
@@ -73,7 +73,7 @@ struct CalculateRotationControlConstraint {
         //----------------------------------------------------------------------
 
         // Phi(0:3) = ut + X0 - ub - Rb*X0
-        RotateVectorByQuaternion(Rb, X0, Rb_X0);
+        math::RotateVectorByQuaternion(Rb, X0, Rb_X0);
         for (auto i = 0; i < 3; ++i) {
             residual_terms(i) = ut(i) + X0(i) - ub(i) - Rb_X0(i);
         }
@@ -91,15 +91,15 @@ struct CalculateRotationControlConstraint {
         }
 
         // Convert scaled axis to quaternion and calculate inverse
-        RotationVectorToQuaternion(RV, Rc);
-        QuaternionInverse(Rc, RcT);
+        math::RotationVectorToQuaternion(RV, Rc);
+        math::QuaternionInverse(Rc, RcT);
 
         // Phi(3:6) = axial(Rt*inv(Rc)*inv(Rb))
-        QuaternionInverse(Rb, RbT);
-        QuaternionCompose(Rt, RcT, Rt_RcT);
-        QuaternionCompose(Rt_RcT, RbT, Rt_RcT_RbT);
-        QuaternionToRotationMatrix(Rt_RcT_RbT, C);
-        AxialVectorOfMatrix(C, V3);
+        math::QuaternionInverse(Rb, RbT);
+        math::QuaternionCompose(Rt, RcT, Rt_RcT);
+        math::QuaternionCompose(Rt_RcT, RbT, Rt_RcT_RbT);
+	math::QuaternionToRotationMatrix(Rt_RcT_RbT, C);
+        math::AxialVectorOfMatrix(C, V3);
         CopyVector::invoke(V3, subview(residual_terms, make_pair(3, 6)));
 
         //----------------------------------------------------------------------
@@ -115,7 +115,7 @@ struct CalculateRotationControlConstraint {
         }
 
         // B(3:6,3:6) = AX(Rb*Rc*inv(Rt)) = transpose(AX(Rt*inv(Rc)*inv(Rb)))
-        AX_Matrix(C, A);
+	math::AX_Matrix(C, A);
         CopyMatrixTranspose::invoke(
             A, subview(target_gradient_terms, make_pair(3, 6), make_pair(3, 6))
         );
@@ -129,11 +129,11 @@ struct CalculateRotationControlConstraint {
         }
 
         // B(0:3,3:6) = tilde(Rb*X0)
-        VecTilde(Rb_X0, A);
+	math::VecTilde(Rb_X0, A);
         CopyMatrix::invoke(A, subview(base_gradient_terms, make_pair(0, 3), make_pair(3, 6)));
 
         // B(3:6,3:6) = -AX(Rt*inv(Rc)*inv(Rb))
-        AX_Matrix(C, A);
+	math::AX_Matrix(C, A);
         for (auto component_1 = 0; component_1 < 3; ++component_1) {
             for (auto component_2 = 0; component_2 < 3; ++component_2) {
                 base_gradient_terms(component_1 + 3, component_2 + 3) = -A(component_1, component_2);

--- a/src/constraints/constraints.hpp
+++ b/src/constraints/constraints.hpp
@@ -288,13 +288,13 @@ struct Constraints {
         std::array<std::array<double, 3>, 3> rotation_matrix{};
         if (constraint.type == ConstraintType::RevoluteJoint) {
             constexpr std::array<double, 3> x = {1., 0., 0.};
-            const std::array<double, 3> x_hat = Norm(constraint.axis_vector) != 0.
-                                                    ? UnitVector(constraint.axis_vector)
-                                                    : UnitVector(x0);
+            const std::array<double, 3> x_hat = math::Norm(constraint.axis_vector) != 0.
+                                                    ? math::UnitVector(constraint.axis_vector)
+                                                    : math::UnitVector(x0);
 
             // Create rotation matrix to rotate x to match vector
-            const auto cross_product = CrossProduct(x, x_hat);
-            const auto dot_product = DotProduct(x_hat, x);
+            const auto cross_product = math::CrossProduct(x, x_hat);
+            const auto dot_product = math::DotProduct(x_hat, x);
             const auto k = 1. / (1. + dot_product);
 
             // Set orthogonal unit vectors from the rotation matrix
@@ -315,7 +315,7 @@ struct Constraints {
 
         // Set rotation_matrix to the unit vector of the constraint axis for rotation control
         if (constraint.type == ConstraintType::RotationControl) {
-            const auto unit_vector = UnitVector(constraint.axis_vector);
+            const auto unit_vector = math::UnitVector(constraint.axis_vector);
             rotation_matrix[0][0] = unit_vector[0];
             rotation_matrix[0][1] = unit_vector[1];
             rotation_matrix[0][2] = unit_vector[2];

--- a/src/elements/beams/calculate_QP_position.hpp
+++ b/src/elements/beams/calculate_QP_position.hpp
@@ -48,7 +48,9 @@ struct CalculateQPPosition {
         // Calculate current orientation
         auto RR0_data = Kokkos::Array<double, 4>{};
         auto RR0 = View<double[4]>(RR0_data.data());
-	math::QuaternionCompose(subview(qp_r_, element, qp, ALL), subview(qp_r0_, element, qp, ALL), RR0);
+        math::QuaternionCompose(
+            subview(qp_r_, element, qp, ALL), subview(qp_r0_, element, qp, ALL), RR0
+        );
         qp_x_(element, qp, 3) = RR0(0);
         qp_x_(element, qp, 4) = RR0(1);
         qp_x_(element, qp, 5) = RR0(2);

--- a/src/elements/beams/calculate_QP_position.hpp
+++ b/src/elements/beams/calculate_QP_position.hpp
@@ -48,7 +48,7 @@ struct CalculateQPPosition {
         // Calculate current orientation
         auto RR0_data = Kokkos::Array<double, 4>{};
         auto RR0 = View<double[4]>(RR0_data.data());
-        QuaternionCompose(subview(qp_r_, element, qp, ALL), subview(qp_r0_, element, qp, ALL), RR0);
+	math::QuaternionCompose(subview(qp_r_, element, qp, ALL), subview(qp_r0_, element, qp, ALL), RR0);
         qp_x_(element, qp, 3) = RR0(0);
         qp_x_(element, qp, 4) = RR0(1);
         qp_x_(element, qp, 5) = RR0(2);

--- a/src/elements/beams/interpolate_QP_state.hpp
+++ b/src/elements/beams/interpolate_QP_state.hpp
@@ -97,7 +97,7 @@ struct InterpolateQPState_r {
         }
 
         for (auto component = 0U; component < 4U; ++component) {
-            qp_r(element, qp, component) = NormalizeQuaternion(local_total)[component];
+            qp_r(element, qp, component) = math::NormalizeQuaternion(local_total)[component];
         }
     }
 };

--- a/src/interfaces/components/beam.cpp
+++ b/src/interfaces/components/beam.cpp
@@ -92,8 +92,9 @@ void Beam::CreateNodeGeometry(const BeamInput& input) {
         const std::vector<double> kp_xi(math::MapGeometricLocations(input.ref_axis.coordinate_grid));
         const auto gll_points = GenerateGLLPoints(n_geometry_pts - 1);
         const auto phi_kn_geometry = math::ComputeShapeFunctionValues(kp_xi, gll_points);
-        const auto geometry_points =
-            math::PerformLeastSquaresFitting(n_geometry_pts, phi_kn_geometry, input.ref_axis.coordinates);
+        const auto geometry_points = math::PerformLeastSquaresFitting(
+            n_geometry_pts, phi_kn_geometry, input.ref_axis.coordinates
+        );
         const auto node_coords =
             math::ProjectPointsToTargetPolynomial(n_geometry_pts, n_nodes, geometry_points);
 

--- a/src/interfaces/components/beam.cpp
+++ b/src/interfaces/components/beam.cpp
@@ -89,13 +89,13 @@ void Beam::CreateNodeGeometry(const BeamInput& input) {
 
     if (n_geometry_pts < n_nodes) {
         // We need to project from n_geometry_pts -> element_order
-        const std::vector<double> kp_xi(MapGeometricLocations(input.ref_axis.coordinate_grid));
+        const std::vector<double> kp_xi(math::MapGeometricLocations(input.ref_axis.coordinate_grid));
         const auto gll_points = GenerateGLLPoints(n_geometry_pts - 1);
-        const auto phi_kn_geometry = ComputeShapeFunctionValues(kp_xi, gll_points);
+        const auto phi_kn_geometry = math::ComputeShapeFunctionValues(kp_xi, gll_points);
         const auto geometry_points =
-            PerformLeastSquaresFitting(n_geometry_pts, phi_kn_geometry, input.ref_axis.coordinates);
+            math::PerformLeastSquaresFitting(n_geometry_pts, phi_kn_geometry, input.ref_axis.coordinates);
         const auto node_coords =
-            ProjectPointsToTargetPolynomial(n_geometry_pts, n_nodes, geometry_points);
+            math::ProjectPointsToTargetPolynomial(n_geometry_pts, n_nodes, geometry_points);
 
         this->node_coordinates.clear();
         this->node_coordinates.reserve(node_coords.size());
@@ -104,10 +104,10 @@ void Beam::CreateNodeGeometry(const BeamInput& input) {
         );
     } else {
         // Fit node coordinates to key points
-        const std::vector<double> kp_xi(MapGeometricLocations(input.ref_axis.coordinate_grid));
-        const auto phi_kn = ComputeShapeFunctionValues(kp_xi, this->node_xi);
+        const std::vector<double> kp_xi(math::MapGeometricLocations(input.ref_axis.coordinate_grid));
+        const auto phi_kn = math::ComputeShapeFunctionValues(kp_xi, this->node_xi);
         this->node_coordinates =
-            PerformLeastSquaresFitting(n_nodes, phi_kn, input.ref_axis.coordinates);
+            math::PerformLeastSquaresFitting(n_nodes, phi_kn, input.ref_axis.coordinates);
     }
 
     // Calculate tangent vectors at each node
@@ -119,7 +119,7 @@ void Beam::CreateBeamElement(const BeamInput& input, Model& model) {
     std::vector<size_t> node_ids;
     for (auto node = 0U; node < this->node_xi.size(); ++node) {
         const auto& pos = this->node_coordinates[node];
-        const auto q_rot = TangentTwistToQuaternion(this->node_tangents[node], 0.);
+        const auto q_rot = math::TangentTwistToQuaternion(this->node_tangents[node], 0.);
         const auto node_id =
             model.AddNode()
                 .SetElemLocation((this->node_xi[node] + 1.) / 2.)
@@ -180,8 +180,8 @@ void Beam::CalcNodeTangents() {
     const auto n_nodes{this->node_coordinates.size()};
 
     // Calculate the derivative shape function matrix for the nodes
-    const auto phi = ComputeShapeFunctionValues(this->node_xi, this->node_xi);
-    const auto phi_prime = ComputeShapeFunctionDerivatives(this->node_xi, this->node_xi);
+    const auto phi = math::ComputeShapeFunctionValues(this->node_xi, this->node_xi);
+    const auto phi_prime = math::ComputeShapeFunctionDerivatives(this->node_xi, this->node_xi);
 
     // Calculate tangent vectors for each node
     this->node_tangents.resize(n_nodes, {0., 0., 0.});
@@ -199,7 +199,7 @@ void Beam::CalcNodeTangents() {
     std::transform(
         this->node_tangents.begin(), this->node_tangents.end(), this->node_tangents.begin(),
         [](std::array<double, 3>& tangent) {
-            const auto norm = Norm(tangent);
+            const auto norm = math::Norm(tangent);
             std::transform(tangent.begin(), tangent.end(), tangent.begin(), [norm](double v) {
                 return v / norm;
             });
@@ -215,10 +215,10 @@ std::vector<BeamSection> Beam::BuildBeamSections(const BeamInput& input) {
     // Add first section after rotating matrices to account for twist
     auto twist =
         LinearInterp(input.sections[0].location, input.ref_axis.twist_grid, input.ref_axis.twist);
-    auto q_twist = RotationVectorToQuaternion({twist * M_PI / 180., 0., 0.});
+    auto q_twist = math::RotationVectorToQuaternion({twist * M_PI / 180., 0., 0.});
     sections.emplace_back(
-        input.sections[0].location, RotateMatrix6(input.sections[0].mass_matrix, q_twist),
-        RotateMatrix6(input.sections[0].stiffness_matrix, q_twist)
+        input.sections[0].location, math::RotateMatrix6(input.sections[0].mass_matrix, q_twist),
+        math::RotateMatrix6(input.sections[0].stiffness_matrix, q_twist)
     );
 
     // Loop through remaining section locations
@@ -258,19 +258,19 @@ std::vector<BeamSection> Beam::BuildBeamSections(const BeamInput& input) {
             twist = LinearInterp(section_location, input.ref_axis.twist_grid, input.ref_axis.twist);
 
             // Add refinement section
-            q_twist = RotationVectorToQuaternion({twist * M_PI / 180., 0., 0.});
+            q_twist = math::RotationVectorToQuaternion({twist * M_PI / 180., 0., 0.});
             sections.emplace_back(
-                grid_value, RotateMatrix6(mass_matrix, q_twist),
-                RotateMatrix6(stiffness_matrix, q_twist)
+                grid_value, math::RotateMatrix6(mass_matrix, q_twist),
+                math::RotateMatrix6(stiffness_matrix, q_twist)
             );
         }
 
         // Add ending section
         twist = LinearInterp(section_location, input.ref_axis.twist_grid, input.ref_axis.twist);
-        q_twist = RotationVectorToQuaternion({twist * M_PI / 180., 0., 0.});
+        q_twist = math::RotationVectorToQuaternion({twist * M_PI / 180., 0., 0.});
         sections.emplace_back(
-            section_location, RotateMatrix6(section_mass_matrix, q_twist),
-            RotateMatrix6(section_stiffness_matrix, q_twist)
+            section_location, math::RotateMatrix6(section_mass_matrix, q_twist),
+            math::RotateMatrix6(section_stiffness_matrix, q_twist)
         );
     }
 

--- a/src/interfaces/components/beam_builder.cpp
+++ b/src/interfaces/components/beam_builder.cpp
@@ -31,7 +31,8 @@ BeamBuilder& BeamBuilder::AddRefAxisPoint(
     }
     if (ref_axis == ReferenceAxisOrientation::Z) {
         const auto q_z_to_x = math::RotationVectorToQuaternion({0., M_PI / 2., 0.});
-        input.ref_axis.coordinates.emplace_back(math::RotateVectorByQuaternion(q_z_to_x, coordinates));
+        input.ref_axis.coordinates.emplace_back(math::RotateVectorByQuaternion(q_z_to_x, coordinates)
+        );
         return *this;
     }
     throw std::invalid_argument("Invalid reference axis orientation");

--- a/src/interfaces/components/beam_builder.cpp
+++ b/src/interfaces/components/beam_builder.cpp
@@ -30,8 +30,8 @@ BeamBuilder& BeamBuilder::AddRefAxisPoint(
         return *this;
     }
     if (ref_axis == ReferenceAxisOrientation::Z) {
-        const auto q_z_to_x = RotationVectorToQuaternion({0., M_PI / 2., 0.});
-        input.ref_axis.coordinates.emplace_back(RotateVectorByQuaternion(q_z_to_x, coordinates));
+        const auto q_z_to_x = math::RotationVectorToQuaternion({0., M_PI / 2., 0.});
+        input.ref_axis.coordinates.emplace_back(math::RotateVectorByQuaternion(q_z_to_x, coordinates));
         return *this;
     }
     throw std::invalid_argument("Invalid reference axis orientation");
@@ -78,10 +78,10 @@ BeamBuilder& BeamBuilder::AddSection(
         return *this;
     }
     if (ref_axis == ReferenceAxisOrientation::Z) {
-        const auto q_z_to_x = RotationVectorToQuaternion({0., M_PI / 2., 0.});
+        const auto q_z_to_x = math::RotationVectorToQuaternion({0., M_PI / 2., 0.});
         input.sections.emplace_back(
-            grid_location, RotateMatrix6(mass_matrix, q_z_to_x),
-            RotateMatrix6(stiffness_matrix, q_z_to_x)
+            grid_location, math::RotateMatrix6(mass_matrix, q_z_to_x),
+            math::RotateMatrix6(stiffness_matrix, q_z_to_x)
         );
         return *this;
     }

--- a/src/interfaces/components/turbine.cpp
+++ b/src/interfaces/components/turbine.cpp
@@ -98,10 +98,10 @@ void Turbine::PositionNodes(const TurbineInput& input, Model& model) {
 
     // Calculate rotation quaternion to align a component from x-axis to z-axis (i.e.
     // rotate about y-axis by -90 degrees)
-    const auto q_x_to_z = RotationVectorToQuaternion({0., -M_PI / 2., 0.});
+    const auto q_x_to_z = math::RotationVectorToQuaternion({0., -M_PI / 2., 0.});
 
     // Calculate cone angle rotation quaternion (rotate about y-axis by -cone angle)
-    const auto q_cone = RotationVectorToQuaternion({0., -input.cone_angle, 0.});
+    const auto q_cone = math::RotationVectorToQuaternion({0., -input.cone_angle, 0.});
 
     //--------------------------------------------------------------------------
     // Position tower
@@ -161,7 +161,7 @@ void Turbine::PositionNodes(const TurbineInput& input, Model& model) {
 
         // Calculate azimuth angle rotation quaternion (rotate about x-axis)
         const auto q_azimuth =
-            RotationVectorToQuaternion({static_cast<double>(beam) * blade_angle_delta, 0., 0.});
+            math::RotationVectorToQuaternion({static_cast<double>(beam) * blade_angle_delta, 0., 0.});
 
         // Rotate blade nodes (including apex node) -> cone angle -> azimuth angle
         for (const auto& node_id : current_blade_node_ids) {
@@ -176,7 +176,7 @@ void Turbine::PositionNodes(const TurbineInput& input, Model& model) {
     //--------------------------------------------------------------------------
 
     // Create shaft rotation quaternion
-    const auto q_shaft_tilt = RotationVectorToQuaternion({0., input.shaft_tilt_angle, 0.});
+    const auto q_shaft_tilt = math::RotationVectorToQuaternion({0., input.shaft_tilt_angle, 0.});
 
     // Rotate rotor nodes by shaft tilt angle and translate to apex position
     for (const auto& node_id : this->rotor_node_ids) {
@@ -425,7 +425,7 @@ void Turbine::SetInitialDisplacements(const TurbineInput& input, Model& model) {
         };
 
         // Create rotation vector about the pitch axis
-        const auto pitch_axis_unit = UnitVector(pitch_axis);
+        const auto pitch_axis_unit = math::UnitVector(pitch_axis);
         const auto rotation_vector = std::array{
             input.blade_pitch_angle * pitch_axis_unit[0],
             input.blade_pitch_angle * pitch_axis_unit[1],
@@ -433,7 +433,7 @@ void Turbine::SetInitialDisplacements(const TurbineInput& input, Model& model) {
         };
 
         // Calculate pitch rotation quaternion
-        const auto q_pitch = RotationVectorToQuaternion(rotation_vector);
+        const auto q_pitch = math::RotationVectorToQuaternion(rotation_vector);
 
         // Use apex node position as rotation center
         const auto pitch_center = std::array{apex_node.x0[0], apex_node.x0[1], apex_node.x0[2]};
@@ -454,7 +454,7 @@ void Turbine::SetInitialDisplacements(const TurbineInput& input, Model& model) {
         const auto& tower_top_node = model.GetNode(this->tower.nodes.back().id);
 
         // Create yaw rotation quaternion (rotation about tower Z-axis)
-        const auto q_yaw = RotationVectorToQuaternion({0., 0., input.nacelle_yaw_angle});
+        const auto q_yaw = math::RotationVectorToQuaternion({0., 0., input.nacelle_yaw_angle});
 
         // Rotate all nacelle components about tower top position
         for (const auto& node_id : this->nacelle_node_ids) {
@@ -485,8 +485,8 @@ void Turbine::SetInitialDisplacements(const TurbineInput& input, Model& model) {
     };
 
     // Apply tower base displacement if displacement is non-zero or rotation is non-identity
-    if (Norm(tower_base_displacement) > kZeroTolerance ||
-        !IsIdentityQuaternion(tower_base_orientation, kZeroTolerance)) {
+    if (math::Norm(tower_base_displacement) > kZeroTolerance ||
+        !math::IsIdentityQuaternion(tower_base_orientation, kZeroTolerance)) {
         // Apply displacement to all turbine nodes
         for (const auto& node_id : this->all_turbine_node_ids) {
             // first rotate about original tower base position
@@ -510,7 +510,7 @@ void Turbine::SetInitialRotorVelocity(const TurbineInput& input, Model& model) {
     // Calculate shaft axis in current configuration
     const auto hub_position = model.GetNode(this->hub_node.id).DisplacedPosition();
     const auto shaft_base_position = model.GetNode(this->shaft_base_node.id).DisplacedPosition();
-    const auto shaft_axis = UnitVector(
+    const auto shaft_axis = math::UnitVector(
         {hub_position[0] - shaft_base_position[0], hub_position[1] - shaft_base_position[1],
          hub_position[2] - shaft_base_position[2]}
     );

--- a/src/interfaces/components/turbine.cpp
+++ b/src/interfaces/components/turbine.cpp
@@ -161,7 +161,8 @@ void Turbine::PositionNodes(const TurbineInput& input, Model& model) {
 
         // Calculate azimuth angle rotation quaternion (rotate about x-axis)
         const auto q_azimuth =
-            math::RotationVectorToQuaternion({static_cast<double>(beam) * blade_angle_delta, 0., 0.});
+            math::RotationVectorToQuaternion({static_cast<double>(beam) * blade_angle_delta, 0., 0.}
+            );
 
         // Rotate blade nodes (including apex node) -> cone angle -> azimuth angle
         for (const auto& node_id : current_blade_node_ids) {

--- a/src/math/least_squares_fit.hpp
+++ b/src/math/least_squares_fit.hpp
@@ -181,4 +181,4 @@ inline std::vector<std::array<double, 3>> PerformLeastSquaresFitting(
     return result;
 }
 
-}  // namespace openturbine
+}  // namespace openturbine::math

--- a/src/math/least_squares_fit.hpp
+++ b/src/math/least_squares_fit.hpp
@@ -14,7 +14,7 @@ namespace lapack {
 
 #include "elements/beams/interpolation.hpp"
 
-namespace openturbine {
+namespace openturbine::math {
 
 /**
  * @brief Maps input geometric locations -> normalized domain using linear mapping

--- a/src/math/matrix_operations.hpp
+++ b/src/math/matrix_operations.hpp
@@ -6,7 +6,7 @@
 
 #include "math/quaternion_operations.hpp"
 
-namespace openturbine {
+namespace openturbine::math {
 
 /**
  * @brief Computes AX(A) of a square matrix

--- a/src/math/matrix_operations.hpp
+++ b/src/math/matrix_operations.hpp
@@ -87,4 +87,4 @@ inline std::array<std::array<double, 6>, 6> RotateMatrix6(
     return mo;
 }
 
-}  // namespace openturbine
+}  // namespace openturbine::math

--- a/src/math/project_points_to_target_polynomial.hpp
+++ b/src/math/project_points_to_target_polynomial.hpp
@@ -6,7 +6,7 @@
 #include "elements/beams/interpolation.hpp"
 #include "least_squares_fit.hpp"
 
-namespace openturbine {
+namespace openturbine::math {
 
 /**
  * @brief Projects 3D points from a given (lower) polynomial representation to a target (higher)

--- a/src/math/project_points_to_target_polynomial.hpp
+++ b/src/math/project_points_to_target_polynomial.hpp
@@ -49,4 +49,4 @@ inline std::vector<std::array<double, 3>> ProjectPointsToTargetPolynomial(
     return output_points;
 }
 
-}  // namespace openturbine
+}  // namespace openturbine::math

--- a/src/math/quaternion_operations.hpp
+++ b/src/math/quaternion_operations.hpp
@@ -354,4 +354,4 @@ inline bool IsIdentityQuaternion(const std::array<double, 4>& q, double toleranc
            std::abs(q[2]) <= tolerance && std::abs(q[3]) <= tolerance;
 }
 
-}  // namespace openturbine
+}  // namespace openturbine::math

--- a/src/math/quaternion_operations.hpp
+++ b/src/math/quaternion_operations.hpp
@@ -7,7 +7,7 @@
 
 #include "vector_operations.hpp"
 
-namespace openturbine {
+namespace openturbine::math {
 
 /**
  * @brief Converts a 4x1 quaternion to a 3x3 rotation matrix and returns the result

--- a/src/math/vector_operations.hpp
+++ b/src/math/vector_operations.hpp
@@ -73,4 +73,4 @@ constexpr std::array<double, 3> UnitVector(const std::array<double, 3>& v) {
         v[2] / norm,
     };
 }
-}  // namespace openturbine
+}  // namespace openturbine::math

--- a/src/math/vector_operations.hpp
+++ b/src/math/vector_operations.hpp
@@ -4,7 +4,7 @@
 
 #include <Kokkos_Core.hpp>
 
-namespace openturbine {
+namespace openturbine::math {
 
 /// Converts a 3x1 vector to a 3x3 skew-symmetric matrix and returns the result
 template <typename VectorType, typename MatrixType>

--- a/src/model/node.hpp
+++ b/src/model/node.hpp
@@ -67,7 +67,7 @@ struct Node {
         displaced_position[2] = this->x0[2] + this->u[2];
 
         // Compose quaternions for orientation (w, i, j, k)
-        auto q_displaced = QuaternionCompose(
+        auto q_displaced = math::QuaternionCompose(
             {this->x0[3], this->x0[4], this->x0[5], this->x0[6]},  // initial orientation
             {this->u[3], this->u[4], this->u[5], this->u[6]}       // displacement orientation
         );
@@ -106,7 +106,7 @@ struct Node {
             std::array{this->x0[0] - point[0], this->x0[1] - point[1], this->x0[2] - point[2]};
 
         // Rotate the vector r using the provided quaternion q
-        const auto rotated_r = RotateVectorByQuaternion(q, r);
+        const auto rotated_r = math::RotateVectorByQuaternion(q, r);
 
         // Update the position by adding the rotated vector to the reference point
         this->x0[0] = rotated_r[0] + point[0];
@@ -117,7 +117,7 @@ struct Node {
         // Orientation, x(3:6)
         //----------------------------------------------------
         // Compose q with initial orientation to get rotated orientation
-        auto q_new = QuaternionCompose(q, {this->x0[3], this->x0[4], this->x0[5], this->x0[6]});
+        auto q_new = math::QuaternionCompose(q, {this->x0[3], this->x0[4], this->x0[5], this->x0[6]});
 
         // Update the orientation
         this->x0[3] = q_new[0];
@@ -130,7 +130,7 @@ struct Node {
 
     /// Rotate node by a rotation vector about the given point
     Node& RotateAboutPoint(const std::array<double, 3>& rv, const std::array<double, 3>& point) {
-        const auto q = RotationVectorToQuaternion(rv);
+        const auto q = math::RotationVectorToQuaternion(rv);
         this->RotateAboutPoint(q, point);
         return *this;
     }
@@ -162,7 +162,7 @@ struct Node {
         };
 
         // Rotate the vector r using the provided quaternion q
-        const auto rotated_r = RotateVectorByQuaternion(q, r);
+        const auto rotated_r = math::RotateVectorByQuaternion(q, r);
 
         // Update the displacement position by adding the rotated vector to the reference point
         // and subtracting the initial position
@@ -174,7 +174,7 @@ struct Node {
         // Displacement orientation, u(3:6)
         //----------------------------------------------------
         // Compose q with initial displacement orientation to get rotated displacement orientation
-        auto q_new = QuaternionCompose(q, {this->u[3], this->u[4], this->u[5], this->u[6]});
+        auto q_new = math::QuaternionCompose(q, {this->u[3], this->u[4], this->u[5], this->u[6]});
 
         // Update the displacement orientation
         this->u[3] = q_new[0];
@@ -189,7 +189,7 @@ struct Node {
     Node& RotateDisplacementAboutPoint(
         const std::array<double, 3>& rv, const std::array<double, 3>& point
     ) {
-        const auto q = RotationVectorToQuaternion(rv);
+        const auto q = math::RotationVectorToQuaternion(rv);
         this->RotateDisplacementAboutPoint(q, point);
         return *this;
     }
@@ -211,7 +211,7 @@ struct Node {
 
         // Calculate velocity contribution from angular velocity
         const auto omega = std::array{velocity[3], velocity[4], velocity[5]};
-        const auto omega_cross_r = CrossProduct(omega, r);
+        const auto omega_cross_r = math::CrossProduct(omega, r);
 
         // Set node translational velocity
         this->v[0] = velocity[0] + omega_cross_r[0];
@@ -242,8 +242,8 @@ struct Node {
 
         // Calculate translational acceleration contribution from angular velocity
         const auto alpha = std::array{acceleration[3], acceleration[4], acceleration[5]};
-        const auto alpha_cross_r = CrossProduct(alpha, r);
-        const auto omega_cross_omega_cross_r = CrossProduct(omega, CrossProduct(omega, r));
+        const auto alpha_cross_r = math::CrossProduct(alpha, r);
+        const auto omega_cross_omega_cross_r = math::CrossProduct(omega, math::CrossProduct(omega, r));
 
         // Set node translational acceleration
         this->vd[0] = acceleration[0] + alpha_cross_r[0] + omega_cross_omega_cross_r[0];

--- a/src/model/node.hpp
+++ b/src/model/node.hpp
@@ -117,7 +117,8 @@ struct Node {
         // Orientation, x(3:6)
         //----------------------------------------------------
         // Compose q with initial orientation to get rotated orientation
-        auto q_new = math::QuaternionCompose(q, {this->x0[3], this->x0[4], this->x0[5], this->x0[6]});
+        auto q_new =
+            math::QuaternionCompose(q, {this->x0[3], this->x0[4], this->x0[5], this->x0[6]});
 
         // Update the orientation
         this->x0[3] = q_new[0];
@@ -243,7 +244,8 @@ struct Node {
         // Calculate translational acceleration contribution from angular velocity
         const auto alpha = std::array{acceleration[3], acceleration[4], acceleration[5]};
         const auto alpha_cross_r = math::CrossProduct(alpha, r);
-        const auto omega_cross_omega_cross_r = math::CrossProduct(omega, math::CrossProduct(omega, r));
+        const auto omega_cross_omega_cross_r =
+            math::CrossProduct(omega, math::CrossProduct(omega, r));
 
         // Set node translational acceleration
         this->vd[0] = acceleration[0] + alpha_cross_r[0] + omega_cross_omega_cross_r[0];

--- a/src/state/calculate_displacement.hpp
+++ b/src/state/calculate_displacement.hpp
@@ -36,13 +36,13 @@ struct CalculateDisplacement {
 
         auto quat_delta_data = Array<double, 4>{};
         auto quat_delta = View<double[4]>{quat_delta_data.data()};
-	math::RotationVectorToQuaternion(delta, quat_delta);
+        math::RotationVectorToQuaternion(delta, quat_delta);
         auto quat_prev_data =
             Array<double, 4>{q_prev(node, 3), q_prev(node, 4), q_prev(node, 5), q_prev(node, 6)};
         auto quat_prev = View<double[4]>{quat_prev_data.data()};
         auto quat_new_data = Array<double, 4>{};
         auto quat_new = View<double[4]>{quat_new_data.data()};
-	math::QuaternionCompose(quat_delta, quat_prev, quat_new);
+        math::QuaternionCompose(quat_delta, quat_prev, quat_new);
 
         for (auto component = 0; component < 4; ++component) {
             q(node, component + 3) = quat_new(component);

--- a/src/state/calculate_displacement.hpp
+++ b/src/state/calculate_displacement.hpp
@@ -36,13 +36,13 @@ struct CalculateDisplacement {
 
         auto quat_delta_data = Array<double, 4>{};
         auto quat_delta = View<double[4]>{quat_delta_data.data()};
-        RotationVectorToQuaternion(delta, quat_delta);
+	math::RotationVectorToQuaternion(delta, quat_delta);
         auto quat_prev_data =
             Array<double, 4>{q_prev(node, 3), q_prev(node, 4), q_prev(node, 5), q_prev(node, 6)};
         auto quat_prev = View<double[4]>{quat_prev_data.data()};
         auto quat_new_data = Array<double, 4>{};
         auto quat_new = View<double[4]>{quat_new_data.data()};
-        QuaternionCompose(quat_delta, quat_prev, quat_new);
+	math::QuaternionCompose(quat_delta, quat_prev, quat_new);
 
         for (auto component = 0; component < 4; ++component) {
             q(node, component + 3) = quat_new(component);

--- a/src/state/update_global_position.hpp
+++ b/src/state/update_global_position.hpp
@@ -35,7 +35,7 @@ struct UpdateGlobalPosition {
         // Calculate global orientation
         auto node_x_data = Array<double, 4>{};
         const auto node_x = View<double[4]>{node_x_data.data()};
-	math::QuaternionCompose(
+        math::QuaternionCompose(
             subview(q, node, make_pair(3, 7)), subview(x0, node, make_pair(3, 7)), node_x
         );
         x(node, 3) = node_x(0);

--- a/src/state/update_global_position.hpp
+++ b/src/state/update_global_position.hpp
@@ -35,7 +35,7 @@ struct UpdateGlobalPosition {
         // Calculate global orientation
         auto node_x_data = Array<double, 4>{};
         const auto node_x = View<double[4]>{node_x_data.data()};
-        QuaternionCompose(
+	math::QuaternionCompose(
             subview(q, node, make_pair(3, 7)), subview(x0, node, make_pair(3, 7)), node_x
         );
         x(node, 3) = node_x(0);

--- a/src/system/beams/calculate_inertial_quadrature_point_values.hpp
+++ b/src/system/beams/calculate_inertial_quadrature_point_values.hpp
@@ -95,16 +95,16 @@ struct CalculateInertialQuadraturePointValues {
             omega_dot
         );
 
-        QuaternionCompose(r, r0, xr);
+	math::QuaternionCompose(r, r0, xr);
         masses::RotateSectionMatrix<DeviceType>::invoke(xr, Mstar, Muu);
 
         const auto mass = Muu(0, 0);
         masses::CalculateEta<DeviceType>(Muu, eta);
-        VecTilde(eta, eta_tilde);
+	math::VecTilde(eta, eta_tilde);
         masses::CalculateRho<DeviceType>(Muu, rho);
 
-        VecTilde(omega, omega_tilde);
-        VecTilde(omega_dot, omega_dot_tilde);
+	math::VecTilde(omega, omega_tilde);
+	math::VecTilde(omega_dot, omega_dot_tilde);
 
         masses::CalculateInertialForce<DeviceType>::invoke(
             mass, u_ddot, omega, omega_dot, eta, eta_tilde, rho, omega_tilde, omega_dot_tilde, FI

--- a/src/system/beams/calculate_inertial_quadrature_point_values.hpp
+++ b/src/system/beams/calculate_inertial_quadrature_point_values.hpp
@@ -95,16 +95,16 @@ struct CalculateInertialQuadraturePointValues {
             omega_dot
         );
 
-	math::QuaternionCompose(r, r0, xr);
+        math::QuaternionCompose(r, r0, xr);
         masses::RotateSectionMatrix<DeviceType>::invoke(xr, Mstar, Muu);
 
         const auto mass = Muu(0, 0);
         masses::CalculateEta<DeviceType>(Muu, eta);
-	math::VecTilde(eta, eta_tilde);
+        math::VecTilde(eta, eta_tilde);
         masses::CalculateRho<DeviceType>(Muu, rho);
 
-	math::VecTilde(omega, omega_tilde);
-	math::VecTilde(omega_dot, omega_dot_tilde);
+        math::VecTilde(omega, omega_tilde);
+        math::VecTilde(omega_dot, omega_dot_tilde);
 
         masses::CalculateInertialForce<DeviceType>::invoke(
             mass, u_ddot, omega, omega_dot, eta, eta_tilde, rho, omega_tilde, omega_dot_tilde, FI

--- a/src/system/beams/calculate_stiffness_quadrature_point_values.hpp
+++ b/src/system/beams/calculate_stiffness_quadrature_point_values.hpp
@@ -102,7 +102,7 @@ struct CalculateStiffnessQuadraturePointValues {
             qp_jacobian(qp), subview(shape_interp, ALL, qp), subview(shape_deriv, ALL, qp), node_u,
             u, r, u_prime, r_prime
         );
-	math::QuaternionCompose(r, r0, xr);
+        math::QuaternionCompose(r, r0, xr);
 
         masses::RotateSectionMatrix<DeviceType>::invoke(xr, Cstar, Cuu);
 
@@ -111,8 +111,8 @@ struct CalculateStiffnessQuadraturePointValues {
         beams::CalculateForceFC<DeviceType>::invoke(Cuu, strain, FC);
         beams::CalculateForceFD<DeviceType>::invoke(x0pupSS, FC, FD);
 
-	math::VecTilde(subview(FC, make_pair(0, 3)), N_tilde);
-	math::VecTilde(subview(FC, make_pair(3, 6)), M_tilde);
+        math::VecTilde(subview(FC, make_pair(0, 3)), N_tilde);
+        math::VecTilde(subview(FC, make_pair(3, 6)), M_tilde);
 
         beams::CalculateOuu<DeviceType>::invoke(Cuu, x0pupSS, M_tilde, N_tilde, Ouu);
         beams::CalculatePuu<DeviceType>::invoke(Cuu, x0pupSS, N_tilde, Puu);

--- a/src/system/beams/calculate_stiffness_quadrature_point_values.hpp
+++ b/src/system/beams/calculate_stiffness_quadrature_point_values.hpp
@@ -102,7 +102,7 @@ struct CalculateStiffnessQuadraturePointValues {
             qp_jacobian(qp), subview(shape_interp, ALL, qp), subview(shape_deriv, ALL, qp), node_u,
             u, r, u_prime, r_prime
         );
-        QuaternionCompose(r, r0, xr);
+	math::QuaternionCompose(r, r0, xr);
 
         masses::RotateSectionMatrix<DeviceType>::invoke(xr, Cstar, Cuu);
 
@@ -111,8 +111,8 @@ struct CalculateStiffnessQuadraturePointValues {
         beams::CalculateForceFC<DeviceType>::invoke(Cuu, strain, FC);
         beams::CalculateForceFD<DeviceType>::invoke(x0pupSS, FC, FD);
 
-        VecTilde(subview(FC, make_pair(0, 3)), N_tilde);
-        VecTilde(subview(FC, make_pair(3, 6)), M_tilde);
+	math::VecTilde(subview(FC, make_pair(0, 3)), N_tilde);
+	math::VecTilde(subview(FC, make_pair(3, 6)), M_tilde);
 
         beams::CalculateOuu<DeviceType>::invoke(Cuu, x0pupSS, M_tilde, N_tilde, Ouu);
         beams::CalculatePuu<DeviceType>::invoke(Cuu, x0pupSS, N_tilde, Puu);

--- a/src/system/beams/calculate_strain.hpp
+++ b/src/system/beams/calculate_strain.hpp
@@ -27,13 +27,13 @@ struct CalculateStrain {
         auto R_x0_prime_data = Array<double, 3>{};
         auto R_x0_prime = View<double[3]>(R_x0_prime_data.data());
 
-        RotateVectorByQuaternion(r, x0_prime, R_x0_prime);
+	math::RotateVectorByQuaternion(r, x0_prime, R_x0_prime);
         KokkosBlas::serial_axpy(-1., u_prime, R_x0_prime);
         KokkosBlas::serial_axpy(-1., x0_prime, R_x0_prime);
 
         auto E_data = Array<double, 12>{};
         auto E = View<double[3][4]>(E_data.data());
-        QuaternionDerivative(r, E);
+	math::QuaternionDerivative(r, E);
         auto e2_data = Array<double, 4>{};
         auto e2 = View<double[4]>{e2_data.data()};
         Gemv::invoke(2., E, r_prime, 0., e2);

--- a/src/system/beams/calculate_strain.hpp
+++ b/src/system/beams/calculate_strain.hpp
@@ -27,13 +27,13 @@ struct CalculateStrain {
         auto R_x0_prime_data = Array<double, 3>{};
         auto R_x0_prime = View<double[3]>(R_x0_prime_data.data());
 
-	math::RotateVectorByQuaternion(r, x0_prime, R_x0_prime);
+        math::RotateVectorByQuaternion(r, x0_prime, R_x0_prime);
         KokkosBlas::serial_axpy(-1., u_prime, R_x0_prime);
         KokkosBlas::serial_axpy(-1., x0_prime, R_x0_prime);
 
         auto E_data = Array<double, 12>{};
         auto E = View<double[3][4]>(E_data.data());
-	math::QuaternionDerivative(r, E);
+        math::QuaternionDerivative(r, E);
         auto e2_data = Array<double, 4>{};
         auto e2 = View<double[4]>{e2_data.data()};
         Gemv::invoke(2., E, r_prime, 0., e2);

--- a/src/system/beams/calculate_temporary_variables.hpp
+++ b/src/system/beams/calculate_temporary_variables.hpp
@@ -24,7 +24,7 @@ struct CalculateTemporaryVariables {
         const auto x0pup = View<double[3]>(x0pup_data.data());
 
         KokkosBlas::serial_axpy(1., u_prime, x0pup);
-	math::VecTilde(x0pup, x0pupSS);
+        math::VecTilde(x0pup, x0pupSS);
     }
 };
 }  // namespace openturbine::beams

--- a/src/system/beams/calculate_temporary_variables.hpp
+++ b/src/system/beams/calculate_temporary_variables.hpp
@@ -24,7 +24,7 @@ struct CalculateTemporaryVariables {
         const auto x0pup = View<double[3]>(x0pup_data.data());
 
         KokkosBlas::serial_axpy(1., u_prime, x0pup);
-        VecTilde(x0pup, x0pupSS);
+	math::VecTilde(x0pup, x0pupSS);
     }
 };
 }  // namespace openturbine::beams

--- a/src/system/calculate_tangent_operator.hpp
+++ b/src/system/calculate_tangent_operator.hpp
@@ -55,7 +55,7 @@ struct CalculateTangentOperator {
         const auto tmp1 = (phi > 1.e-16) ? (Kokkos::cos(phi) - 1.) / (phi * phi) : 0.;
         const auto tmp2 = (phi > 1.e-16) ? (1. - Kokkos::sin(phi) / phi) / (phi * phi) : 0.;
 
-        VecTilde(rv, m2);
+	math::VecTilde(rv, m2);
         CopyMatrix::invoke(m2, m1);
         Gemm::invoke(tmp2, m2, m2, tmp1, m1);
 

--- a/src/system/calculate_tangent_operator.hpp
+++ b/src/system/calculate_tangent_operator.hpp
@@ -55,7 +55,7 @@ struct CalculateTangentOperator {
         const auto tmp1 = (phi > 1.e-16) ? (Kokkos::cos(phi) - 1.) / (phi * phi) : 0.;
         const auto tmp2 = (phi > 1.e-16) ? (1. - Kokkos::sin(phi) / phi) / (phi * phi) : 0.;
 
-	math::VecTilde(rv, m2);
+        math::VecTilde(rv, m2);
         CopyMatrix::invoke(m2, m1);
         Gemm::invoke(tmp2, m2, m2, tmp1, m1);
 

--- a/src/system/masses/calculate_gyroscopic_matrix.hpp
+++ b/src/system/masses/calculate_gyroscopic_matrix.hpp
@@ -46,14 +46,14 @@ struct CalculateGyroscopicMatrix {
         auto Guu_12 = subview(Guu, make_pair(0, 3), make_pair(3, 6));
         KokkosBlas::serial_axpy(mass, eta, V1);
         Gemv::invoke(1., omega_tilde, V1, 0., V2);
-	math::VecTilde(V2, M1);
+        math::VecTilde(V2, M1);
         CopyMatrixTranspose::invoke(M1, Guu_12);
 
-	math::VecTilde(V1, M1);
+        math::VecTilde(V1, M1);
         GemmNT::invoke(1., omega_tilde, M1, 1., Guu_12);
         // Guu_22 = omega.tilde() * rho - (rho * omega).tilde()
         Gemv::invoke(1., rho, omega, 0., V1);
-	math::VecTilde(V1, M1);
+        math::VecTilde(V1, M1);
         auto Guu_22 = subview(Guu, make_pair(3, 6), make_pair(3, 6));
         CopyMatrix::invoke(M1, Guu_22);
         GemmNN::invoke(1., omega_tilde, rho, -1., Guu_22);

--- a/src/system/masses/calculate_gyroscopic_matrix.hpp
+++ b/src/system/masses/calculate_gyroscopic_matrix.hpp
@@ -46,14 +46,14 @@ struct CalculateGyroscopicMatrix {
         auto Guu_12 = subview(Guu, make_pair(0, 3), make_pair(3, 6));
         KokkosBlas::serial_axpy(mass, eta, V1);
         Gemv::invoke(1., omega_tilde, V1, 0., V2);
-        VecTilde(V2, M1);
+	math::VecTilde(V2, M1);
         CopyMatrixTranspose::invoke(M1, Guu_12);
 
-        VecTilde(V1, M1);
+	math::VecTilde(V1, M1);
         GemmNT::invoke(1., omega_tilde, M1, 1., Guu_12);
         // Guu_22 = omega.tilde() * rho - (rho * omega).tilde()
         Gemv::invoke(1., rho, omega, 0., V1);
-        VecTilde(V1, M1);
+	math::VecTilde(V1, M1);
         auto Guu_22 = subview(Guu, make_pair(3, 6), make_pair(3, 6));
         CopyMatrix::invoke(M1, Guu_22);
         GemmNN::invoke(1., omega_tilde, rho, -1., Guu_22);

--- a/src/system/masses/calculate_inertia_stiffness_matrix.hpp
+++ b/src/system/masses/calculate_inertia_stiffness_matrix.hpp
@@ -43,18 +43,18 @@ struct CalculateInertiaStiffnessMatrix {
         KokkosBlas::serial_axpy(1., omega_dot_tilde, M1);
         GemmNN::invoke(1., omega_tilde, omega_tilde, 1., M1);
         KokkosBlas::serial_axpy(mass, eta, V1);
-	math::VecTilde(V1, M2);
+        math::VecTilde(V1, M2);
         auto Kuu_12 = subview(Kuu, make_pair(0, 3), make_pair(3, 6));
         GemmNT::invoke(1., M1, M2, 0., Kuu_12);
-	math::VecTilde(u_ddot, M1);
+        math::VecTilde(u_ddot, M1);
         auto Kuu_22 = subview(Kuu, make_pair(3, 6), make_pair(3, 6));
         GemmNN::invoke(1., rho, omega_dot_tilde, 0., Kuu_22);
         GemmNN::invoke(1., M1, M2, 1., Kuu_22);
         Gemv::invoke(1., rho, omega_dot, 0., V1);
-	math::VecTilde(V1, M2);
+        math::VecTilde(V1, M2);
         KokkosBlas::serial_axpy(-1., M2, Kuu_22);
         Gemv::invoke(1., rho, omega, 0., V1);
-	math::VecTilde(V1, M1);
+        math::VecTilde(V1, M1);
         GemmNN::invoke(1., rho, omega_tilde, -1., M1);
         GemmNN::invoke(1., omega_tilde, M1, 1., Kuu_22);
     }

--- a/src/system/masses/calculate_inertia_stiffness_matrix.hpp
+++ b/src/system/masses/calculate_inertia_stiffness_matrix.hpp
@@ -43,18 +43,18 @@ struct CalculateInertiaStiffnessMatrix {
         KokkosBlas::serial_axpy(1., omega_dot_tilde, M1);
         GemmNN::invoke(1., omega_tilde, omega_tilde, 1., M1);
         KokkosBlas::serial_axpy(mass, eta, V1);
-        VecTilde(V1, M2);
+	math::VecTilde(V1, M2);
         auto Kuu_12 = subview(Kuu, make_pair(0, 3), make_pair(3, 6));
         GemmNT::invoke(1., M1, M2, 0., Kuu_12);
-        VecTilde(u_ddot, M1);
+	math::VecTilde(u_ddot, M1);
         auto Kuu_22 = subview(Kuu, make_pair(3, 6), make_pair(3, 6));
         GemmNN::invoke(1., rho, omega_dot_tilde, 0., Kuu_22);
         GemmNN::invoke(1., M1, M2, 1., Kuu_22);
         Gemv::invoke(1., rho, omega_dot, 0., V1);
-        VecTilde(V1, M2);
+	math::VecTilde(V1, M2);
         KokkosBlas::serial_axpy(-1., M2, Kuu_22);
         Gemv::invoke(1., rho, omega, 0., V1);
-        VecTilde(V1, M1);
+	math::VecTilde(V1, M1);
         GemmNN::invoke(1., rho, omega_tilde, -1., M1);
         GemmNN::invoke(1., omega_tilde, M1, 1., Kuu_22);
     }

--- a/src/system/masses/calculate_quadrature_point_values.hpp
+++ b/src/system/masses/calculate_quadrature_point_values.hpp
@@ -83,7 +83,7 @@ struct CalculateQuadraturePointValues {
             const auto xr = View<double[4]>(xr_data.data());
 
             CopyMatrix::invoke(subview(qp_Mstar, element, ALL, ALL), Mstar);
-	    math::QuaternionCompose(r, r0, xr);
+            math::QuaternionCompose(r, r0, xr);
             math::VecTilde(omega, omega_tilde);
             math::VecTilde(omega_dot, omega_dot_tilde);
 
@@ -104,7 +104,7 @@ struct CalculateQuadraturePointValues {
 
             const auto mass = Muu(0, 0);
 
-	    math::VecTilde(eta, eta_tilde);
+            math::VecTilde(eta, eta_tilde);
 
             CalculateGravityForce<DeviceType>::invoke(mass, gravity, eta_tilde, Fg);
             CalculateInertialForce<DeviceType>::invoke(

--- a/src/system/masses/calculate_quadrature_point_values.hpp
+++ b/src/system/masses/calculate_quadrature_point_values.hpp
@@ -83,9 +83,9 @@ struct CalculateQuadraturePointValues {
             const auto xr = View<double[4]>(xr_data.data());
 
             CopyMatrix::invoke(subview(qp_Mstar, element, ALL, ALL), Mstar);
-            QuaternionCompose(r, r0, xr);
-            VecTilde(omega, omega_tilde);
-            VecTilde(omega_dot, omega_dot_tilde);
+	    math::QuaternionCompose(r, r0, xr);
+            math::VecTilde(omega, omega_tilde);
+            math::VecTilde(omega_dot, omega_dot_tilde);
 
             RotateSectionMatrix<DeviceType>::invoke(xr, Mstar, Muu);
 
@@ -104,7 +104,7 @@ struct CalculateQuadraturePointValues {
 
             const auto mass = Muu(0, 0);
 
-            VecTilde(eta, eta_tilde);
+	    math::VecTilde(eta, eta_tilde);
 
             CalculateGravityForce<DeviceType>::invoke(mass, gravity, eta_tilde, Fg);
             CalculateInertialForce<DeviceType>::invoke(

--- a/src/system/masses/rotate_section_matrix.hpp
+++ b/src/system/masses/rotate_section_matrix.hpp
@@ -30,7 +30,7 @@ struct RotateSectionMatrix {
 
         auto RR0_data = Array<double, 9>{};
         auto RR0 = View<double[3][3]>(RR0_data.data());
-	math::QuaternionToRotationMatrix(xr, RR0);
+        math::QuaternionToRotationMatrix(xr, RR0);
 
         const auto Cstar_top = subview(Cstar, make_pair(0, 3), ALL);
         const auto Cstar_bottom = subview(Cstar, make_pair(3, 6), ALL);

--- a/src/system/masses/rotate_section_matrix.hpp
+++ b/src/system/masses/rotate_section_matrix.hpp
@@ -30,7 +30,7 @@ struct RotateSectionMatrix {
 
         auto RR0_data = Array<double, 9>{};
         auto RR0 = View<double[3][3]>(RR0_data.data());
-        QuaternionToRotationMatrix(xr, RR0);
+	math::QuaternionToRotationMatrix(xr, RR0);
 
         const auto Cstar_top = subview(Cstar, make_pair(0, 3), ALL);
         const auto Cstar_bottom = subview(Cstar, make_pair(3, 6), ALL);

--- a/src/system/springs/calculate_stiffness_matrix.hpp
+++ b/src/system/springs/calculate_stiffness_matrix.hpp
@@ -31,7 +31,7 @@ struct CalculateStiffnessMatrix {
         a(1, 1) = diag_term;
         a(2, 2) = diag_term;
 
-        VecTilde(r, r_tilde);
+	math::VecTilde(r, r_tilde);
         Gemm::invoke(-c2, r_tilde, r_tilde, 1., a);
     }
 };

--- a/src/system/springs/calculate_stiffness_matrix.hpp
+++ b/src/system/springs/calculate_stiffness_matrix.hpp
@@ -31,7 +31,7 @@ struct CalculateStiffnessMatrix {
         a(1, 1) = diag_term;
         a(2, 2) = diag_term;
 
-	math::VecTilde(r, r_tilde);
+        math::VecTilde(r, r_tilde);
         Gemm::invoke(-c2, r_tilde, r_tilde, 1., a);
     }
 };

--- a/src/utilities/aerodynamics/aerodyn_inflow.hpp
+++ b/src/utilities/aerodynamics/aerodyn_inflow.hpp
@@ -170,7 +170,7 @@ inline void SetPositionAndOrientation(
     }
 
     // Set orientation (converts last 4 elements i.e. quaternion -> 3x3 rotation matrix)
-    orientation = QuaternionToRotationMatrix({data[3], data[4], data[5], data[6]});
+    orientation = math::QuaternionToRotationMatrix({data[3], data[4], data[5], data[6]});
 }
 
 /**
@@ -393,13 +393,13 @@ struct TurbineData {
         }
 
         // Rotation to convert blade orientation
-        const auto r_x2z = RotationVectorToQuaternion({0., M_PI / 2., 0.});
+        const auto r_x2z = math::RotationVectorToQuaternion({0., M_PI / 2., 0.});
 
         // Original orientation
         const std::array<double, 4> r{position[3], position[4], position[5], position[6]};
 
         // Converted orientation
-        const auto r_adi = QuaternionCompose(r, r_x2z);
+        const auto r_adi = math::QuaternionCompose(r, r_x2z);
 
         // Position with new orientation
         const std::array<double, 7> position_new{position[0], position[1], position[2], r_adi[0],
@@ -430,13 +430,13 @@ struct TurbineData {
         }
 
         // Rotation to convert blade orientation
-        const auto r_x2z = RotationVectorToQuaternion({0., M_PI / 2., 0.});
+        const auto r_x2z = math::RotationVectorToQuaternion({0., M_PI / 2., 0.});
 
         // Original orientation
         const auto r = std::array{position[3], position[4], position[5], position[6]};
 
         // Converted orientation
-        const auto r_adi = QuaternionCompose(r, r_x2z);
+        const auto r_adi = math::QuaternionCompose(r, r_x2z);
 
         // Position with new orientation
         const auto position_new = std::array{position[0], position[1], position[2], r_adi[0],

--- a/tests/documentation_tests/heavy_top/heavy_top.cpp
+++ b/tests/documentation_tests/heavy_top/heavy_top.cpp
@@ -15,8 +15,8 @@ int main() {
         constexpr auto mass = 15.;                                         // mass
         constexpr auto inertia = std::array{0.234375, 0.46875, 0.234375};  // inertia matrix
         const auto x = std::array{0., 1., 0.};                             // initial position
-        const auto omega = std::array{0., 150., -4.61538};       // initial angular velocity
-        const auto x_dot = openturbine::CrossProduct(omega, x);  // initial velocity
+        const auto omega = std::array{0., 150., -4.61538};             // initial angular velocity
+        const auto x_dot = openturbine::math::CrossProduct(omega, x);  // initial velocity
         const auto omega_dot =
             std::array{661.3461692307691919, 0., 0.};  // initial anguluar acceleration
         const auto x_ddot =

--- a/tests/documentation_tests/three_blade_rotor/three_blade_rotor.cpp
+++ b/tests/documentation_tests/three_blade_rotor/three_blade_rotor.cpp
@@ -84,7 +84,7 @@ int main() {
                 }
             );
             auto blade_elem_id = model.AddBeamElement(beam_node_ids, sections, quadrature);
-            auto rotation_quaternion = openturbine::RotationVectorToQuaternion(
+            auto rotation_quaternion = openturbine::math::RotationVectorToQuaternion(
                 {0., 0., 2. * M_PI * blade_number / num_blades}
             );
             model.TranslateBeam(blade_elem_id, {hub_radius, 0., 0.});
@@ -141,7 +141,7 @@ int main() {
         // For this problem, we will prescribe a rotation on the hub boundary condition, which will
         // be transmitted to the blades through their respective constraints.
         for (auto i = 0U; i < num_steps; ++i) {
-            const auto q_hub = openturbine::RotationVectorToQuaternion(
+            const auto q_hub = openturbine::math::RotationVectorToQuaternion(
                 {step_size * (i + 1) * velocity[3], step_size * (i + 1) * velocity[4],
                  step_size * (i + 1) * velocity[5]}
             );

--- a/tests/regression_tests/external/test_rotor_aero_controller.cpp
+++ b/tests/regression_tests/external/test_rotor_aero_controller.cpp
@@ -229,7 +229,7 @@ TEST(Milestone, IEA15RotorAeroController) {
     // Blade nodes and elements
     //--------------------------------------------------------------------------
 
-    auto base_rot = RotationVectorToQuaternion({0., -M_PI / 2., 0.});
+    auto base_rot = math::RotationVectorToQuaternion({0., -M_PI / 2., 0.});
 
     // Number of nodes and quadrature points in each blade
     constexpr auto n_blade_nodes = node_xi.size();
@@ -254,7 +254,7 @@ TEST(Milestone, IEA15RotorAeroController) {
     q_roots.reserve(n_blades);
     for (auto i = 0U; i < n_blades; ++i) {
         q_roots.emplace_back(
-            RotationVectorToQuaternion({d_theta * static_cast<double>(i) + azimuth_init, 0., 0.})
+            math::RotationVectorToQuaternion({d_theta * static_cast<double>(i) + azimuth_init, 0., 0.})
         );
     }
 
@@ -267,7 +267,7 @@ TEST(Milestone, IEA15RotorAeroController) {
         std::cbegin(blade_list), std::cend(blade_list), std::back_inserter(beam_elem_ids),
         [&](const size_t i) {
             // Define root rotation about x-axis
-            const auto q_root = QuaternionCompose(q_roots[i], base_rot);
+            const auto q_root = math::QuaternionCompose(q_roots[i], base_rot);
 
             // Declare vector of beam nodes
             std::vector<size_t> beam_node_ids;
@@ -275,14 +275,14 @@ TEST(Milestone, IEA15RotorAeroController) {
             // Loop through nodes in blade
             for (auto j = 0U; j < n_blade_nodes; ++j) {
                 // Calculate node position and orientation for this blade
-                const auto rot = QuaternionCompose(
+                const auto rot = math::QuaternionCompose(
                     q_root,
                     {node_coords[j][3], node_coords[j][4], node_coords[j][5], node_coords[j][6]}
                 );
-                auto pos = RotateVectorByQuaternion(
+                auto pos = math::RotateVectorByQuaternion(
                     q_root, {node_coords[j][0] + hub_radius, node_coords[j][1], node_coords[j][2]}
                 );
-                const auto v = CrossProduct(omega, pos);
+                const auto v = math::CrossProduct(omega, pos);
 
                 // Add hub overhang and hub height to position after calculating node velocity
                 pos[0] += hub_overhang;
@@ -312,13 +312,13 @@ TEST(Milestone, IEA15RotorAeroController) {
     // Blade root nodes
     std::vector<size_t> root_node_ids;
     for (auto i = 0U; i < n_blades; ++i) {
-        const auto q_root = QuaternionCompose(q_roots[i], base_rot);
+        const auto q_root = math::QuaternionCompose(q_roots[i], base_rot);
 
         // Calculate node position and orientation for this blade
-        auto pos = RotateVectorByQuaternion(
+        auto pos = math::RotateVectorByQuaternion(
             q_root, {node_coords[0][0] + hub_radius, node_coords[0][1], node_coords[0][2]}
         );
-        const auto v = CrossProduct(omega, pos);
+        const auto v = math::CrossProduct(omega, pos);
 
         // Add hub overhang and hub height to position after calculating node velocity
         pos[0] += hub_overhang;

--- a/tests/regression_tests/external/test_rotor_aero_controller.cpp
+++ b/tests/regression_tests/external/test_rotor_aero_controller.cpp
@@ -253,9 +253,9 @@ TEST(Milestone, IEA15RotorAeroController) {
     std::vector<std::array<double, 4>> q_roots;
     q_roots.reserve(n_blades);
     for (auto i = 0U; i < n_blades; ++i) {
-        q_roots.emplace_back(
-            math::RotationVectorToQuaternion({d_theta * static_cast<double>(i) + azimuth_init, 0., 0.})
-        );
+        q_roots.emplace_back(math::RotationVectorToQuaternion(
+            {d_theta * static_cast<double>(i) + azimuth_init, 0., 0.}
+        ));
     }
 
     constexpr auto omega = std::array{

--- a/tests/regression_tests/interfaces/test_blade_interface.cpp
+++ b/tests/regression_tests/interfaces/test_blade_interface.cpp
@@ -206,7 +206,8 @@ TEST(BladeInterfaceTest, RotatingBeam) {
         const auto t{static_cast<double>(i) * time_step};
 
         // Calculate root displacement from initial position and apply
-        const auto u_rot = math::RotationVectorToQuaternion({omega[0] * t, omega[1] * t, omega[2] * t});
+        const auto u_rot =
+            math::RotationVectorToQuaternion({omega[0] * t, omega[1] * t, omega[2] * t});
         const auto x_root = math::RotateVectorByQuaternion(u_rot, x0_root);
         const auto u_trans =
             std::array{x_root[0] - x0_root[0], x_root[1] - x0_root[1], x_root[2] - x0_root[2]};

--- a/tests/regression_tests/interfaces/test_blade_interface.cpp
+++ b/tests/regression_tests/interfaces/test_blade_interface.cpp
@@ -128,7 +128,7 @@ TEST(BladeInterfaceTest, RotatingBeam) {
     const auto time_step{0.01};
     const auto omega = std::array{0., 0., 1.};
     const auto x0_root = std::array{2., 0., 0.};
-    const auto root_vel = CrossProduct(omega, x0_root);
+    const auto root_vel = math::CrossProduct(omega, x0_root);
     const auto write_output{false};
 
     // Create interface builder
@@ -206,8 +206,8 @@ TEST(BladeInterfaceTest, RotatingBeam) {
         const auto t{static_cast<double>(i) * time_step};
 
         // Calculate root displacement from initial position and apply
-        const auto u_rot = RotationVectorToQuaternion({omega[0] * t, omega[1] * t, omega[2] * t});
-        const auto x_root = RotateVectorByQuaternion(u_rot, x0_root);
+        const auto u_rot = math::RotationVectorToQuaternion({omega[0] * t, omega[1] * t, omega[2] * t});
+        const auto x_root = math::RotateVectorByQuaternion(u_rot, x0_root);
         const auto u_trans =
             std::array{x_root[0] - x0_root[0], x_root[1] - x0_root[1], x_root[2] - x0_root[2]};
         interface.SetRootDisplacement(

--- a/tests/regression_tests/regression/test_heavy_top.cpp
+++ b/tests/regression_tests/regression/test_heavy_top.cpp
@@ -15,7 +15,7 @@ inline auto SetUpHeavyTopTest() {
     constexpr auto inertia = std::array{0.234375, 0.46875, 0.234375};  // inertia matrix
     const auto x = std::array{0., 1., 0.};                             // initial position
     const auto omega = std::array{0., 150., -4.61538};                 // initial angular velocity
-    const auto x_dot = CrossProduct(omega, x);                         // initial velocity
+    const auto x_dot = math::CrossProduct(omega, x);                   // initial velocity
     const auto omega_dot =
         std::array{661.3461692307691919, 0., 0.};  // initial anguluar acceleration
     const auto x_ddot =

--- a/tests/regression_tests/regression/test_rotating_beam.cpp
+++ b/tests/regression_tests/regression/test_rotating_beam.cpp
@@ -132,8 +132,8 @@ TEST(RotatingBeamTest, StepConvergence) {
     // Perform 10 time steps and check for convergence within max_iter iterations
     for (auto i = 0; i < 10; ++i) {
         // Set constraint displacement
-        const auto q = RotationVectorToQuaternion({0., 0., omega * step_size * (i + 1)});
-        const auto x_root = RotateVectorByQuaternion(q, x0_root);
+        const auto q = math::RotationVectorToQuaternion({0., 0., omega * step_size * (i + 1)});
+        const auto x_root = math::RotateVectorByQuaternion(q, x0_root);
         const auto u_root =
             std::array{x_root[0] - x0_root[0], x_root[1] - x0_root[1], x_root[2] - x0_root[2]};
         constraints.UpdateDisplacement(0, {u_root[0], u_root[1], u_root[2], q[0], q[1], q[2], q[3]});
@@ -214,7 +214,7 @@ inline void CreateTwoBeamSolverWithSameBeamsAndStep() {
     auto solver = CreateSolver<>(state, elements, constraints);
 
     // Calculate hub rotation for this time step
-    const auto q_hub = RotationVectorToQuaternion(
+    const auto q_hub = math::RotationVectorToQuaternion(
         {step_size * velocity[3], step_size * velocity[4], step_size * velocity[5]}
     );
 
@@ -276,7 +276,7 @@ TEST(RotatingBeamTest, ThreeBladeRotor) {
         );
         auto blade_elem_id = model.AddBeamElement(beam_node_ids, sections, quadrature);
         auto rotation_quaternion =
-            openturbine::RotationVectorToQuaternion({0., 0., 2. * M_PI * blade_number / num_blades});
+            math::RotationVectorToQuaternion({0., 0., 2. * M_PI * blade_number / num_blades});
         model.TranslateBeam(blade_elem_id, {hub_radius, 0., 0.});
         model.RotateBeamAboutPoint(blade_elem_id, rotation_quaternion, origin);
         model.SetBeamVelocityAboutPoint(blade_elem_id, velocity, origin);
@@ -303,7 +303,7 @@ TEST(RotatingBeamTest, ThreeBladeRotor) {
     // Perform time steps and check for convergence within max_iter iterations
     for (auto i = 0U; i < num_steps; ++i) {
         // Calculate hub rotation for this time step
-        const auto q_hub = RotationVectorToQuaternion(
+        const auto q_hub = math::RotationVectorToQuaternion(
             {step_size * (i + 1) * velocity[3], step_size * (i + 1) * velocity[4],
              step_size * (i + 1) * velocity[5]}
         );
@@ -368,7 +368,7 @@ TEST(RotatingBeamTest, MasslessConstraints) {
     // Perform 10 time steps and check for convergence within max_iter iterations
     for (auto i = 0; i < 10; ++i) {
         // Set constraint displacement
-        const auto q = RotationVectorToQuaternion({0., 0., omega * step_size * (i + 1)});
+        const auto q = math::RotationVectorToQuaternion({0., 0., omega * step_size * (i + 1)});
         constraints.UpdateDisplacement(hub_bc_id, {0., 0., 0., q[0], q[1], q[2], q[3]});
         const auto converged = Step(parameters, solver, elements, state, constraints);
         EXPECT_EQ(converged, true);
@@ -510,14 +510,14 @@ TEST(RotatingBeamTest, CompoundRotationControlConstraint) {
         const auto t = step_size * static_cast<double>(i + 1);
         pitch = t * M_PI / 2.;
         azimuth = 0.5 * t * M_PI / 2.;
-        auto q = RotationVectorToQuaternion({0., 0., azimuth});
+        auto q = math::RotationVectorToQuaternion({0., 0., azimuth});
         constraints.UpdateDisplacement(hub_bc_id, {0., 0., 0., q[0], q[1], q[2], q[3]});
         const auto converged = Step(parameters, solver, elements, state, constraints);
         EXPECT_EQ(converged, true);
     }
 
     auto q = kokkos_view_2D_to_vector(state.q);
-    auto rv = QuaternionToRotationVector({q[0][3], q[0][4], q[0][5], q[0][6]});
+    auto rv = math::QuaternionToRotationVector({q[0][3], q[0][4], q[0][5], q[0][6]});
 
     // Same as euler rotation xz [azimuth, pitch]
     EXPECT_NEAR(rv[0], 1.482189821649821, 1e-8);
@@ -615,7 +615,7 @@ void GeneratorTorqueWithAxisTilt(
     model.SetGravity(0., 0., 0.);
 
     // Calculate tilt about x axis as a quaternion
-    auto node_tilt = RotationVectorToQuaternion({tilt, 0., 0.});
+    auto node_tilt = math::RotationVectorToQuaternion({tilt, 0., 0.});
 
     // Build vector of nodes (straight along x axis, no rotation)
     constexpr double hub_size = 2.;

--- a/tests/regression_tests/regression/test_rotor.cpp
+++ b/tests/regression_tests/regression/test_rotor.cpp
@@ -41,7 +41,7 @@ Model CreateIEA15Blades(const std::array<double, 3>& omega) {
     constexpr auto origin = std::array{0., 0., 0.};
 
     for (auto blade_number = 0U; blade_number < num_blades; ++blade_number) {
-        const auto rotation_quaternion = RotationVectorToQuaternion(
+        const auto rotation_quaternion = math::RotationVectorToQuaternion(
             {0., 0., -2. * M_PI * static_cast<double>(blade_number) / static_cast<double>(num_blades)
             }
         );
@@ -119,7 +119,7 @@ TEST(RotorTest, IEA15Rotor) {
     // Perform time steps and check for convergence within max_iter iterations
     for (auto i = 0U; i < num_steps; ++i) {
         // Calculate hub rotation for this time step
-        const auto q_hub = RotationVectorToQuaternion(
+        const auto q_hub = math::RotationVectorToQuaternion(
             {omega[0] * step_size * static_cast<double>(i + 1),
              omega[1] * step_size * static_cast<double>(i + 1),
              omega[2] * step_size * static_cast<double>(i + 1)}
@@ -225,7 +225,7 @@ TEST(RotorTest, IEA15RotorHub) {
     // Perform time steps and check for convergence within max_iter iterations
     for (auto i = 0U; i < num_steps; ++i) {
         // Calculate hub rotation for this time step
-        const auto q_hub = RotationVectorToQuaternion(
+        const auto q_hub = math::RotationVectorToQuaternion(
             {omega[0] * step_size * static_cast<double>(i + 1),
              omega[1] * step_size * static_cast<double>(i + 1),
              omega[2] * step_size * static_cast<double>(i + 1)}
@@ -282,8 +282,8 @@ TEST(RotorTest, IEA15RotorController) {
     for (const auto& beam_elem : model.GetBeamElements()) {
         const auto rotation_fraction =
             static_cast<double>(beam_elem.ID) / static_cast<double>(num_blades);
-        const auto q_root = RotationVectorToQuaternion({0., 0., -2. * M_PI * rotation_fraction});
-        const auto pitch_axis = RotateVectorByQuaternion(q_root, {1., 0., 0.});
+        const auto q_root = math::RotationVectorToQuaternion({0., 0., -2. * M_PI * rotation_fraction});
+        const auto pitch_axis = math::RotateVectorByQuaternion(q_root, {1., 0., 0.});
         model.AddRotationControl(
             {hub_node_id, beam_elem.node_ids[0]}, pitch_axis, blade_pitch_command[beam_elem.ID]
         );
@@ -300,7 +300,7 @@ TEST(RotorTest, IEA15RotorController) {
         const double t = step_size * static_cast<double>(i + 1);
 
         // Calculate hub rotation for this time step
-        const auto q_hub = RotationVectorToQuaternion({omega[0] * t, omega[1] * t, omega[2] * t});
+        const auto q_hub = math::RotationVectorToQuaternion({omega[0] * t, omega[1] * t, omega[2] * t});
 
         // Update prescribed displacement constraint on hub
         const auto u_hub = std::array{0., 0., 0., q_hub[0], q_hub[1], q_hub[2], q_hub[3]};
@@ -356,7 +356,7 @@ TEST(RotorTest, IEA15RotorHost) {
     // Perform time steps and check for convergence within max_iter iterations
     for (auto i = 0U; i < num_steps; ++i) {
         // Calculate hub rotation for this time step
-        const auto q_hub = RotationVectorToQuaternion(
+        const auto q_hub = math::RotationVectorToQuaternion(
             {omega[0] * step_size * static_cast<double>(i + 1),
              omega[1] * step_size * static_cast<double>(i + 1),
              omega[2] * step_size * static_cast<double>(i + 1)}

--- a/tests/regression_tests/regression/test_rotor.cpp
+++ b/tests/regression_tests/regression/test_rotor.cpp
@@ -282,7 +282,8 @@ TEST(RotorTest, IEA15RotorController) {
     for (const auto& beam_elem : model.GetBeamElements()) {
         const auto rotation_fraction =
             static_cast<double>(beam_elem.ID) / static_cast<double>(num_blades);
-        const auto q_root = math::RotationVectorToQuaternion({0., 0., -2. * M_PI * rotation_fraction});
+        const auto q_root =
+            math::RotationVectorToQuaternion({0., 0., -2. * M_PI * rotation_fraction});
         const auto pitch_axis = math::RotateVectorByQuaternion(q_root, {1., 0., 0.});
         model.AddRotationControl(
             {hub_node_id, beam_elem.node_ids[0]}, pitch_axis, blade_pitch_command[beam_elem.ID]
@@ -300,7 +301,8 @@ TEST(RotorTest, IEA15RotorController) {
         const double t = step_size * static_cast<double>(i + 1);
 
         // Calculate hub rotation for this time step
-        const auto q_hub = math::RotationVectorToQuaternion({omega[0] * t, omega[1] * t, omega[2] * t});
+        const auto q_hub =
+            math::RotationVectorToQuaternion({omega[0] * t, omega[1] * t, omega[2] * t});
 
         // Update prescribed displacement constraint on hub
         const auto u_hub = std::array{0., 0., 0., q_hub[0], q_hub[1], q_hub[2], q_hub[3]};

--- a/tests/regression_tests/regression/test_solver.cpp
+++ b/tests/regression_tests/regression/test_solver.cpp
@@ -95,8 +95,8 @@ inline void SetUpSolverAndAssemble() {
     auto [state, elements, constraints] = model.CreateSystem();
     auto solver = CreateSolver<>(state, elements, constraints);
 
-    auto u_rot = RotationVectorToQuaternion({0., 0., omega * step_size});
-    auto x_root = RotateVectorByQuaternion(u_rot, x0_root);
+    auto u_rot = math::RotationVectorToQuaternion({0., 0., omega * step_size});
+    auto x_root = math::RotateVectorByQuaternion(u_rot, x0_root);
     auto u_trans =
         std::array{x_root[0] - x0_root[0], x_root[1] - x0_root[1], x_root[2] - x0_root[2]};
     constraints.UpdateDisplacement(
@@ -326,8 +326,8 @@ inline void SetupAndTakeNoSteps() {
     auto [state, elements, constraints] = model.CreateSystem();
     auto solver = CreateSolver<>(state, elements, constraints);
 
-    auto u_rot = RotationVectorToQuaternion({0., 0., omega * step_size});
-    auto x_root = RotateVectorByQuaternion(u_rot, x0_root);
+    auto u_rot = math::RotationVectorToQuaternion({0., 0., omega * step_size});
+    auto x_root = math::RotateVectorByQuaternion(u_rot, x0_root);
     auto u_trans =
         std::array{x_root[0] - x0_root[0], x_root[1] - x0_root[1], x_root[2] - x0_root[2]};
     constraints.UpdateDisplacement(
@@ -525,7 +525,7 @@ inline auto SetupAndTakeTwoSteps() {
     auto [state, elements, constraints] = model.CreateSystem();
     auto solver = CreateSolver<>(state, elements, constraints);
 
-    auto q = RotationVectorToQuaternion({0., 0., omega * step_size});
+    auto q = math::RotationVectorToQuaternion({0., 0., omega * step_size});
     constraints.UpdateDisplacement(0, {0., 0., 0., q[0], q[1], q[2], q[3]});
 
     Step(parameters, solver, elements, state, constraints);

--- a/tests/unit_tests/interfaces/components/test_beam.cpp
+++ b/tests/unit_tests/interfaces/components/test_beam.cpp
@@ -40,7 +40,7 @@ TEST(BeamComponentTest, InitialBeamHasCorrectRotation) {
         std::array{root_node.x0[3], root_node.x0[4], root_node.x0[5], root_node.x0[6]};
 
     const auto root_rotation_matrix =
-        openturbine::QuaternionToRotationMatrix(root_rotation_quaternion);
+        math::QuaternionToRotationMatrix(root_rotation_quaternion);
 
     EXPECT_NEAR(root_node.x0[0], 0., 1.e-16);
     EXPECT_NEAR(root_node.x0[1], 0., 1.e-16);
@@ -63,7 +63,7 @@ TEST(BeamComponentTest, InitialBeamHasCorrectRotation) {
         std::array{middle_node.x0[3], middle_node.x0[4], middle_node.x0[5], middle_node.x0[6]};
 
     const auto middle_rotation_matrix =
-        openturbine::QuaternionToRotationMatrix(middle_rotation_quaternion);
+        math::QuaternionToRotationMatrix(middle_rotation_quaternion);
 
     EXPECT_NEAR(middle_node.x0[0], .5, 1.e-16);
     EXPECT_NEAR(middle_node.x0[1], 0., 1.e-16);
@@ -86,7 +86,7 @@ TEST(BeamComponentTest, InitialBeamHasCorrectRotation) {
         std::array{end_node.x0[3], end_node.x0[4], end_node.x0[5], end_node.x0[6]};
 
     const auto end_rotation_matrix =
-        openturbine::QuaternionToRotationMatrix(end_rotation_quaternion);
+        math::QuaternionToRotationMatrix(end_rotation_quaternion);
 
     EXPECT_NEAR(end_node.x0[0], 1., 1.e-16);
     EXPECT_NEAR(end_node.x0[1], 0., 1.e-16);
@@ -135,7 +135,7 @@ TEST(BeamComponentTest, UnrotatedBeamHasIdentityRotationMatrix) {
         std::array{root_node.x0[3], root_node.x0[4], root_node.x0[5], root_node.x0[6]};
 
     const auto root_rotation_matrix =
-        openturbine::QuaternionToRotationMatrix(root_rotation_quaternion);
+        math::QuaternionToRotationMatrix(root_rotation_quaternion);
 
     EXPECT_NEAR(root_rotation_matrix[0][0], 1., 1.e-16);
     EXPECT_NEAR(root_rotation_matrix[0][1], 0., 1.e-16);
@@ -183,7 +183,7 @@ TEST(BeamComponentTest, RotatedBeamAboutYAxisPointsAlongZAxis) {
         std::array{root_node.x0[3], root_node.x0[4], root_node.x0[5], root_node.x0[6]};
 
     const auto root_rotation_matrix =
-        openturbine::QuaternionToRotationMatrix(root_rotation_quaternion);
+        math::QuaternionToRotationMatrix(root_rotation_quaternion);
 
     EXPECT_NEAR(root_node.x0[0], 0., 1.e-15);
     EXPECT_NEAR(root_node.x0[1], 0., 1.e-15);
@@ -206,7 +206,7 @@ TEST(BeamComponentTest, RotatedBeamAboutYAxisPointsAlongZAxis) {
         std::array{middle_node.x0[3], middle_node.x0[4], middle_node.x0[5], middle_node.x0[6]};
 
     const auto middle_rotation_matrix =
-        openturbine::QuaternionToRotationMatrix(middle_rotation_quaternion);
+        math::QuaternionToRotationMatrix(middle_rotation_quaternion);
 
     EXPECT_NEAR(middle_node.x0[0], 0., 1.e-15);
     EXPECT_NEAR(middle_node.x0[1], 0., 1.e-15);
@@ -229,7 +229,7 @@ TEST(BeamComponentTest, RotatedBeamAboutYAxisPointsAlongZAxis) {
         std::array{end_node.x0[3], end_node.x0[4], end_node.x0[5], end_node.x0[6]};
 
     const auto end_rotation_matrix =
-        openturbine::QuaternionToRotationMatrix(end_rotation_quaternion);
+        math::QuaternionToRotationMatrix(end_rotation_quaternion);
 
     EXPECT_NEAR(end_node.x0[0], 0., 1.e-15);
     EXPECT_NEAR(end_node.x0[1], 0., 1.e-15);
@@ -281,7 +281,7 @@ TEST(BeamComponentTest, RotatedBeamAboutZAxisPointsAlongYAxis) {
         std::array{root_node.x0[3], root_node.x0[4], root_node.x0[5], root_node.x0[6]};
 
     const auto root_rotation_matrix =
-        openturbine::QuaternionToRotationMatrix(root_rotation_quaternion);
+        math::QuaternionToRotationMatrix(root_rotation_quaternion);
 
     EXPECT_NEAR(root_node.x0[0], 0., 1.e-15);
     EXPECT_NEAR(root_node.x0[1], 0., 1.e-15);
@@ -304,7 +304,7 @@ TEST(BeamComponentTest, RotatedBeamAboutZAxisPointsAlongYAxis) {
         std::array{middle_node.x0[3], middle_node.x0[4], middle_node.x0[5], middle_node.x0[6]};
 
     const auto middle_rotation_matrix =
-        openturbine::QuaternionToRotationMatrix(middle_rotation_quaternion);
+        math::QuaternionToRotationMatrix(middle_rotation_quaternion);
 
     EXPECT_NEAR(middle_node.x0[0], 0., 1.e-15);
     EXPECT_NEAR(middle_node.x0[1], .5, 1.e-15);
@@ -327,7 +327,7 @@ TEST(BeamComponentTest, RotatedBeamAboutZAxisPointsAlongYAxis) {
         std::array{end_node.x0[3], end_node.x0[4], end_node.x0[5], end_node.x0[6]};
 
     const auto end_rotation_matrix =
-        openturbine::QuaternionToRotationMatrix(end_rotation_quaternion);
+        math::QuaternionToRotationMatrix(end_rotation_quaternion);
 
     EXPECT_NEAR(end_node.x0[0], 0., 1.e-15);
     EXPECT_NEAR(end_node.x0[1], 1., 1.e-15);
@@ -379,7 +379,7 @@ TEST(BeamComponentTest, RotatedBeamAboutXAxisStillPointsAlongXAxis) {
         std::array{root_node.x0[3], root_node.x0[4], root_node.x0[5], root_node.x0[6]};
 
     const auto root_rotation_matrix =
-        openturbine::QuaternionToRotationMatrix(root_rotation_quaternion);
+        math::QuaternionToRotationMatrix(root_rotation_quaternion);
 
     EXPECT_NEAR(root_node.x0[0], 0., 1.e-15);
     EXPECT_NEAR(root_node.x0[1], 0., 1.e-15);
@@ -402,7 +402,7 @@ TEST(BeamComponentTest, RotatedBeamAboutXAxisStillPointsAlongXAxis) {
         std::array{middle_node.x0[3], middle_node.x0[4], middle_node.x0[5], middle_node.x0[6]};
 
     const auto middle_rotation_matrix =
-        openturbine::QuaternionToRotationMatrix(middle_rotation_quaternion);
+        math::QuaternionToRotationMatrix(middle_rotation_quaternion);
 
     EXPECT_NEAR(middle_node.x0[0], .5, 1.e-15);
     EXPECT_NEAR(middle_node.x0[1], 0., 1.e-15);
@@ -425,7 +425,7 @@ TEST(BeamComponentTest, RotatedBeamAboutXAxisStillPointsAlongXAxis) {
         std::array{end_node.x0[3], end_node.x0[4], end_node.x0[5], end_node.x0[6]};
 
     const auto end_rotation_matrix =
-        openturbine::QuaternionToRotationMatrix(end_rotation_quaternion);
+        math::QuaternionToRotationMatrix(end_rotation_quaternion);
 
     EXPECT_NEAR(end_node.x0[0], 1., 1.e-15);
     EXPECT_NEAR(end_node.x0[1], 0., 1.e-15);

--- a/tests/unit_tests/interfaces/components/test_beam.cpp
+++ b/tests/unit_tests/interfaces/components/test_beam.cpp
@@ -39,8 +39,7 @@ TEST(BeamComponentTest, InitialBeamHasCorrectRotation) {
     const auto root_rotation_quaternion =
         std::array{root_node.x0[3], root_node.x0[4], root_node.x0[5], root_node.x0[6]};
 
-    const auto root_rotation_matrix =
-        math::QuaternionToRotationMatrix(root_rotation_quaternion);
+    const auto root_rotation_matrix = math::QuaternionToRotationMatrix(root_rotation_quaternion);
 
     EXPECT_NEAR(root_node.x0[0], 0., 1.e-16);
     EXPECT_NEAR(root_node.x0[1], 0., 1.e-16);
@@ -62,8 +61,7 @@ TEST(BeamComponentTest, InitialBeamHasCorrectRotation) {
     const auto middle_rotation_quaternion =
         std::array{middle_node.x0[3], middle_node.x0[4], middle_node.x0[5], middle_node.x0[6]};
 
-    const auto middle_rotation_matrix =
-        math::QuaternionToRotationMatrix(middle_rotation_quaternion);
+    const auto middle_rotation_matrix = math::QuaternionToRotationMatrix(middle_rotation_quaternion);
 
     EXPECT_NEAR(middle_node.x0[0], .5, 1.e-16);
     EXPECT_NEAR(middle_node.x0[1], 0., 1.e-16);
@@ -85,8 +83,7 @@ TEST(BeamComponentTest, InitialBeamHasCorrectRotation) {
     const auto end_rotation_quaternion =
         std::array{end_node.x0[3], end_node.x0[4], end_node.x0[5], end_node.x0[6]};
 
-    const auto end_rotation_matrix =
-        math::QuaternionToRotationMatrix(end_rotation_quaternion);
+    const auto end_rotation_matrix = math::QuaternionToRotationMatrix(end_rotation_quaternion);
 
     EXPECT_NEAR(end_node.x0[0], 1., 1.e-16);
     EXPECT_NEAR(end_node.x0[1], 0., 1.e-16);
@@ -134,8 +131,7 @@ TEST(BeamComponentTest, UnrotatedBeamHasIdentityRotationMatrix) {
     const auto root_rotation_quaternion =
         std::array{root_node.x0[3], root_node.x0[4], root_node.x0[5], root_node.x0[6]};
 
-    const auto root_rotation_matrix =
-        math::QuaternionToRotationMatrix(root_rotation_quaternion);
+    const auto root_rotation_matrix = math::QuaternionToRotationMatrix(root_rotation_quaternion);
 
     EXPECT_NEAR(root_rotation_matrix[0][0], 1., 1.e-16);
     EXPECT_NEAR(root_rotation_matrix[0][1], 0., 1.e-16);
@@ -182,8 +178,7 @@ TEST(BeamComponentTest, RotatedBeamAboutYAxisPointsAlongZAxis) {
     const auto root_rotation_quaternion =
         std::array{root_node.x0[3], root_node.x0[4], root_node.x0[5], root_node.x0[6]};
 
-    const auto root_rotation_matrix =
-        math::QuaternionToRotationMatrix(root_rotation_quaternion);
+    const auto root_rotation_matrix = math::QuaternionToRotationMatrix(root_rotation_quaternion);
 
     EXPECT_NEAR(root_node.x0[0], 0., 1.e-15);
     EXPECT_NEAR(root_node.x0[1], 0., 1.e-15);
@@ -205,8 +200,7 @@ TEST(BeamComponentTest, RotatedBeamAboutYAxisPointsAlongZAxis) {
     const auto middle_rotation_quaternion =
         std::array{middle_node.x0[3], middle_node.x0[4], middle_node.x0[5], middle_node.x0[6]};
 
-    const auto middle_rotation_matrix =
-        math::QuaternionToRotationMatrix(middle_rotation_quaternion);
+    const auto middle_rotation_matrix = math::QuaternionToRotationMatrix(middle_rotation_quaternion);
 
     EXPECT_NEAR(middle_node.x0[0], 0., 1.e-15);
     EXPECT_NEAR(middle_node.x0[1], 0., 1.e-15);
@@ -228,8 +222,7 @@ TEST(BeamComponentTest, RotatedBeamAboutYAxisPointsAlongZAxis) {
     const auto end_rotation_quaternion =
         std::array{end_node.x0[3], end_node.x0[4], end_node.x0[5], end_node.x0[6]};
 
-    const auto end_rotation_matrix =
-        math::QuaternionToRotationMatrix(end_rotation_quaternion);
+    const auto end_rotation_matrix = math::QuaternionToRotationMatrix(end_rotation_quaternion);
 
     EXPECT_NEAR(end_node.x0[0], 0., 1.e-15);
     EXPECT_NEAR(end_node.x0[1], 0., 1.e-15);
@@ -280,8 +273,7 @@ TEST(BeamComponentTest, RotatedBeamAboutZAxisPointsAlongYAxis) {
     const auto root_rotation_quaternion =
         std::array{root_node.x0[3], root_node.x0[4], root_node.x0[5], root_node.x0[6]};
 
-    const auto root_rotation_matrix =
-        math::QuaternionToRotationMatrix(root_rotation_quaternion);
+    const auto root_rotation_matrix = math::QuaternionToRotationMatrix(root_rotation_quaternion);
 
     EXPECT_NEAR(root_node.x0[0], 0., 1.e-15);
     EXPECT_NEAR(root_node.x0[1], 0., 1.e-15);
@@ -303,8 +295,7 @@ TEST(BeamComponentTest, RotatedBeamAboutZAxisPointsAlongYAxis) {
     const auto middle_rotation_quaternion =
         std::array{middle_node.x0[3], middle_node.x0[4], middle_node.x0[5], middle_node.x0[6]};
 
-    const auto middle_rotation_matrix =
-        math::QuaternionToRotationMatrix(middle_rotation_quaternion);
+    const auto middle_rotation_matrix = math::QuaternionToRotationMatrix(middle_rotation_quaternion);
 
     EXPECT_NEAR(middle_node.x0[0], 0., 1.e-15);
     EXPECT_NEAR(middle_node.x0[1], .5, 1.e-15);
@@ -326,8 +317,7 @@ TEST(BeamComponentTest, RotatedBeamAboutZAxisPointsAlongYAxis) {
     const auto end_rotation_quaternion =
         std::array{end_node.x0[3], end_node.x0[4], end_node.x0[5], end_node.x0[6]};
 
-    const auto end_rotation_matrix =
-        math::QuaternionToRotationMatrix(end_rotation_quaternion);
+    const auto end_rotation_matrix = math::QuaternionToRotationMatrix(end_rotation_quaternion);
 
     EXPECT_NEAR(end_node.x0[0], 0., 1.e-15);
     EXPECT_NEAR(end_node.x0[1], 1., 1.e-15);
@@ -378,8 +368,7 @@ TEST(BeamComponentTest, RotatedBeamAboutXAxisStillPointsAlongXAxis) {
     const auto root_rotation_quaternion =
         std::array{root_node.x0[3], root_node.x0[4], root_node.x0[5], root_node.x0[6]};
 
-    const auto root_rotation_matrix =
-        math::QuaternionToRotationMatrix(root_rotation_quaternion);
+    const auto root_rotation_matrix = math::QuaternionToRotationMatrix(root_rotation_quaternion);
 
     EXPECT_NEAR(root_node.x0[0], 0., 1.e-15);
     EXPECT_NEAR(root_node.x0[1], 0., 1.e-15);
@@ -401,8 +390,7 @@ TEST(BeamComponentTest, RotatedBeamAboutXAxisStillPointsAlongXAxis) {
     const auto middle_rotation_quaternion =
         std::array{middle_node.x0[3], middle_node.x0[4], middle_node.x0[5], middle_node.x0[6]};
 
-    const auto middle_rotation_matrix =
-        math::QuaternionToRotationMatrix(middle_rotation_quaternion);
+    const auto middle_rotation_matrix = math::QuaternionToRotationMatrix(middle_rotation_quaternion);
 
     EXPECT_NEAR(middle_node.x0[0], .5, 1.e-15);
     EXPECT_NEAR(middle_node.x0[1], 0., 1.e-15);
@@ -424,8 +412,7 @@ TEST(BeamComponentTest, RotatedBeamAboutXAxisStillPointsAlongXAxis) {
     const auto end_rotation_quaternion =
         std::array{end_node.x0[3], end_node.x0[4], end_node.x0[5], end_node.x0[6]};
 
-    const auto end_rotation_matrix =
-        math::QuaternionToRotationMatrix(end_rotation_quaternion);
+    const auto end_rotation_matrix = math::QuaternionToRotationMatrix(end_rotation_quaternion);
 
     EXPECT_NEAR(end_node.x0[0], 1., 1.e-15);
     EXPECT_NEAR(end_node.x0[1], 0., 1.e-15);

--- a/tests/unit_tests/math/test_least_squares_fit.cpp
+++ b/tests/unit_tests/math/test_least_squares_fit.cpp
@@ -13,7 +13,7 @@ TEST(LeastSquaresFitTest, MapGeometricLocations_PositiveRange) {
     const std::vector<double> input = {0., 2.5, 5.};
     const std::vector<double> expected = {-1., 0., 1.};
 
-    const auto result = openturbine::MapGeometricLocations(input);
+    const auto result = math::MapGeometricLocations(input);
 
     ASSERT_EQ(result.size(), expected.size());
     for (auto i = 0U; i < result.size(); ++i) {
@@ -25,7 +25,7 @@ TEST(LeastSquaresFitTest, MapGeometricLocations_NegativeRange) {
     const std::vector<double> input = {-10., -5., 0.};
     const std::vector<double> expected = {-1., 0., 1.};
 
-    const auto result = openturbine::MapGeometricLocations(input);
+    const auto result = math::MapGeometricLocations(input);
 
     ASSERT_EQ(result.size(), expected.size());
     for (auto i = 0U; i < result.size(); ++i) {
@@ -37,7 +37,7 @@ TEST(LeastSquaresFitTest, MapGeometricLocations_UnitRange) {
     const std::vector<double> input = {0., 0.5, 1.};
     const std::vector<double> expected = {-1., 0., 1.};
 
-    auto result = openturbine::MapGeometricLocations(input);
+    auto result = math::MapGeometricLocations(input);
 
     ASSERT_EQ(result.size(), expected.size());
     for (auto i = 0U; i < result.size(); ++i) {
@@ -48,7 +48,7 @@ TEST(LeastSquaresFitTest, MapGeometricLocations_UnitRange) {
 TEST(LeastSquaresFitTest, MapGeometricLocations_InvalidInput) {
     const std::vector<double> input = {1., 1.};
 
-    EXPECT_THROW(openturbine::MapGeometricLocations(input), std::invalid_argument);
+    EXPECT_THROW(math::MapGeometricLocations(input), std::invalid_argument);
 }
 
 TEST(LeastSquaresFitTest, ShapeFunctionMatrices_FirstOrder) {
@@ -56,8 +56,8 @@ TEST(LeastSquaresFitTest, ShapeFunctionMatrices_FirstOrder) {
     const size_t p{2};                               // Polynomial order + 1
     const std::vector<double> xi_g = {-1., 0., 1.};  // Evaluation points
     const auto gll_pts = GenerateGLLPoints(p - 1);
-    const auto phi_g = ComputeShapeFunctionValues(xi_g, gll_pts);
-    const auto dphi_g = ComputeShapeFunctionDerivatives(xi_g, gll_pts);
+    const auto phi_g = math::ComputeShapeFunctionValues(xi_g, gll_pts);
+    const auto dphi_g = math::ComputeShapeFunctionDerivatives(xi_g, gll_pts);
 
     // Check GLL points (2 at -1 and 1)
     ASSERT_EQ(gll_pts.size(), p);
@@ -103,8 +103,8 @@ TEST(LeastSquaresFitTest, ShapeFunctionMatrices_SecondOrder) {
     const size_t p{3};                                          // Polynomial order + 1
     const std::vector<double> xi_g = {-1., -0.5, 0., 0.5, 1.};  // Evaluation points
     const auto gll_pts = GenerateGLLPoints(p - 1);
-    const auto phi_g = ComputeShapeFunctionValues(xi_g, gll_pts);
-    const auto dphi_g = ComputeShapeFunctionDerivatives(xi_g, gll_pts);
+    const auto phi_g = math::ComputeShapeFunctionValues(xi_g, gll_pts);
+    const auto dphi_g = math::ComputeShapeFunctionDerivatives(xi_g, gll_pts);
 
     // Check GLL points (3 at -1, 0, and 1)
     ASSERT_EQ(gll_pts.size(), 3);
@@ -163,16 +163,16 @@ TEST(LeastSquaresFitTest, FitsParametricCurve) {
     };
 
     // Step 1: Map geometric locations
-    auto mapped_locations = MapGeometricLocations(geom_locations);
+    auto mapped_locations = math::MapGeometricLocations(geom_locations);
 
     // Step 2: Generate shape function matrices (using p = 4 i.e. cubic interpolation)
     const size_t p = 4;
     const auto gll_pts = GenerateGLLPoints(p - 1);
-    const auto phi_g = ComputeShapeFunctionValues(mapped_locations, gll_pts);
-    const auto dphi_g = ComputeShapeFunctionDerivatives(mapped_locations, gll_pts);
+    const auto phi_g = math::ComputeShapeFunctionValues(mapped_locations, gll_pts);
+    const auto dphi_g = math::ComputeShapeFunctionDerivatives(mapped_locations, gll_pts);
 
     // Step 3: Perform least squares fitting
-    const auto X = PerformLeastSquaresFitting(p, phi_g, input_points);
+    const auto X = math::PerformLeastSquaresFitting(p, phi_g, input_points);
 
     // Expected coefficients from Mathematica (rounded to 3 decimal places)
     const std::vector<std::array<double, 3>> expected_coefficients = {

--- a/tests/unit_tests/math/test_matrix_operations.cpp
+++ b/tests/unit_tests/math/test_matrix_operations.cpp
@@ -19,7 +19,7 @@ Kokkos::View<double[rows][cols]> Create2DView(const std::array<double, rows * co
 inline void test_AX_Matrix() {
     const auto A = Create2DView<3, 3>({1., 2., 3., 4., 5., 6., 7., 8., 9.});
     const auto out = Kokkos::View<double[3][3]>("out");
-    Kokkos::parallel_for(1, KOKKOS_LAMBDA(int) { AX_Matrix(A, out); });
+    Kokkos::parallel_for(1, KOKKOS_LAMBDA(int) { math::AX_Matrix(A, out); });
     const auto out_mirror = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), out);
 
     constexpr auto expected_data = std::array{7., -1., -1.5, -2., 5., -3., -3.5, -4., 3.};
@@ -40,7 +40,7 @@ TEST(MatrixTest, AX_Matrix) {
 Kokkos::View<double[3]> TestAxialVectorOfMatrix(const Kokkos::View<const double[3][3]>& m) {
     auto v = Kokkos::View<double[3]>("v");
     Kokkos::parallel_for(
-        "AxialVectorOfMatrix", 1, KOKKOS_LAMBDA(int) { AxialVectorOfMatrix(m, v); }
+        "AxialVectorOfMatrix", 1, KOKKOS_LAMBDA(int) { math::AxialVectorOfMatrix(m, v); }
     );
     return v;
 }
@@ -72,7 +72,7 @@ TEST(MatrixTest, RotateMatrix6_1) {
         std::array{25., 26., 27., 28., 29., 30.}, std::array{31., 32., 33., 34., 35., 36.},
     };
     const auto q = std::array{1., 0., 0., 0.};
-    const auto m_act = RotateMatrix6(m, q);
+    const auto m_act = math::RotateMatrix6(m, q);
     for (auto i = 0U; i < 6U; ++i) {
         for (auto j = 0U; j < 6U; ++j) {
             EXPECT_NEAR(m_act[i][j], m_exp[i][j], 1.e-12);
@@ -92,7 +92,7 @@ TEST(MatrixTest, RotateMatrix6_2) {
         std::array{-25, 26, 27, -28, 29, 30}, std::array{-31, 32, 33, -34, 35, 36},
     };
     const auto q = std::array{0., 1., 0., 0.};
-    const auto m_act = RotateMatrix6(m, q);
+    const auto m_act = math::RotateMatrix6(m, q);
     for (auto i = 0U; i < 6U; ++i) {
         for (auto j = 0U; j < 6U; ++j) {
             EXPECT_NEAR(m_act[i][j], m_exp[i][j], 1.e-12);
@@ -131,8 +131,8 @@ TEST(MatrixTest, RotateMatrix6_3) {
         },
 
     };
-    const auto q = RotationVectorToQuaternion({0., M_PI / 4., 0.});
-    const auto m_act = RotateMatrix6(m, q);
+    const auto q = math::RotationVectorToQuaternion({0., M_PI / 4., 0.});
+    const auto m_act = math::RotateMatrix6(m, q);
     for (auto i = 0U; i < 6U; ++i) {
         for (auto j = 0U; j < 6U; ++j) {
             EXPECT_NEAR(m_act[i][j], m_exp[i][j], 1.e-12);

--- a/tests/unit_tests/math/test_project_points_to_target_polynomial.cpp
+++ b/tests/unit_tests/math/test_project_points_to_target_polynomial.cpp
@@ -15,7 +15,7 @@ TEST(ProjectPointsToTargetPolynomialTest, Project2ndOrderTo4thOrderPolynomial) {
     };
 
     const auto output_points =
-        ProjectPointsToTargetPolynomial(num_input_pts, num_output_pts, input_points);
+        math::ProjectPointsToTargetPolynomial(num_input_pts, num_output_pts, input_points);
 
     // Expected projected points from Mathematica
     const std::vector<std::array<double, 3>> expected_projected_points = {

--- a/tests/unit_tests/math/test_quaternion_operations.cpp
+++ b/tests/unit_tests/math/test_quaternion_operations.cpp
@@ -97,7 +97,8 @@ Kokkos::View<double[3]> TestRotateVectorByQuaternion(
 ) {
     auto v_rot = Kokkos::View<double[3]>("v_rot");
     Kokkos::parallel_for(
-        "RotateVectorBoyQuaternion", 1, KOKKOS_LAMBDA(int) { math::RotateVectorByQuaternion(q, v, v_rot); }
+        "RotateVectorBoyQuaternion", 1,
+        KOKKOS_LAMBDA(int) { math::RotateVectorByQuaternion(q, v, v_rot); }
     );
     return v_rot;
 }

--- a/tests/unit_tests/math/test_vector_operations.cpp
+++ b/tests/unit_tests/math/test_vector_operations.cpp
@@ -21,7 +21,7 @@ Kokkos::View<double[size]> Create1DView(const std::array<double, size>& input) {
 
 Kokkos::View<double[3][3]> TestVecTilde(const Kokkos::View<double[3]>& v) {
     auto m = Kokkos::View<double[3][3]>("m");
-    Kokkos::parallel_for("VecTilde", 1, KOKKOS_LAMBDA(int) { VecTilde(v, m); });
+    Kokkos::parallel_for("VecTilde", 1, KOKKOS_LAMBDA(int) { math::VecTilde(v, m); });
     return m;
 }
 
@@ -45,7 +45,7 @@ TEST(VectorTest, VecTilde) {
 TEST(VectorTest, CrossProduct_Set1) {
     auto a = std::array<double, 3>{1., 2., 3.};
     auto b = std::array<double, 3>{4., 5., 6.};
-    auto c = CrossProduct(a, b);
+    auto c = math::CrossProduct(a, b);
 
     ASSERT_EQ(c[0], -3.);
     ASSERT_EQ(c[1], 6.);
@@ -55,7 +55,7 @@ TEST(VectorTest, CrossProduct_Set1) {
 TEST(VectorTest, CrossProduct_Set2) {
     auto a = std::array<double, 3>{0.19, -5.03, 2.71};
     auto b = std::array<double, 3>{1.16, 0.09, 0.37};
-    auto c = CrossProduct(a, b);
+    auto c = math::CrossProduct(a, b);
 
     ASSERT_EQ(c[0], -5.03 * 0.37 - 2.71 * 0.09);
     ASSERT_EQ(c[1], 2.71 * 1.16 - 0.19 * 0.37);
@@ -67,7 +67,7 @@ void test_DotProduct_View() {
     auto b = Create1DView<3>({4., 5., 6.});
     auto c = 0.;
     Kokkos::parallel_reduce(
-        "DotProduct_View", 1, KOKKOS_LAMBDA(int, double& result) { result = DotProduct(a, b); }, c
+        "DotProduct_View", 1, KOKKOS_LAMBDA(int, double& result) { result = math::DotProduct(a, b); }, c
     );
     ASSERT_EQ(c, 32.);
 }
@@ -79,13 +79,13 @@ TEST(VectorTest, DotProduct_View) {
 TEST(VectorTest, DotProduct_Array) {
     auto a = std::array<double, 3>{1., 2., 3.};
     auto b = std::array<double, 3>{4., 5., 6.};
-    auto c = DotProduct(a, b);
+    auto c = math::DotProduct(a, b);
     ASSERT_EQ(c, 32);
 }
 
 TEST(VectorTest, UnitVector_Set1) {
     auto a = std::array<double, 3>{5., 0., 0.};
-    auto b = UnitVector(a);
+    auto b = math::UnitVector(a);
     ASSERT_EQ(b[0], 1.);
     ASSERT_EQ(b[1], 0.);
     ASSERT_EQ(b[2], 0.);
@@ -93,7 +93,7 @@ TEST(VectorTest, UnitVector_Set1) {
 
 TEST(VectorTest, UnitVector_Set2) {
     auto a = std::array<double, 3>{3., 4., 0.};
-    auto b = UnitVector(a);
+    auto b = math::UnitVector(a);
     ASSERT_EQ(b[0], 0.6);
     ASSERT_EQ(b[1], 0.8);
     ASSERT_EQ(b[2], 0.);
@@ -101,7 +101,7 @@ TEST(VectorTest, UnitVector_Set2) {
 
 TEST(VectorTest, VectorTest_UnitVector_Set3_Test) {
     auto a = std::array<double, 3>{0., 0., 0.};
-    EXPECT_THROW(UnitVector(a), std::invalid_argument);
+    EXPECT_THROW(math::UnitVector(a), std::invalid_argument);
 }
 
 }  // namespace openturbine::tests

--- a/tests/unit_tests/math/test_vector_operations.cpp
+++ b/tests/unit_tests/math/test_vector_operations.cpp
@@ -67,7 +67,8 @@ void test_DotProduct_View() {
     auto b = Create1DView<3>({4., 5., 6.});
     auto c = 0.;
     Kokkos::parallel_reduce(
-        "DotProduct_View", 1, KOKKOS_LAMBDA(int, double& result) { result = math::DotProduct(a, b); }, c
+        "DotProduct_View", 1,
+        KOKKOS_LAMBDA(int, double& result) { result = math::DotProduct(a, b); }, c
     );
     ASSERT_EQ(c, 32.);
 }

--- a/tests/unit_tests/model/test_model.cpp
+++ b/tests/unit_tests/model/test_model.cpp
@@ -82,8 +82,8 @@ TEST(ModelTest, ModelCreateState) {
     Model model;
 
     // Rotation of 1 radian around x
-    auto R1 = RotationVectorToQuaternion({1., 0., 0.});
-    auto R2 = RotationVectorToQuaternion({0., 1., 0.});
+    auto R1 = math::RotationVectorToQuaternion({1., 0., 0.});
+    auto R2 = math::RotationVectorToQuaternion({0., 1., 0.});
 
     // Create node with initial position and displacement from initial position
     static_cast<void>(model.AddNode()
@@ -111,7 +111,7 @@ TEST(ModelTest, ModelCreateState) {
     }
 
     // Verify current position (initial position plus displacement)
-    auto Rt = QuaternionCompose(R2, R1);
+    auto Rt = math::QuaternionCompose(R2, R1);
     const auto x = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), state.x);
     const auto exact_x = std::array{4., 4., 4., Rt[0], Rt[1], Rt[2], Rt[3]};
     for (auto i = 0U; i < 7U; ++i) {
@@ -123,8 +123,8 @@ TEST(ModelTest, ModelCreateSystem) {
     Model model;
 
     // Rotation of 1 radian around x
-    auto R1 = RotationVectorToQuaternion({1., 0., 0.});
-    auto R2 = RotationVectorToQuaternion({0., 1., 0.});
+    auto R1 = math::RotationVectorToQuaternion({1., 0., 0.});
+    auto R2 = math::RotationVectorToQuaternion({0., 1., 0.});
 
     // Create node with initial position and displacement from initial position
     static_cast<void>(model.AddNode()
@@ -150,7 +150,7 @@ TEST(ModelTest, ModelCreateSystem) {
     }
 
     // Verify current position (initial position plus displacement)
-    auto Rt = QuaternionCompose(R2, R1);
+    auto Rt = math::QuaternionCompose(R2, R1);
     const auto x = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), state.x);
     const auto exact_x = std::array{4., 4., 4., Rt[0], Rt[1], Rt[2], Rt[3]};
     for (auto i = 0U; i < 7U; ++i) {

--- a/tests/unit_tests/model/test_node.cpp
+++ b/tests/unit_tests/model/test_node.cpp
@@ -42,7 +42,7 @@ TEST(NodeTest, DisplacedPosition_RotationOnly) {
     constexpr auto init_position = std::array{1., 2., 3.};
     constexpr auto init_orientation = std::array{1., 0., 0., 0.};  // identity quaternion
     // 90° rotation around z-axis
-    const auto rotation = RotationVectorToQuaternion({0., 0., M_PI / 2.});
+    const auto rotation = math::RotationVectorToQuaternion({0., 0., M_PI / 2.});
     auto node_id =
         model.AddNode()
             .SetPosition(
@@ -73,7 +73,7 @@ TEST(NodeTest, DisplacedPosition_TranslationAndRotation) {
     constexpr auto init_position = std::array{1., 0., 0.};
     constexpr auto init_orientation = std::array{1., 0., 0., 0.};
     constexpr auto disp_position = std::array{1., 2., 3.};
-    const auto disp_rotation = RotationVectorToQuaternion({0., M_PI / 3., 0.});  // 60° around y axis
+    const auto disp_rotation = math::RotationVectorToQuaternion({0., M_PI / 3., 0.});  // 60° around y axis
 
     auto node_id = model.AddNode()
                        .SetPosition(
@@ -95,7 +95,7 @@ TEST(NodeTest, DisplacedPosition_TranslationAndRotation) {
     ASSERT_NEAR(displaced_position[2], init_position[2] + disp_position[2], 1e-12);  // 3.
 
     // Check rotation composition
-    auto expected_orientation = QuaternionCompose(init_orientation, disp_rotation);
+    auto expected_orientation = math::QuaternionCompose(init_orientation, disp_rotation);
     ASSERT_NEAR(displaced_position[3], expected_orientation[0], 1e-12);
     ASSERT_NEAR(displaced_position[4], expected_orientation[1], 1e-12);
     ASSERT_NEAR(displaced_position[5], expected_orientation[2], 1e-12);

--- a/tests/unit_tests/model/test_node.cpp
+++ b/tests/unit_tests/model/test_node.cpp
@@ -73,7 +73,8 @@ TEST(NodeTest, DisplacedPosition_TranslationAndRotation) {
     constexpr auto init_position = std::array{1., 0., 0.};
     constexpr auto init_orientation = std::array{1., 0., 0., 0.};
     constexpr auto disp_position = std::array{1., 2., 3.};
-    const auto disp_rotation = math::RotationVectorToQuaternion({0., M_PI / 3., 0.});  // 60° around y axis
+    const auto disp_rotation =
+        math::RotationVectorToQuaternion({0., M_PI / 3., 0.});  // 60° around y axis
 
     auto node_id = model.AddNode()
                        .SetPosition(


### PR DESCRIPTION
Looking at our Doxygen documentation, the openturbine namespace is a large grab-bag of functions and classes, many of which are not relevant to the average user.  Better organization will let this tool actually be useful for us and our users.