### PR TITLE
Fix incorrect addition of generator inertia with gearbox ratio

### DIFF
--- a/tests/regression_tests/external/test_turbine_rosco_interface.cpp
+++ b/tests/regression_tests/external/test_turbine_rosco_interface.cpp
@@ -307,8 +307,8 @@ TEST(TurbineInterfaceTest, IEA15_ROSCOControllerWithAero) {
         {{{hub_mass, 0., 0., 0., 0., 0.},
           {0., hub_mass, 0., 0., 0., 0.},
           {0., 0., hub_mass, 0., 0., 0.},
-          {0., 0., 0., hub_inertia[0] + gearbox_ratio * generator_inertia[0], hub_inertia[3],
-           hub_inertia[4]},
+          {0., 0., 0., hub_inertia[0] + generator_inertia[0] * gearbox_ratio * gearbox_ratio,
+           hub_inertia[3], hub_inertia[4]},
           {0., 0., 0., hub_inertia[3], hub_inertia[1], hub_inertia[5]},
           {0., 0., 0., hub_inertia[4], hub_inertia[5], hub_inertia[2]}}}
     );

--- a/tests/regression_tests/interfaces/test_aerodynamics_interface.cpp
+++ b/tests/regression_tests/interfaces/test_aerodynamics_interface.cpp
@@ -294,8 +294,8 @@ TEST(AerodynamicsInterfaceTest, IEA15_Turbine) {
         {{{hub_mass, 0., 0., 0., 0., 0.},
           {0., hub_mass, 0., 0., 0., 0.},
           {0., 0., hub_mass, 0., 0., 0.},
-          {0., 0., 0., hub_inertia[0] + generator_inertia[0] * gearbox_ratio, hub_inertia[3],
-           hub_inertia[4]},
+          {0., 0., 0., hub_inertia[0] + generator_inertia[0] * gearbox_ratio * gearbox_ratio,
+           hub_inertia[3], hub_inertia[4]},
           {0., 0., 0., hub_inertia[3], hub_inertia[1], hub_inertia[5]},
           {0., 0., 0., hub_inertia[4], hub_inertia[5], hub_inertia[2]}}}
     );

--- a/tests/regression_tests/interfaces/test_turbine_interface.cpp
+++ b/tests/regression_tests/interfaces/test_turbine_interface.cpp
@@ -290,8 +290,8 @@ TEST(TurbineInterfaceTest, IEA15_Structure) {
         {{{hub_mass, 0., 0., 0., 0., 0.},
           {0., hub_mass, 0., 0., 0., 0.},
           {0., 0., hub_mass, 0., 0., 0.},
-          {0., 0., 0., hub_inertia[0] + generator_inertia[0] * gearbox_ratio, hub_inertia[3],
-           hub_inertia[4]},
+          {0., 0., 0., hub_inertia[0] + generator_inertia[0] * gearbox_ratio * gearbox_ratio,
+           hub_inertia[3], hub_inertia[4]},
           {0., 0., 0., hub_inertia[3], hub_inertia[1], hub_inertia[5]},
           {0., 0., 0., hub_inertia[4], hub_inertia[5], hub_inertia[2]}}}
     );


### PR DESCRIPTION
This PR fixes the use of gearbox ratio when adding generator inertia to the hub inertia matrix. The additional inertia is proportional to the square of the gearbox ratio, not just the gearbox ratio.

This doesn't affect the regression test results as the IEA15 gearbox ratio is 1.0.