### PR TITLE
added missing K^I term to lsfe.rst

### DIFF
--- a/docs/sphinx/theory/lsfe.rst
+++ b/docs/sphinx/theory/lsfe.rst
@@ -259,7 +259,8 @@ following:
    \underline{\underline{\mathcal{P}}}^\mathrm{D2}(\xi^Q_k) \right]
    \phi'_j(\xi^Q_k) \\
    & + \phi_i(\xi^Q_k) \left[
-   \underline{\underline{\mathcal{K}}}^\mathrm{E2}(\xi^Q_k)
+   \underline{\underline{\mathcal{K}}}^\mathrm{I}(\xi^Q_k)
+   +\underline{\underline{\mathcal{K}}}^\mathrm{E2}(\xi^Q_k)
    +\underline{\underline{\mathcal{K}}}^\mathrm{D2}(\xi^Q_k) 
    \right]\phi_j(\xi^Q_k) J(\xi^Q_k)
    \Big\} w^Q_k 


### PR DESCRIPTION
This pull request makes a correction to the mathematical expression in the `docs/sphinx/theory/lsfe.rst` documentation. The change clarifies the terms in the equation by adding the missing interior kernel term and correcting the placement of the exterior kernel term.

Correction to equation in documentation:

* Updated the equation to include both the interior kernel term (`\mathcal{K}^\mathrm{I}`) and the exterior kernel term (`\mathcal{K}^\mathrm{E2}`) in the sum, improving the accuracy and clarity of the documentation.