### PR TITLE
Upgrades kynema to use Kokkos version 5.

### DIFF
--- a/.github/workflows/correctness-linux.yaml
+++ b/.github/workflows/correctness-linux.yaml
@@ -41,7 +41,7 @@ jobs:
           spack install superlu
           spack install rosco@2.9.0
           spack install openfast
-          spack install kokkos-kernels@4.7.02
+          spack install kokkos-kernels
           spack install eigen@5.0.1
       - name: Clone
         uses: actions/checkout@v4

--- a/.github/workflows/correctness-macos.yaml
+++ b/.github/workflows/correctness-macos.yaml
@@ -40,7 +40,7 @@ jobs:
           spack install superlu
           spack install rosco@2.9.0
           spack install openfast
-          spack install kokkos-kernels@4.7.02
+          spack install kokkos-kernels
           spack install eigen@5.0.1
       - name: Clone
         uses: actions/checkout@v4

--- a/.github/workflows/deploy_docs.yaml
+++ b/.github/workflows/deploy_docs.yaml
@@ -34,7 +34,7 @@ jobs:
           spack install superlu
           spack install rosco@2.9.0
           spack install openfast
-          spack install kokkos-kernels@4.7.02
+          spack install kokkos-kernel
           spack install eigen@5.0.1
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/.github/workflows/install-spack.yaml
+++ b/.github/workflows/install-spack.yaml
@@ -22,7 +22,7 @@ jobs:
           spack compiler find
           spack env create -d .
           spack env activate .
-          spack add kynema-fmb ^netcdf-c~mpi ^hdf5~mpi ^kokkos-kernels@4.7.02
+          spack add kynema-fmb ^netcdf-c~mpi ^hdf5~mpi
           spack develop kynema-fmb@main
           spack concretize -f
           cd kynema-fmb

--- a/src/constraints/calculate_constraint_residual_gradient.hpp
+++ b/src/constraints/calculate_constraint_residual_gradient.hpp
@@ -32,8 +32,8 @@ struct CalculateConstraintResidualGradient {
     using Gemm = KokkosBatched::SerialGemm<
         KokkosBatched::Trans::NoTranspose, KokkosBatched::Trans::NoTranspose,
         KokkosBatched::Algo::Gemm::Default>;
-    using CopyVector = KokkosBatched::SerialCopy<KokkosBatched::Trans::NoTranspose, 1>;
-    using CopyMatrix = KokkosBatched::SerialCopy<KokkosBatched::Trans::NoTranspose, 2>;
+    using CopyVector = KokkosBatched::SerialCopy<KokkosBatched::Trans::NoTranspose>;
+    using CopyMatrix = KokkosBatched::SerialCopy<KokkosBatched::Trans::NoTranspose>;
     template <typename ValueType>
     using View = Kokkos::View<ValueType, DeviceType>;
     template <typename ValueType>

--- a/src/constraints/calculate_fixed_bc_constraint.hpp
+++ b/src/constraints/calculate_fixed_bc_constraint.hpp
@@ -26,7 +26,7 @@ struct CalculateFixedBCConstraint {
         using Kokkos::Array;
         using Kokkos::make_pair;
         using Kokkos::subview;
-        using CopyVector = KokkosBatched::SerialCopy<KokkosBatched::Trans::NoTranspose, 1>;
+        using CopyVector = KokkosBatched::SerialCopy<KokkosBatched::Trans::NoTranspose>;
         using CopyMatrixTranspose = KokkosBatched::SerialCopy<KokkosBatched::Trans::Transpose>;
 
         constexpr auto u1_data = Array<double, 3>{0., 0., 0.};

--- a/src/constraints/calculate_prescribed_bc_constraint.hpp
+++ b/src/constraints/calculate_prescribed_bc_constraint.hpp
@@ -27,7 +27,7 @@ struct CalculatePrescribedBCConstraint {
         using Kokkos::Array;
         using Kokkos::make_pair;
         using Kokkos::subview;
-        using CopyVector = KokkosBatched::SerialCopy<KokkosBatched::Trans::NoTranspose, 1>;
+        using CopyVector = KokkosBatched::SerialCopy<KokkosBatched::Trans::NoTranspose>;
         using CopyTransposeMatrix = KokkosBatched::SerialCopy<KokkosBatched::Trans::Transpose>;
 
         const auto u1_data = Array<double, 3>{inputs(0), inputs(1), inputs(2)};

--- a/src/constraints/calculate_rotation_control_constraint.hpp
+++ b/src/constraints/calculate_rotation_control_constraint.hpp
@@ -30,7 +30,7 @@ struct CalculateRotationControlConstraint {
         using Kokkos::Array;
         using Kokkos::make_pair;
         using Kokkos::subview;
-        using CopyVector = KokkosBatched::SerialCopy<KokkosBatched::Trans::NoTranspose, 1>;
+        using CopyVector = KokkosBatched::SerialCopy<KokkosBatched::Trans::NoTranspose>;
         using CopyMatrixTranspose = KokkosBatched::SerialCopy<KokkosBatched::Trans::Transpose>;
         using CopyMatrix = KokkosBatched::SerialCopy<>;
 

--- a/src/constraints/constraints.hpp
+++ b/src/constraints/constraints.hpp
@@ -60,8 +60,8 @@ struct Constraints {
     View<double* [6]> lambda;
 
     // Host mirrors for CPU access
-    typename View<double* [7]>::HostMirror host_input;
-    typename View<double* [3]>::HostMirror host_output;
+    typename View<double* [7]>::host_mirror_type host_input;
+    typename View<double* [3]>::host_mirror_type host_output;
 
     // System contributions
     View<double* [6]> residual_terms;

--- a/src/interfaces/cfd/interface.cpp
+++ b/src/interfaces/cfd/interface.cpp
@@ -28,10 +28,10 @@ namespace {
  */
 void GetNodeMotion(
     kynema_fmb::interfaces::cfd::NodeData& node,
-    const Kokkos::View<double* [7]>::HostMirror::const_type& host_state_x,
-    const Kokkos::View<double* [7]>::HostMirror::const_type& host_state_q,
-    const Kokkos::View<double* [6]>::HostMirror::const_type& host_state_v,
-    const Kokkos::View<double* [6]>::HostMirror::const_type& host_state_vd
+    const Kokkos::View<double* [7]>::host_mirror_type::const_type& host_state_x,
+    const Kokkos::View<double* [7]>::host_mirror_type::const_type& host_state_q,
+    const Kokkos::View<double* [6]>::host_mirror_type::const_type& host_state_v,
+    const Kokkos::View<double* [6]>::host_mirror_type::const_type& host_state_vd
 ) {
     for (auto component : std::views::iota(0U, 7U)) {
         node.position[component] = host_state_x(node.id, component);
@@ -207,10 +207,10 @@ void SetPlatformLoads(
  */
 void GetFloatingPlatformMotion(
     kynema_fmb::interfaces::cfd::FloatingPlatform& platform,
-    const Kokkos::View<double* [7]>::HostMirror::const_type& host_state_x,
-    const Kokkos::View<double* [7]>::HostMirror::const_type& host_state_q,
-    const Kokkos::View<double* [6]>::HostMirror::const_type& host_state_v,
-    const Kokkos::View<double* [6]>::HostMirror::const_type& host_state_vd
+    const Kokkos::View<double* [7]>::host_mirror_type::const_type& host_state_x,
+    const Kokkos::View<double* [7]>::host_mirror_type::const_type& host_state_q,
+    const Kokkos::View<double* [6]>::host_mirror_type::const_type& host_state_v,
+    const Kokkos::View<double* [6]>::host_mirror_type::const_type& host_state_vd
 ) {
     // If platform is not active, return
     if (!platform.active) {
@@ -275,10 +275,10 @@ void SetTurbineLoads(
  */
 void GetTurbineMotion(
     kynema_fmb::interfaces::cfd::Turbine& turbine,
-    const Kokkos::View<double* [7]>::HostMirror::const_type& host_state_x,
-    const Kokkos::View<double* [7]>::HostMirror::const_type& host_state_q,
-    const Kokkos::View<double* [6]>::HostMirror::const_type& host_state_v,
-    const Kokkos::View<double* [6]>::HostMirror::const_type& host_state_vd
+    const Kokkos::View<double* [7]>::host_mirror_type::const_type& host_state_x,
+    const Kokkos::View<double* [7]>::host_mirror_type::const_type& host_state_q,
+    const Kokkos::View<double* [6]>::host_mirror_type::const_type& host_state_v,
+    const Kokkos::View<double* [6]>::host_mirror_type::const_type& host_state_vd
 ) {
     GetFloatingPlatformMotion(
         turbine.floating_platform, host_state_x, host_state_q, host_state_v, host_state_vd

--- a/src/interfaces/host_constraints.hpp
+++ b/src/interfaces/host_constraints.hpp
@@ -20,7 +20,7 @@ namespace kynema_fmb::interfaces {
 template <typename DeviceType>
 struct HostConstraints {
     template <typename ValueType>
-    using HostView = typename Kokkos::View<ValueType, DeviceType>::HostMirror;
+    using HostView = typename Kokkos::View<ValueType, DeviceType>::host_mirror_type;
 
     /// @brief Host local copy of current inputs
     HostView<double* [7]> input;

--- a/src/interfaces/host_state.hpp
+++ b/src/interfaces/host_state.hpp
@@ -21,7 +21,7 @@ namespace kynema_fmb::interfaces {
 template <typename DeviceType>
 struct HostState {
     template <typename ValueType>
-    using HostView = typename Kokkos::View<ValueType, DeviceType>::HostMirror;
+    using HostView = typename Kokkos::View<ValueType, DeviceType>::host_mirror_type;
 
     /// @brief Host local copy of current position
     HostView<double* [7]> x;

--- a/src/state/read_state_from_file.hpp
+++ b/src/state/read_state_from_file.hpp
@@ -29,10 +29,10 @@ inline void ReadStateFromFile(std::istream& input, State<DeviceType>& state) {
         throw std::length_error("Number of system nodes in file is not the same as in model");
     }
 
-    const auto mirror_7 = Kokkos::View<double* [7]>::HostMirror("mirror_7", num_system_nodes);
+    const auto mirror_7 = Kokkos::View<double* [7]>::host_mirror_type("mirror_7", num_system_nodes);
     const auto out_7 = Kokkos::View<double* [7], Kokkos::HostSpace>("out_7", num_system_nodes);
 
-    const auto mirror_6 = Kokkos::View<double* [6]>::HostMirror("mirror_6", num_system_nodes);
+    const auto mirror_6 = Kokkos::View<double* [6]>::host_mirror_type("mirror_6", num_system_nodes);
     const auto out_6 = Kokkos::View<double* [6], Kokkos::HostSpace>("out_6", num_system_nodes);
 
     const auto read_7 = [&](const Kokkos::View<double* [7]>& data) {

--- a/src/state/write_state_to_file.hpp
+++ b/src/state/write_state_to_file.hpp
@@ -22,10 +22,10 @@ inline void WriteStateToFile(std::ostream& output, const State<DeviceType>& stat
     // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
     output.write(reinterpret_cast<char*>(&num_system_nodes), sizeof(size_t));
 
-    const auto mirror_7 = Kokkos::View<double* [7]>::HostMirror("mirror_7", num_system_nodes);
+    const auto mirror_7 = Kokkos::View<double* [7]>::host_mirror_type("mirror_7", num_system_nodes);
     const auto out_7 = Kokkos::View<double* [7], Kokkos::HostSpace>("out_7", num_system_nodes);
 
-    const auto mirror_6 = Kokkos::View<double* [6]>::HostMirror("mirror_6", num_system_nodes);
+    const auto mirror_6 = Kokkos::View<double* [6]>::host_mirror_type("mirror_6", num_system_nodes);
     const auto out_6 = Kokkos::View<double* [6], Kokkos::HostSpace>("out_6", num_system_nodes);
 
     const auto write_7 = [&](const Kokkos::View<double* [7]>& data) {

--- a/src/step/assemble_system_matrix.hpp
+++ b/src/step/assemble_system_matrix.hpp
@@ -26,7 +26,8 @@ inline void AssembleSystemMatrix(
     const auto num_springs = static_cast<int>(elements.springs.num_elems);
 
     const auto vector_length = std::min(num_nodes, TeamPolicy::vector_length_max());
-    auto beams_sparse_matrix_policy = TeamPolicy(num_beams, Kokkos::AUTO(), vector_length);
+    auto beams_sparse_matrix_policy =
+        TeamPolicy(num_beams, Kokkos::AUTO(), std::max(vector_length, 1));
     auto masses_sparse_matrix_policy = TeamPolicy(num_masses, Kokkos::AUTO());
     auto springs_sparse_matrix_policy = TeamPolicy(num_springs, Kokkos::AUTO());
 

--- a/src/step/update_system_variables_beams.hpp
+++ b/src/step/update_system_variables_beams.hpp
@@ -23,7 +23,8 @@ inline void UpdateSystemVariablesBeams(
 
     const auto vector_length =
         std::min(static_cast<int>(num_nodes * num_nodes), TeamPolicy::vector_length_max());
-    auto range_policy = TeamPolicy(static_cast<int>(beams.num_elems), Kokkos::AUTO(), vector_length);
+    auto range_policy =
+        TeamPolicy(static_cast<int>(beams.num_elems), Kokkos::AUTO(), std::max(vector_length, 1));
 
     const auto shape_size = Kokkos::View<double**>::shmem_size(padded_num_nodes, num_qps);
     const auto weight_size = Kokkos::View<double*>::shmem_size(num_qps);

--- a/src/system/beams/calculate_quadrature_point_damping_values.hpp
+++ b/src/system/beams/calculate_quadrature_point_damping_values.hpp
@@ -64,7 +64,7 @@ struct CalculateQuadraturePointDampingValues {
         using Kokkos::make_pair;
         using Kokkos::subview;
         using CopyMatrix = KokkosBatched::SerialCopy<>;
-        using CopyVector = KokkosBatched::SerialCopy<KokkosBatched::Trans::NoTranspose, 1>;
+        using CopyVector = KokkosBatched::SerialCopy<KokkosBatched::Trans::NoTranspose>;
 
         // If mu is all zeros, zero the output and skip the calculation
         if (mu(0) == 0.0 && mu(1) == 0.0 && mu(2) == 0.0 && mu(3) == 0.0 && mu(4) == 0.0 &&

--- a/src/system/beams/calculate_quadrature_point_inertial_values.hpp
+++ b/src/system/beams/calculate_quadrature_point_inertial_values.hpp
@@ -46,7 +46,7 @@ struct CalculateQuadraturePointInertialValues {
         using Kokkos::Array;
         using Kokkos::subview;
         using CopyMatrix = KokkosBatched::SerialCopy<>;
-        using CopyVector = KokkosBatched::SerialCopy<KokkosBatched::Trans::NoTranspose, 1>;
+        using CopyVector = KokkosBatched::SerialCopy<KokkosBatched::Trans::NoTranspose>;
 
         const auto r0_data = Array<double, 4>{
             qp_r0(element, qp, 0), qp_r0(element, qp, 1), qp_r0(element, qp, 2),

--- a/src/system/beams/calculate_quadrature_point_stiffness_values.hpp
+++ b/src/system/beams/calculate_quadrature_point_stiffness_values.hpp
@@ -50,7 +50,7 @@ struct CalculateQuadraturePointStiffnessValues {
         using Kokkos::make_pair;
         using Kokkos::subview;
         using CopyMatrix = KokkosBatched::SerialCopy<>;
-        using CopyVector = KokkosBatched::SerialCopy<KokkosBatched::Trans::NoTranspose, 1>;
+        using CopyVector = KokkosBatched::SerialCopy<KokkosBatched::Trans::NoTranspose>;
 
         const auto r0_data = Array<double, 4>{
             qp_r0(element, qp, 0), qp_r0(element, qp, 1), qp_r0(element, qp, 2),

--- a/src/system/beams/calculate_quadrature_point_values.hpp
+++ b/src/system/beams/calculate_quadrature_point_values.hpp
@@ -60,7 +60,7 @@ struct CalculateQuadraturePointValues {
         using Kokkos::TeamVectorRange;
         using CopyMatrix = KokkosBatched::TeamVectorCopy<member_type>;
         using CopyVector =
-            KokkosBatched::TeamVectorCopy<member_type, KokkosBatched::Trans::NoTranspose, 1>;
+            KokkosBatched::TeamVectorCopy<member_type, KokkosBatched::Trans::NoTranspose>;
 
         const auto element = static_cast<size_t>(member.league_rank());
         const auto num_nodes = num_nodes_per_element(element);

--- a/src/system/beams/integrate_inertia_matrix.hpp
+++ b/src/system/beams/integrate_inertia_matrix.hpp
@@ -36,7 +36,8 @@ struct IntegrateInertiaMatrixElement {
     KOKKOS_FUNCTION
     void operator()(size_t node_simd_node) const {
         using simd_type = Kokkos::Experimental::simd<double>;
-        using tag_type = Kokkos::Experimental::vector_aligned_tag;
+        using tag_type =
+            Kokkos::Experimental::simd_flags<Kokkos::Experimental::simd_alignment_vector_aligned>;
         using Kokkos::ALL;
         using Kokkos::Array;
         using Kokkos::make_pair;
@@ -64,11 +65,11 @@ struct IntegrateInertiaMatrixElement {
             const auto w = simd_type(qp_weight_(qp));
             const auto jacobian = simd_type(qp_jacobian_(qp));
             const auto phi_1 = simd_type(shape_interp_(node, qp));
-            auto phi_2 = simd_type{};
-            phi_2.copy_from(&shape_interp_(simd_node, qp), tag_type());
+            const auto phi_2 =
+                simd_unchecked_load<simd_type>(&shape_interp_(simd_node, qp), tag_type());
             const auto phi_prime_1 = simd_type(shape_deriv_(node, qp));
-            auto phi_prime_2 = simd_type{};
-            phi_prime_2.copy_from(&shape_deriv_(simd_node, qp), tag_type());
+            const auto phi_prime_2 =
+                simd_unchecked_load<simd_type>(&shape_deriv_(simd_node, qp), tag_type());
             const auto c1 = (phi_prime_1 * phi_prime_2) * (w / jacobian);
             const auto c2 = (phi_prime_1 * phi_2) * w;
             const auto c3 = (phi_1 * phi_prime_2) * w;
@@ -92,7 +93,8 @@ struct IntegrateInertiaMatrixElement {
             }
         }
 
-        const auto num_lanes = Kokkos::min(width, num_nodes - simd_node);
+        const auto num_lanes =
+            Kokkos::min(width, static_cast<decltype(width)>(num_nodes - simd_node));
         const auto global_M = View<double** [36]>(gbl_M_.data(), num_nodes, num_nodes);
         const auto M_slice =
             subview(global_M, node, make_pair(simd_node, simd_node + num_lanes), ALL);

--- a/src/system/beams/integrate_stiffness_matrix.hpp
+++ b/src/system/beams/integrate_stiffness_matrix.hpp
@@ -38,7 +38,8 @@ struct IntegrateStiffnessMatrixElement {
     KOKKOS_FUNCTION
     void operator()(size_t node_simd_node) const {
         using simd_type = Kokkos::Experimental::simd<double>;
-        using tag_type = Kokkos::Experimental::vector_aligned_tag;
+        using tag_type =
+            Kokkos::Experimental::simd_flags<Kokkos::Experimental::simd_alignment_vector_aligned>;
         using Kokkos::ALL;
         using Kokkos::Array;
         using Kokkos::make_pair;
@@ -67,11 +68,11 @@ struct IntegrateStiffnessMatrixElement {
             const auto w = simd_type(qp_weight_(qp));
             const auto jacobian = simd_type(qp_jacobian_(qp));
             const auto phi_1 = simd_type(shape_interp_(node, qp));
-            auto phi_2 = simd_type{};
-            phi_2.copy_from(&shape_interp_(simd_node, qp), tag_type());
+            const auto phi_2 =
+                simd_unchecked_load<simd_type>(&shape_interp_(simd_node, qp), tag_type());
             const auto phi_prime_1 = simd_type(shape_deriv_(node, qp));
-            auto phi_prime_2 = simd_type{};
-            phi_prime_2.copy_from(&shape_deriv_(simd_node, qp), tag_type());
+            const auto phi_prime_2 =
+                simd_unchecked_load<simd_type>(&shape_deriv_(simd_node, qp), tag_type());
             const auto A = (phi_1 * phi_2) * (w * jacobian);
             const auto B = (phi_1 * phi_prime_2) * w;
             const auto C = (phi_prime_1 * phi_prime_2) * (w / jacobian);
@@ -100,7 +101,8 @@ struct IntegrateStiffnessMatrixElement {
             }
         }
 
-        const auto num_lanes = Kokkos::min(width, num_nodes - simd_node);
+        const auto num_lanes =
+            Kokkos::min(width, static_cast<decltype(width)>(num_nodes - simd_node));
         const auto global_M = View<double** [36]>(gbl_M_.data(), num_nodes, num_nodes);
         const auto M_slice =
             subview(global_M, node, make_pair(simd_node, simd_node + num_lanes), ALL);

--- a/tests/regression_tests/external/test_rotor_aero_controller.cpp
+++ b/tests/regression_tests/external/test_rotor_aero_controller.cpp
@@ -24,7 +24,7 @@ namespace {
 constexpr bool use_node_loads = true;
 
 std::array<double, 6> GetNodeData(
-    const size_t index, const Kokkos::View<double* [6]>::HostMirror& state_matrix
+    const size_t index, const Kokkos::View<double* [6]>::host_mirror_type& state_matrix
 ) {
     return {
         state_matrix(index, 0), state_matrix(index, 1), state_matrix(index, 2),
@@ -33,7 +33,7 @@ std::array<double, 6> GetNodeData(
 }
 
 std::array<double, 7> GetNodeData(
-    const size_t index, const Kokkos::View<double* [7]>::HostMirror& state_matrix
+    const size_t index, const Kokkos::View<double* [7]>::host_mirror_type& state_matrix
 ) {
     return {
         state_matrix(index, 0), state_matrix(index, 1), state_matrix(index, 2),


### PR DESCRIPTION
Applied API changes to the SIMD loading functions and Kokkos-Kernels batched copy.  The HostMirror type is also replaced by host_mirror_type on Kokkos Views.  Extra protection was added to prevent kernel vector lengths of 0 (this state was impossible to reach previously, but it triggered newly added checks in Kokkos).