### PR TITLE
add ability to set time step index externally

### DIFF
--- a/.github/workflows/correctness-linux.yaml
+++ b/.github/workflows/correctness-linux.yaml
@@ -28,7 +28,10 @@ jobs:
           path: |
             ${{ github.workspace }}/spack
             ${{ github.workspace }}/spack-packages
-          key: linux-spack_v7
+          key: linux-spack_v8-${{ runner.os }}-${{ matrix.compiler }}-${{ matrix.build_type }}-${{ matrix.build_external }}
+          restore-keys: |
+            linux-spack_v8-${{ runner.os }}-${{ matrix.compiler }}-
+            linux-spack_v8-${{ runner.os }}-
       - name: Install Dependencies
         if: steps.cache-dependencies.outputs.cache-hit != 'true'
         run: |

--- a/src/interfaces/turbine/turbine_interface.hpp
+++ b/src/interfaces/turbine/turbine_interface.hpp
@@ -141,6 +141,9 @@ public:
      */
     void ReadCheckpointFile(const std::string& file_path);
 
+    /// @brief Allows time step index to be set externally (e.g., for checkpoint restart)
+    void SetTimeStepIndex(int idx) {state.time_step = idx;}
+
 private:
     Model model;                    ///< Kynema-FMB class for model construction
     components::Turbine turbine;    ///< Turbine model input/output data

--- a/src/interfaces/turbine/turbine_interface.hpp
+++ b/src/interfaces/turbine/turbine_interface.hpp
@@ -141,8 +141,8 @@ public:
      */
     void ReadCheckpointFile(const std::string& file_path);
 
-    /// @brief Allows time step index to be set externally (e.g., for checkpoint restart)
-void SetTimeStepIndex(size_t idx) { this->state.time_step = idx; }
+    /// @brief Allows time step index to be set externally (e.g., for restart)
+    void SetTimeStepIndex(size_t idx) { this->state.time_step = idx; }
 
 private:
     Model model;                    ///< Kynema-FMB class for model construction

--- a/src/interfaces/turbine/turbine_interface.hpp
+++ b/src/interfaces/turbine/turbine_interface.hpp
@@ -142,7 +142,7 @@ public:
     void ReadCheckpointFile(const std::string& file_path);
 
     /// @brief Allows time step index to be set externally (e.g., for checkpoint restart)
-    void SetTimeStepIndex(int idx) {state.time_step = idx;}
+void SetTimeStepIndex(size_t idx) { this->state.time_step = idx; }
 
 private:
     Model model;                    ///< Kynema-FMB class for model construction


### PR DESCRIPTION
without this, a restarted kynema sgf+fmb simulation always resumes with a time step of 0, which is confusing 