### PR TITLE
Fixed some lapack conflicts when using MKL.

### DIFF
--- a/docs/sphinx/user/compiling.rst
+++ b/docs/sphinx/user/compiling.rst
@@ -130,6 +130,7 @@ Install Kokkos and Kokkos Kernels
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 For a simple serial build
+
 .. code-block:: bash
 
     spack install kokkos

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -114,11 +114,14 @@ add_shared_library(DISCON_ROTOR_TEST_CONTROLLER)
 #----------------------------------------
 # Set include directories
 #----------------------------------------
+if(OpenTurbine_ENABLE_MKL)
+else()
 find_path(LAPACKE_INCLUDE_DIRS lapacke.h)
 target_include_directories(openturbine_library SYSTEM
-  PUBLIC
-  ${LAPACKE_INCLUDE_DIRS}
+ PUBLIC
+${LAPACKE_INCLUDE_DIRS}
 )
+endif()
 
 target_include_directories(openturbine_library
   PUBLIC

--- a/src/math/least_squares_fit.hpp
+++ b/src/math/least_squares_fit.hpp
@@ -174,12 +174,11 @@ inline std::vector<std::array<double, 3>> PerformLeastSquaresFitting(
 #else
     using index_type = int;
 #endif
-    const auto IPIV = Kokkos::View<index_type*, Kokkos::LayoutLeft, Kokkos::HostSpace>("IPIV", B.extent(0));
+    const auto IPIV =
+        Kokkos::View<index_type*, Kokkos::LayoutLeft, Kokkos::HostSpace>("IPIV", B.extent(0));
+    const auto rows = static_cast<index_type>(p);
 
-    lapack::LAPACKE_dgesv(
-        LAPACK_COL_MAJOR, static_cast<index_type>(p), 3, A.data(), static_cast<index_type>(p), IPIV.data(),
-        B.data(), static_cast<index_type>(p)
-    );
+    lapack::LAPACKE_dgesv(LAPACK_COL_MAJOR, rows, 3, A.data(), rows, IPIV.data(), B.data(), rows);
 
     auto result = std::vector<std::array<double, 3>>(B.extent(0));
 

--- a/src/solver/solver.hpp
+++ b/src/solver/solver.hpp
@@ -57,7 +57,7 @@ struct Solver {
 
     using HandleType = dss::Handle<algorithm>;
 #if defined(OpenTurbine_ENABLE_MKL)
-    using IndexType = std::conditional<algorithm == dss::Algorithm::MKL, MKL_INT, int>;
+    using IndexType = std::conditional<algorithm == dss::Algorithm::MKL, MKL_INT, int>::type;
 #else
     using IndexType = int;
 #endif


### PR DESCRIPTION
There are still problems that appear when using versions newer than 2022.x.x

I don't know what the cause is, so for now the answer might be to constrain use through the spack package