### PR TITLE
one way to get output timing more available

### DIFF
--- a/src/interfaces/turbine/turbine_interface.cpp
+++ b/src/interfaces/turbine/turbine_interface.cpp
@@ -120,7 +120,7 @@ void TurbineInterface::UpdateAerodynamicLoads(
     }
 }
 
-bool TurbineInterface::Step(bool allow_output) {
+bool TurbineInterface::Step() {
     auto step_resion = Kokkos::Profiling::ScopedRegion("TurbineInterface::Step");
     // Update the host state with current node loads
     {
@@ -155,16 +155,6 @@ bool TurbineInterface::Step(bool allow_output) {
 
         // Update the turbine constraint loads based on the host constraints
         this->turbine.GetLoads(this->host_constraints);
-    }
-
-    // Write outputs and increment timestep counter
-    if (this->outputs && allow_output) {
-        auto output_region = Kokkos::Profiling::ScopedRegion("Output Data");
-        // Write node state outputs
-        this->outputs->WriteNodeOutputsAtTimestep(this->host_state, this->state.time_step);
-
-        // Calculate rotor azimuth and speed -> write rotor time-series data
-        this->WriteTimeSeriesData();
     }
 
     return true;

--- a/src/interfaces/turbine/turbine_interface.cpp
+++ b/src/interfaces/turbine/turbine_interface.cpp
@@ -120,7 +120,7 @@ void TurbineInterface::UpdateAerodynamicLoads(
     }
 }
 
-bool TurbineInterface::Step() {
+bool TurbineInterface::Step(bool allow_output) {
     auto step_resion = Kokkos::Profiling::ScopedRegion("TurbineInterface::Step");
     // Update the host state with current node loads
     {
@@ -158,7 +158,7 @@ bool TurbineInterface::Step() {
     }
 
     // Write outputs and increment timestep counter
-    if (this->outputs) {
+    if (this->outputs && allow_output) {
         auto output_region = Kokkos::Profiling::ScopedRegion("Output Data");
         // Write node state outputs
         this->outputs->WriteNodeOutputsAtTimestep(this->host_state, this->state.time_step);
@@ -573,5 +573,29 @@ void TurbineInterface::ApplyController(double t) {
     this->turbine.blade_pitch_control[1] = controller->io.pitch_collective_command;
     this->turbine.blade_pitch_control[2] = controller->io.pitch_collective_command;
     this->turbine.yaw_control = controller->YawAngleCommand();
+}
+
+void TurbineInterface::CloseOutputFile()
+{
+    if (this->outputs) {
+        this->outputs->Close();
+    }
+}
+
+void TurbineInterface::OutputNow(int timestep)
+{
+    // Write outputs and increment timestep counter
+    if (this->outputs) {
+        this->outputs->Open();
+
+        auto output_region = Kokkos::Profiling::ScopedRegion("Output Data");
+        // Write node state outputs
+        this->outputs->WriteNodeOutputsAtTimestep(this->host_state, timestep);
+
+        // Calculate rotor azimuth and speed -> write rotor time-series data
+        this->WriteTimeSeriesData();
+
+        this->outputs->Close();
+    }
 }
 }  // namespace kynema::interfaces

--- a/src/interfaces/turbine/turbine_interface.cpp
+++ b/src/interfaces/turbine/turbine_interface.cpp
@@ -575,32 +575,27 @@ void TurbineInterface::ApplyController(double t) {
     this->turbine.yaw_control = controller->YawAngleCommand();
 }
 
-void TurbineInterface::OpenOutputFile()
-{
+void TurbineInterface::OpenOutputFile() {
     if (this->outputs) {
         this->outputs->Open();
     }
 }
 
-void TurbineInterface::CloseOutputFile()
-{
+void TurbineInterface::CloseOutputFile() {
     if (this->outputs) {
         this->outputs->Close();
     }
 }
 
-void TurbineInterface::OutputNow(int timestep)
-{
+void TurbineInterface::WriteOutput() {
+    assert(this->outputs);
     // Write outputs and increment timestep counter
-    if (this->outputs) {
 
-        auto output_region = Kokkos::Profiling::ScopedRegion("Output Data");
-        // Write node state outputs
-        this->outputs->WriteNodeOutputsAtTimestep(this->host_state, timestep);
+    auto output_region = Kokkos::Profiling::ScopedRegion("Output Data");
+    // Write node state outputs
+    this->outputs->WriteNodeOutputsAtTimestep(this->host_state, this->state.time_step);
 
-        // Calculate rotor azimuth and speed -> write rotor time-series data
-        this->WriteTimeSeriesData();
-
-    }
+    // Calculate rotor azimuth and speed -> write rotor time-series data
+    this->WriteTimeSeriesData();
 }
 }  // namespace kynema::interfaces

--- a/src/interfaces/turbine/turbine_interface.cpp
+++ b/src/interfaces/turbine/turbine_interface.cpp
@@ -575,6 +575,13 @@ void TurbineInterface::ApplyController(double t) {
     this->turbine.yaw_control = controller->YawAngleCommand();
 }
 
+void TurbineInterface::OpenOutputFile()
+{
+    if (this->outputs) {
+        this->outputs->Open();
+    }
+}
+
 void TurbineInterface::CloseOutputFile()
 {
     if (this->outputs) {
@@ -586,7 +593,6 @@ void TurbineInterface::OutputNow(int timestep)
 {
     // Write outputs and increment timestep counter
     if (this->outputs) {
-        this->outputs->Open();
 
         auto output_region = Kokkos::Profiling::ScopedRegion("Output Data");
         // Write node state outputs
@@ -595,7 +601,6 @@ void TurbineInterface::OutputNow(int timestep)
         // Calculate rotor azimuth and speed -> write rotor time-series data
         this->WriteTimeSeriesData();
 
-        this->outputs->Close();
     }
 }
 }  // namespace kynema::interfaces

--- a/src/interfaces/turbine/turbine_interface.hpp
+++ b/src/interfaces/turbine/turbine_interface.hpp
@@ -111,7 +111,7 @@ public:
      */
     [[nodiscard]] double CalculateRotorSpeed() const;
 
-    void OutputNow(int timestep);
+    void WriteOutput();
 
     void OpenOutputFile();
 

--- a/src/interfaces/turbine/turbine_interface.hpp
+++ b/src/interfaces/turbine/turbine_interface.hpp
@@ -85,7 +85,7 @@ public:
      *       solves the dynamic system, and updates the node motion with the new state.
      *       If the solver does not converge, the motion is not updated.
      */
-    [[nodiscard]] bool Step(bool allow_output = true);
+    [[nodiscard]] bool Step();
 
     /// @brief Saves the current state for potential restoration (in correction step)
     void SaveState();

--- a/src/interfaces/turbine/turbine_interface.hpp
+++ b/src/interfaces/turbine/turbine_interface.hpp
@@ -113,6 +113,8 @@ public:
 
     void OutputNow(int timestep);
 
+    void OpenOutputFile();
+
     void CloseOutputFile();
 
 private:

--- a/src/interfaces/turbine/turbine_interface.hpp
+++ b/src/interfaces/turbine/turbine_interface.hpp
@@ -85,7 +85,7 @@ public:
      *       solves the dynamic system, and updates the node motion with the new state.
      *       If the solver does not converge, the motion is not updated.
      */
-    [[nodiscard]] bool Step();
+    [[nodiscard]] bool Step(bool allow_output = true);
 
     /// @brief Saves the current state for potential restoration (in correction step)
     void SaveState();
@@ -110,6 +110,10 @@ public:
      * @return Rotor speed in rad/s
      */
     [[nodiscard]] double CalculateRotorSpeed() const;
+
+    void OutputNow(int timestep);
+
+    void CloseOutputFile();
 
 private:
     Model model;                    ///< Kynema class for model construction


### PR DESCRIPTION
Currently, just having an output file populated leads to outputting every step. This PR allows turning off that default behavior, allows outputting on command, and provides access to some of the NetCDF features that @faisal-bhuiyan added.