### PR TITLE
modify flush command to do nothing if file is closed

### DIFF
--- a/src/utilities/netcdf/netcdf_file.hpp
+++ b/src/utilities/netcdf/netcdf_file.hpp
@@ -57,6 +57,11 @@ public:
      */
     void Open();
 
+    /**
+     * @brief Checks if the NetCDF file is open
+     */
+    bool IsOpen() const { return netcdf_id_ != -1; }
+
     //--------------------------------------------------------------------------
     // Setter/Write methods
     //--------------------------------------------------------------------------

--- a/src/utilities/netcdf/netcdf_file.hpp
+++ b/src/utilities/netcdf/netcdf_file.hpp
@@ -60,7 +60,7 @@ public:
     /**
      * @brief Checks if the NetCDF file is open
      */
-    bool IsOpen() const { return netcdf_id_ != -1; }
+    [[nodiscard]] bool IsOpen() const { return netcdf_id_ != -1; }
 
     //--------------------------------------------------------------------------
     // Setter/Write methods

--- a/src/utilities/netcdf/time_series_writer.cpp
+++ b/src/utilities/netcdf/time_series_writer.cpp
@@ -186,7 +186,7 @@ void TimeSeriesWriter::FlushBuffer() {
 
 void TimeSeriesWriter::Flush() {
     this->FlushBuffer();
-    if (file_.GetNetCDFId() != -1) {
+    if (file_.IsOpen()) {
         // Only do sync when file is open
         file_.Sync();
     }

--- a/src/utilities/netcdf/time_series_writer.cpp
+++ b/src/utilities/netcdf/time_series_writer.cpp
@@ -185,8 +185,11 @@ void TimeSeriesWriter::FlushBuffer() {
 }
 
 void TimeSeriesWriter::Flush() {
-    this->FlushBuffer();
-    file_.Sync();
+    if (file_.GetNetCDFId() != -1) {
+        // Only do flush and sync when file is open
+        this->FlushBuffer();
+        file_.Sync();
+    }
 }
 
 void TimeSeriesWriter::Close() {

--- a/src/utilities/netcdf/time_series_writer.cpp
+++ b/src/utilities/netcdf/time_series_writer.cpp
@@ -185,9 +185,9 @@ void TimeSeriesWriter::FlushBuffer() {
 }
 
 void TimeSeriesWriter::Flush() {
+    this->FlushBuffer();
     if (file_.GetNetCDFId() != -1) {
-        // Only do flush and sync when file is open
-        this->FlushBuffer();
+        // Only do sync when file is open
         file_.Sync();
     }
 }

--- a/src/utilities/netcdf/time_series_writer.hpp
+++ b/src/utilities/netcdf/time_series_writer.hpp
@@ -79,7 +79,7 @@ public:
      */
     void WriteRowAtTimestep(size_t timestep, std::span<const double> row);
 
-    /// @brief Flushes any remaining buffered rows unless file is closed
+    /// @brief Flushes any remaining buffered rows and, if the file is open, syncs
     void Flush();
 
     /// @brief Manually closes the underlying NetCDF file and flush any remaining buffered rows

--- a/src/utilities/netcdf/time_series_writer.hpp
+++ b/src/utilities/netcdf/time_series_writer.hpp
@@ -79,7 +79,7 @@ public:
      */
     void WriteRowAtTimestep(size_t timestep, std::span<const double> row);
 
-    /// @brief Flushes any remaining buffered rows
+    /// @brief Flushes any remaining buffered rows unless file is closed
     void Flush();
 
     /// @brief Manually closes the underlying NetCDF file and flush any remaining buffered rows


### PR DESCRIPTION
#537 introduced a Flush() command as part of the time series writer destructor. This causes an error at the conclusion of AMR-Wind-coupled runs, because it attempts to flush and sync when the file has already been closed (which is how it is set up on the AMR-Wind side). Following the existing paradigm in the netCDF interface of kynema, where Open() and Close() do nothing if the file is already in that state, this PR makes Flush() do nothing if the file is already closed.