### PR TITLE
Add missing deep copy in blade_interface

### DIFF
--- a/src/interfaces/blade/blade_interface.cpp
+++ b/src/interfaces/blade/blade_interface.cpp
@@ -63,6 +63,7 @@ bool BladeInterface::Step() {
         }
     }
     Kokkos::deep_copy(this->state.f, this->host_state.f);
+    Kokkos::deep_copy(this->state.v, this->host_state.v);
 
     // Solve for state at end of step
     auto converged =


### PR DESCRIPTION
New test failures resulted only the on the GPU after #536. With the help of Copilot, I think this should be key to fixing the failing GPU tests.