### PR TITLE
Makes element_mu local variable exist in scratch memory rather than stack

### DIFF
--- a/src/step/update_system_variables_beams.hpp
+++ b/src/step/update_system_variables_beams.hpp
@@ -27,6 +27,7 @@ inline void UpdateSystemVariablesBeams(
 
     const auto shape_size = Kokkos::View<double**>::shmem_size(padded_num_nodes, num_qps);
     const auto weight_size = Kokkos::View<double*>::shmem_size(num_qps);
+    const auto mu_size = Kokkos::View<double[6]>::shmem_size();
     const auto node_variable_size = Kokkos::View<double* [7]>::shmem_size(num_nodes);
     const auto qp_variable_size = Kokkos::View<double* [6]>::shmem_size(num_qps);
     const auto qp_matrix_size = Kokkos::View<double* [6][6]>::shmem_size(num_qps);
@@ -34,7 +35,7 @@ inline void UpdateSystemVariablesBeams(
 
     const auto hbmem = (4 * node_variable_size) + (10 * qp_variable_size) + (15 * qp_matrix_size) +
                        (2 * system_matrix_size);
-    const auto smem = (2 * shape_size) + (2 * weight_size);
+    const auto smem = (2 * shape_size) + (2 * weight_size) + mu_size;
     range_policy.set_scratch_size(1, Kokkos::PerTeam(hbmem))
         .set_scratch_size(0, Kokkos::PerTeam(smem));
 

--- a/src/system/beams/calculate_quadrature_point_values.hpp
+++ b/src/system/beams/calculate_quadrature_point_values.hpp
@@ -158,9 +158,9 @@ struct CalculateQuadraturePointValues {
 
         const auto damping_quad_point_calculator =
             beams::CalculateQuadraturePointDampingValues<DeviceType>{
-                element,   element_mu,      qp_jacobian, shape_interp, shape_deriv, qp_r0_,
-                qp_x0_prime_, qp_Cstar_, node_u,  node_u_dot,  qp_F_D1,      qp_F_D2,     qp_Duu, qp_D_D1,
-                qp_D_D2,   qp_G_D1, qp_G_D2,     qp_P_D2,      qp_K_D1,     qp_K_D2
+                element,   element_mu, qp_jacobian, shape_interp, shape_deriv, qp_r0_, qp_x0_prime_,
+                qp_Cstar_, node_u,     node_u_dot,  qp_F_D1,      qp_F_D2,     qp_Duu, qp_D_D1,
+                qp_D_D2,   qp_G_D1,    qp_G_D2,     qp_P_D2,      qp_K_D1,     qp_K_D2
             };
         parallel_for(qp_range, damping_quad_point_calculator);
 

--- a/src/system/beams/calculate_quadrature_point_values.hpp
+++ b/src/system/beams/calculate_quadrature_point_values.hpp
@@ -33,7 +33,7 @@ struct CalculateQuadraturePointValues {
     ConstView<size_t**> node_state_indices;
     ConstView<size_t*> num_nodes_per_element;
     ConstView<size_t*> num_qps_per_element;
-    ConstView<double* [6]> element_mu;
+    ConstView<double* [6]> element_mu_;
     ConstView<double**> qp_weight_;
     ConstView<double**> qp_jacobian_;
     ConstView<double***> shape_interp_;
@@ -82,6 +82,8 @@ struct CalculateQuadraturePointValues {
         const auto shape_deriv =
             LeftView<double**>(member.team_scratch(0), padded_num_nodes, num_qps);
 
+        const auto element_mu = View<double[6]>(member.team_scratch(0));
+
         const auto qp_weight = View<double*>(member.team_scratch(0), num_qps);
         const auto qp_jacobian = View<double*>(member.team_scratch(0), num_qps);
 
@@ -129,12 +131,10 @@ struct CalculateQuadraturePointValues {
         CopyMatrix::invoke(member, subview(qp_FE_, element, qp_pair, ALL), qp_Fe);
         CopyMatrix::invoke(member, subview(node_FX_, element, node_pair, ALL), node_FX);
 
+        CopyVector::invoke(member, subview(element_mu_, element, ALL), element_mu);
+
         CopyVector::invoke(member, subview(qp_weight_, element, qp_pair), qp_weight);
         CopyVector::invoke(member, subview(qp_jacobian_, element, qp_pair), qp_jacobian);
-
-        auto mu_data = Array<double, 6>{};
-        const auto mu = View<double[6]>(mu_data.data());
-        CopyVector::invoke(member, subview(element_mu, element, ALL), mu);
 
         const auto node_state_updater = beams::UpdateNodeStateElement<DeviceType>{
             element, node_state_indices, node_u, node_u_dot, node_u_ddot, Q, V, A
@@ -158,8 +158,8 @@ struct CalculateQuadraturePointValues {
 
         const auto damping_quad_point_calculator =
             beams::CalculateQuadraturePointDampingValues<DeviceType>{
-                element,   mu,      qp_jacobian, shape_interp, shape_deriv, qp_r0_, qp_x0_prime_,
-                qp_Cstar_, node_u,  node_u_dot,  qp_F_D1,      qp_F_D2,     qp_Duu, qp_D_D1,
+                element,   element_mu,      qp_jacobian, shape_interp, shape_deriv, qp_r0_,
+                qp_x0_prime_, qp_Cstar_, node_u,  node_u_dot,  qp_F_D1,      qp_F_D2,     qp_Duu, qp_D_D1,
                 qp_D_D2,   qp_G_D1, qp_G_D2,     qp_P_D2,      qp_K_D1,     qp_K_D2
             };
         parallel_for(qp_range, damping_quad_point_calculator);


### PR DESCRIPTION

When element_mu was declared in stack memory, it created a different allocation for each thread.  When combined with the parallel copy kernel, each thread ended up with a different value of mu - either all zeros or just a single non-zero at the entry corresponding to the thread id.

Now that each team shares a single allocation for element_mu, the parallel copy performs as expected.