### PR TITLE
changes needed or recommended for AMR-Wind coupling, output

### DIFF
--- a/src/interfaces/components/turbine.cpp
+++ b/src/interfaces/components/turbine.cpp
@@ -12,7 +12,8 @@
 
 namespace kynema::interfaces::components {
 Turbine::Turbine(const TurbineInput& input, Model& model)
-    : blades(CreateBlades(input.blades, model)),
+    : turbine_input(input),
+      blades(CreateBlades(input.blades, model)),
       tower(input.tower, model),
       hub_node(invalid_id),
       azimuth_node(invalid_id),

--- a/src/interfaces/components/turbine.cpp
+++ b/src/interfaces/components/turbine.cpp
@@ -12,8 +12,7 @@
 
 namespace kynema::interfaces::components {
 Turbine::Turbine(const TurbineInput& input, Model& model)
-    : turbine_input(input),
-      blades(CreateBlades(input.blades, model)),
+    : blades(CreateBlades(input.blades, model)),
       tower(input.tower, model),
       hub_node(invalid_id),
       azimuth_node(invalid_id),
@@ -26,7 +25,8 @@ Turbine::Turbine(const TurbineInput& input, Model& model)
       yaw_bearing_to_nacelle_cm{invalid_id},
       shaft_base_to_azimuth{invalid_id},
       azimuth_to_hub{invalid_id},
-      blade_pitch_control(input.blades.size(), input.blade_pitch_angle) {
+      blade_pitch_control(input.blades.size(), input.blade_pitch_angle),
+      turbine_input(input) {
     // Validate turbine inputs
     ValidateInput(input);
 

--- a/src/interfaces/components/turbine.hpp
+++ b/src/interfaces/components/turbine.hpp
@@ -173,6 +173,10 @@ public:
 
     Turbine(Turbine&& other) = delete;
 
+    Turbine& operator=(const Turbine&) = delete;
+
+    Turbine& operator=(Turbine&&) = delete;
+
     /**
      * @brief Populate node motion from host state
      * @param host_state Host state containing position, displacement, velocity, and acceleration

--- a/src/interfaces/components/turbine.hpp
+++ b/src/interfaces/components/turbine.hpp
@@ -169,6 +169,8 @@ public:
      */
     Turbine(const TurbineInput& input, Model& model);
 
+    Turbine(Turbine& other) = delete;
+
     /**
      * @brief Populate node motion from host state
      * @param host_state Host state containing position, displacement, velocity, and acceleration

--- a/src/interfaces/components/turbine.hpp
+++ b/src/interfaces/components/turbine.hpp
@@ -171,6 +171,8 @@ public:
 
     Turbine(Turbine& other) = delete;
 
+    Turbine(Turbine&& other) = delete;
+
     /**
      * @brief Populate node motion from host state
      * @param host_state Host state containing position, displacement, velocity, and acceleration

--- a/src/interfaces/components/turbine.hpp
+++ b/src/interfaces/components/turbine.hpp
@@ -177,6 +177,8 @@ public:
 
     Turbine& operator=(Turbine&&) = delete;
 
+    ~Turbine() = default;
+
     /**
      * @brief Populate node motion from host state
      * @param host_state Host state containing position, displacement, velocity, and acceleration

--- a/src/interfaces/turbine/turbine_interface.cpp
+++ b/src/interfaces/turbine/turbine_interface.cpp
@@ -461,7 +461,7 @@ std::array<double, 3> TurbineInterface::GetHubNodePosition() const {
     };
 }
 
-void TurbineInterface::SetHubInflow(const std::array<double, 3> inflow) {
+void TurbineInterface::SetHubInflow(const std::array<double, 3>& inflow) {
     this->hub_inflow = inflow;
 }
 

--- a/src/interfaces/turbine/turbine_interface.cpp
+++ b/src/interfaces/turbine/turbine_interface.cpp
@@ -378,7 +378,7 @@ void TurbineInterface::WriteTimeSeriesData() const {
 
     // Aerodynamic data
     if (this->aerodynamics) {
-        const auto n_blades = 0U;  // this->aerodynamics->bodies.size()
+        const auto n_blades = this->aerodynamics->bodies.size();
         for (auto i : std::views::iota(0U, n_blades)) {
             const auto& body = this->aerodynamics->bodies[i];
             for (auto j : std::views::iota(0U, body.loads.size())) {
@@ -459,6 +459,10 @@ std::array<double, 3> TurbineInterface::GetHubNodePosition() const {
     return std::array{
         turbine.hub_node.position[0], turbine.hub_node.position[1], turbine.hub_node.position[2]
     };
+}
+
+void TurbineInterface::SetHubInflow(const std::array<double, 3> inflow) {
+    this->hub_inflow = inflow;
 }
 
 void TurbineInterface::InitializeController(

--- a/src/interfaces/turbine/turbine_interface.hpp
+++ b/src/interfaces/turbine/turbine_interface.hpp
@@ -51,6 +51,10 @@ public:
 
     TurbineInterface(TurbineInterface&& other) = delete;
 
+    TurbineInterface& operator=(const TurbineInterface&) = delete;
+
+    TurbineInterface& operator=(TurbineInterface&&) = delete;
+
     /// @brief Returns a reference to the turbine model
     [[nodiscard]] components::Turbine& Turbine() { return this->turbine; }
 

--- a/src/interfaces/turbine/turbine_interface.hpp
+++ b/src/interfaces/turbine/turbine_interface.hpp
@@ -55,6 +55,8 @@ public:
 
     TurbineInterface& operator=(TurbineInterface&&) = delete;
 
+    ~TurbineInterface() = default;
+
     /// @brief Returns a reference to the turbine model
     [[nodiscard]] components::Turbine& Turbine() { return this->turbine; }
 

--- a/src/interfaces/turbine/turbine_interface.hpp
+++ b/src/interfaces/turbine/turbine_interface.hpp
@@ -49,6 +49,8 @@ public:
 
     TurbineInterface(TurbineInterface& other) = delete;
 
+    TurbineInterface(TurbineInterface&& other) = delete;
+
     /// @brief Returns a reference to the turbine model
     [[nodiscard]] components::Turbine& Turbine() { return this->turbine; }
 
@@ -74,7 +76,7 @@ public:
 
     std::array<double, 3> GetHubNodePosition() const;
 
-    void SetHubInflow(const std::array<double, 3> inflow);
+    void SetHubInflow(const std::array<double, 3>& inflow);
 
     /**
      * @brief Update controller inputs from current system state

--- a/src/interfaces/turbine/turbine_interface.hpp
+++ b/src/interfaces/turbine/turbine_interface.hpp
@@ -47,6 +47,8 @@ public:
         const components::OutputsConfig& outputs_config = {}
     );
 
+    TurbineInterface(TurbineInterface& other) = delete;
+
     /// @brief Returns a reference to the turbine model
     [[nodiscard]] components::Turbine& Turbine() { return this->turbine; }
 
@@ -71,6 +73,8 @@ public:
     );
 
     std::array<double, 3> GetHubNodePosition() const;
+
+    void SetHubInflow(const std::array<double, 3> inflow);
 
     /**
      * @brief Update controller inputs from current system state


### PR DESCRIPTION
including
- additions to header files to prevent accidental copying of the interface (recommended change for helping developers)
- uncommenting aerodynamic outputs that are a function of span (necessary for comparing against openfast outputs in benchmark case)
- new function to pass fluid velocity to "hub_inflow" (necessary for coupling to AMR-Wind -- current implementation has hub_inflow as a private variable that is only updated within UpdateAerodynamicLoads, which is not suitable for CFD coupling where inflow is not an analytical function)